### PR TITLE
Add availability threshold audit

### DIFF
--- a/backend/reports/availability_threshold_audit.md
+++ b/backend/reports/availability_threshold_audit.md
@@ -1,0 +1,209 @@
+# Availability Threshold Audit
+
+Generated at: 2026-06-01T22:54:12.674737+00:00
+Current reference date: 2026-06-01
+
+This report audits current Availability Engine output using the existing classifier.
+It is evidence for later threshold review only; it does not change thresholds.
+
+Trust note: current classifications keep fresh, stale, missing, and incomplete data separate.
+Stale or missing Monitor counts should not be read as workload-driven Monitor counts.
+Latest-workload snapshot output anchors each pitcher to their latest game date to inspect
+historical workload windows; it is not current bullpen availability.
+
+## Current Availability Output
+
+Total pitchers evaluated: 704
+
+### Status Distribution
+
+| Value | Count |
+|---|---:|
+| Monitor | 704 |
+
+### Confidence Distribution
+
+| Value | Count |
+|---|---:|
+| low | 704 |
+
+### Data State Distribution
+
+| Value | Count |
+|---|---:|
+| stale | 640 |
+| missing | 64 |
+
+### Status By Data State
+
+| Data state | Status | Count |
+|---|---|---:|
+| stale | Monitor | 640 |
+| missing | Monitor | 64 |
+
+### Top Reason Frequencies
+
+| Reason | Count |
+|---|---:|
+| Latest game log is older than 14 days | 640 |
+| Missing workload history or fatigue score | 64 |
+
+### Workload Input Summary
+
+| Input | Count | Min | Median | Max |
+|---|---:|---:|---:|---:|
+| fatigue_score | 704 | 6 | 48.5 | 85.9 |
+| pitches_yesterday | 704 | 0 | 0 | 0 |
+| pitches_last_3_days | 704 | 0 | 0 | 0 |
+| pitches_last_5_days | 704 | 0 | 0 | 0 |
+
+### Appearance Distributions
+
+#### appearances_last_3_days
+
+| Appearances | Count |
+|---:|---:|
+| 0 | 704 |
+
+#### appearances_last_5_days
+
+| Appearances | Count |
+|---:|---:|
+| 0 | 704 |
+
+### Stale/Incomplete/Missing Counts
+
+| Value | Count |
+|---|---:|
+| stale | 640 |
+| missing | 64 |
+| incomplete | 0 |
+
+### Near-Threshold Examples
+
+| Pitcher | Team | Status | Data state | Boundary | Value | Threshold | Distance | Reasons |
+|---|---|---|---|---|---:|---:|---:|---|
+| Connor Prielipp | MIN | Monitor | stale | Limited fatigue | 60 | 60 | 0 | Latest game log is older than 14 days |
+| Keegan Thompson | COL | Monitor | stale | Monitor fatigue | 40 | 40 | 0 | Latest game log is older than 14 days |
+| Max Lazar | PHI | Monitor | stale | Monitor fatigue | 40 | 40 | 0 | Latest game log is older than 14 days |
+| Tyler Mahle | SF | Monitor | stale | Limited fatigue | 60 | 60 | 0 | Latest game log is older than 14 days |
+| Bailey Ober | MIN | Monitor | stale | Unavailable fatigue | 85.1 | 85 | 0.1 | Latest game log is older than 14 days |
+| Brady Singer | CIN | Monitor | stale | Unavailable fatigue | 85.1 | 85 | 0.1 | Latest game log is older than 14 days |
+| Bryan Woo | SEA | Monitor | stale | Unavailable fatigue | 85.1 | 85 | 0.1 | Latest game log is older than 14 days |
+| Bryce Elder | ATL | Monitor | stale | Unavailable fatigue | 85.1 | 85 | 0.1 | Latest game log is older than 14 days |
+| Carson Whisenhunt | SF | Monitor | stale | Unavailable fatigue | 85.1 | 85 | 0.1 | Latest game log is older than 14 days |
+| Cole Ragans | KC | Monitor | stale | Unavailable fatigue | 85.1 | 85 | 0.1 | Latest game log is older than 14 days |
+| Colin Rea | CHC | Monitor | stale | Unavailable fatigue | 85.1 | 85 | 0.1 | Latest game log is older than 14 days |
+| Eury Pérez | MIA | Monitor | stale | Unavailable fatigue | 85.1 | 85 | 0.1 | Latest game log is older than 14 days |
+
+## Latest-Workload Snapshot Output
+
+Total pitchers evaluated: 704
+
+### Status Distribution
+
+| Value | Count |
+|---|---:|
+| Monitor | 268 |
+| Limited | 174 |
+| Avoid | 99 |
+| Unavailable | 163 |
+
+### Confidence Distribution
+
+| Value | Count |
+|---|---:|
+| high | 640 |
+| low | 64 |
+
+### Data State Distribution
+
+| Value | Count |
+|---|---:|
+| fresh | 640 |
+| missing | 64 |
+
+### Status By Data State
+
+| Data state | Status | Count |
+|---|---|---:|
+| fresh | Monitor | 204 |
+| fresh | Limited | 174 |
+| fresh | Avoid | 99 |
+| fresh | Unavailable | 163 |
+| missing | Monitor | 64 |
+
+### Top Reason Frequencies
+
+| Reason | Count |
+|---|---:|
+| 0 days rest | 640 |
+| 2 appearances in last 5 days | 192 |
+| 2 appearances in last 3 days | 140 |
+| Back-to-back usage | 80 |
+| 3 appearances in last 5 days | 69 |
+| Missing workload history or fatigue score | 64 |
+| Fatigue score 85.5 | 42 |
+| 3 appearances in 4 days | 34 |
+| Fatigue score 85.1 | 31 |
+| 40 pitches over last 3 days | 11 |
+| 90 pitches over last 3 days | 11 |
+| 90 pitches over last 5 days | 11 |
+| 36 pitches over last 3 days | 11 |
+| 95 pitches over last 3 days | 11 |
+| 95 pitches over last 5 days | 11 |
+
+### Workload Input Summary
+
+| Input | Count | Min | Median | Max |
+|---|---:|---:|---:|---:|
+| fatigue_score | 704 | 6 | 48.5 | 85.9 |
+| pitches_yesterday | 704 | 0 | 0 | 35 |
+| pitches_last_3_days | 704 | 0 | 33.5 | 114 |
+| pitches_last_5_days | 704 | 0 | 43 | 114 |
+
+### Appearance Distributions
+
+#### appearances_last_3_days
+
+| Appearances | Count |
+|---:|---:|
+| 0 | 64 |
+| 1 | 492 |
+| 2 | 140 |
+| 3 | 8 |
+
+#### appearances_last_5_days
+
+| Appearances | Count |
+|---:|---:|
+| 0 | 64 |
+| 1 | 372 |
+| 2 | 192 |
+| 3 | 69 |
+| 4 | 7 |
+
+### Stale/Incomplete/Missing Counts
+
+| Value | Count |
+|---|---:|
+| stale | 0 |
+| missing | 64 |
+| incomplete | 0 |
+
+### Near-Threshold Examples
+
+| Pitcher | Team | Status | Data state | Boundary | Value | Threshold | Distance | Reasons |
+|---|---|---|---|---|---:|---:|---:|---|
+| A.J. Minter | NYM | Avoid | fresh | Limited 3-day appearances | 2 | 2 | 0 | 44 pitches over last 3 days; 2 appearances in last 3 days; 3 appearances in last 5 days; Back-to-back usage; 0 days rest; Fatigue score 55.3 |
+| A.J. Minter | NYM | Avoid | fresh | Limited 5-day appearances | 3 | 3 | 0 | 44 pitches over last 3 days; 2 appearances in last 3 days; 3 appearances in last 5 days; Back-to-back usage; 0 days rest; Fatigue score 55.3 |
+| A.J. Puk | AZ | Avoid | fresh | Limited 3-day appearances | 2 | 2 | 0 | 15 pitches yesterday; 36 pitches over last 3 days; 60 pitches over last 5 days; 2 appearances in last 3 days; 3 appearances in last 5 days; Back-to-back usage; 0 days rest; Fatigue score 51.7 |
+| A.J. Puk | AZ | Avoid | fresh | Limited 5-day appearances | 3 | 3 | 0 | 15 pitches yesterday; 36 pitches over last 3 days; 60 pitches over last 5 days; 2 appearances in last 3 days; 3 appearances in last 5 days; Back-to-back usage; 0 days rest; Fatigue score 51.7 |
+| A.J. Puk | AZ | Avoid | fresh | Limited 5-day pitches | 60 | 60 | 0 | 15 pitches yesterday; 36 pitches over last 3 days; 60 pitches over last 5 days; 2 appearances in last 3 days; 3 appearances in last 5 days; Back-to-back usage; 0 days rest; Fatigue score 51.7 |
+| A.J. Puk | AZ | Avoid | fresh | Monitor yesterday pitches | 15 | 15 | 0 | 15 pitches yesterday; 36 pitches over last 3 days; 60 pitches over last 5 days; 2 appearances in last 3 days; 3 appearances in last 5 days; Back-to-back usage; 0 days rest; Fatigue score 51.7 |
+| Aaron Ashby | MIL | Limited | fresh | Limited 3-day pitches | 45 | 45 | 0 | 45 pitches over last 3 days; 0 days rest; Fatigue score 65.1 |
+| Aaron Bummer | ATL | Limited | fresh | Limited 3-day appearances | 2 | 2 | 0 | 2 appearances in last 3 days; 3 appearances in last 5 days; 0 days rest; Fatigue score 46.0 |
+| Aaron Bummer | ATL | Limited | fresh | Limited 5-day appearances | 3 | 3 | 0 | 2 appearances in last 3 days; 3 appearances in last 5 days; 0 days rest; Fatigue score 46.0 |
+| Abner Uribe | MIL | Limited | fresh | Limited 3-day appearances | 2 | 2 | 0 | 2 appearances in last 3 days; 2 appearances in last 5 days; Back-to-back usage; 0 days rest |
+| Abner Uribe | MIL | Limited | fresh | Monitor 5-day appearances | 2 | 2 | 0 | 2 appearances in last 3 days; 2 appearances in last 5 days; Back-to-back usage; 0 days rest |
+| Adrian Morejon | SD | Limited | fresh | Limited 3-day appearances | 2 | 2 | 0 | 43 pitches over last 3 days; 72 pitches over last 5 days; 2 appearances in last 3 days; 3 appearances in last 5 days; 0 days rest; Fatigue score 51.4 |

--- a/backend/scripts/audit_availability_thresholds.py
+++ b/backend/scripts/audit_availability_thresholds.py
@@ -1,0 +1,173 @@
+"""
+Generate an Availability Engine threshold audit from local database data.
+
+The script applies services.availability.classify_availability to existing
+fatigue/game-log rows and writes a Markdown or JSON report. It does not change
+thresholds, fatigue scoring, API responses, or frontend output.
+"""
+
+from argparse import ArgumentParser
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from app import create_app  # noqa: E402
+from models.fatigue_score import FatigueScore  # noqa: E402
+from models.game_log import GameLog  # noqa: E402
+from models.pitcher import Pitcher  # noqa: E402
+from services.availability import ACTIVE_WINDOW_DAYS, classify_availability  # noqa: E402
+from services.availability_threshold_audit import (  # noqa: E402
+    render_json_report,
+    render_markdown_report,
+    summarize_records,
+)
+from utils.db import db  # noqa: E402
+
+
+DEFAULT_OUTPUT = ROOT / 'reports' / 'availability_threshold_audit.md'
+
+
+def parse_date(value):
+    if value is None:
+        return None
+    return datetime.strptime(value, '%Y-%m-%d').date()
+
+
+def latest_fatigue_rows():
+    subq = (
+        db.session.query(
+            FatigueScore.pitcher_id,
+            db.func.max(FatigueScore.calculated_at).label('max_calc'),
+        )
+        .group_by(FatigueScore.pitcher_id)
+        .subquery()
+    )
+
+    return (
+        db.session.query(FatigueScore, Pitcher)
+        .join(
+            subq,
+            (FatigueScore.pitcher_id == subq.c.pitcher_id)
+            & (FatigueScore.calculated_at == subq.c.max_calc),
+        )
+        .join(Pitcher, FatigueScore.pitcher_id == Pitcher.id)
+        .order_by(Pitcher.team_abbreviation, Pitcher.full_name)
+        .all()
+    )
+
+
+def latest_game_date_for(pitcher_id):
+    return (
+        db.session.query(db.func.max(GameLog.game_date))
+        .filter(GameLog.pitcher_id == pitcher_id)
+        .scalar()
+    )
+
+
+def logs_for_window(pitcher_id, reference_date):
+    window_start = reference_date - timedelta(days=4)
+    return (
+        GameLog.query
+        .filter(
+            GameLog.pitcher_id == pitcher_id,
+            GameLog.game_date >= window_start,
+            GameLog.game_date <= reference_date,
+        )
+        .order_by(GameLog.game_date.desc())
+        .all()
+    )
+
+
+def classify_rows(rows, reference_date, mode):
+    records = []
+    for score, pitcher in rows:
+        latest_game_date = latest_game_date_for(pitcher.id)
+        if mode == 'latest_workload_snapshot':
+            ref = latest_game_date or reference_date
+        else:
+            ref = reference_date
+
+        logs = logs_for_window(pitcher.id, ref)
+        availability = classify_availability(
+            score=score,
+            game_logs=logs,
+            reference_date=ref,
+            latest_game_date=latest_game_date,
+            active_window_days=ACTIVE_WINDOW_DAYS,
+        )
+        records.append({
+            'pitcher_id': pitcher.id,
+            'pitcher_name': pitcher.full_name,
+            'team': pitcher.team_abbreviation,
+            'availability': availability,
+        })
+    return records
+
+
+def build_audit(reference_date=None, near_threshold_limit=12):
+    ref = reference_date or date.today()
+    rows = latest_fatigue_rows()
+    current_records = classify_rows(rows, reference_date=ref, mode='current')
+    snapshot_records = classify_rows(rows, reference_date=ref, mode='latest_workload_snapshot')
+    return {
+        'reference_date': ref,
+        'current': summarize_records(current_records, near_threshold_limit=near_threshold_limit),
+        'latest_workload_snapshot': summarize_records(snapshot_records, near_threshold_limit=near_threshold_limit),
+    }
+
+
+def write_report(report_text, output_path):
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(report_text, encoding='utf-8')
+
+
+def print_summary(audit, output_path):
+    current = audit['current']
+    snapshot = audit['latest_workload_snapshot']
+    print(f'Availability threshold audit written to {output_path}')
+    print(f"Current total pitchers: {current['total_pitchers']}")
+    print(f"Current status distribution: {current['status_distribution']}")
+    print(f"Current data state distribution: {current['data_state_distribution']}")
+    print(f"Latest-workload snapshot status distribution: {snapshot['status_distribution']}")
+    print(f"Latest-workload snapshot data state distribution: {snapshot['data_state_distribution']}")
+
+
+def main():
+    parser = ArgumentParser(description='Audit Availability Engine threshold behavior.')
+    parser.add_argument('--output', default=str(DEFAULT_OUTPUT), help='Report path to write.')
+    parser.add_argument('--format', choices=['markdown', 'json'], default='markdown', help='Report format.')
+    parser.add_argument('--reference-date', help='YYYY-MM-DD date for current availability audit. Defaults to today.')
+    parser.add_argument('--near-threshold-limit', type=int, default=12, help='Number of near-threshold examples per section.')
+    args = parser.parse_args()
+
+    reference_date = parse_date(args.reference_date)
+    output_path = Path(args.output)
+
+    app = create_app()
+    with app.app_context():
+        generated_at = datetime.now(timezone.utc)
+        audit = build_audit(reference_date=reference_date, near_threshold_limit=args.near_threshold_limit)
+        if args.format == 'json':
+            report = render_json_report(
+                audit['current'],
+                snapshot_summary=audit['latest_workload_snapshot'],
+                generated_at=generated_at,
+                reference_date=audit['reference_date'],
+            )
+        else:
+            report = render_markdown_report(
+                audit['current'],
+                snapshot_summary=audit['latest_workload_snapshot'],
+                generated_at=generated_at,
+                reference_date=audit['reference_date'],
+            )
+        write_report(report, output_path)
+        print_summary(audit, output_path)
+
+
+if __name__ == '__main__':
+    main()

--- a/backend/services/availability_threshold_audit.py
+++ b/backend/services/availability_threshold_audit.py
@@ -1,0 +1,337 @@
+"""
+Aggregation helpers for auditing Availability Engine threshold behavior.
+
+This module does not classify pitchers. It summarizes already-classified
+availability records so scripts and tests can inspect current V1 behavior
+without duplicating or changing threshold logic.
+"""
+
+from collections import Counter, defaultdict
+from datetime import datetime, timezone
+import json
+
+from services.availability import (
+    STATUS_AVAILABLE,
+    STATUS_MONITOR,
+    STATUS_LIMITED,
+    STATUS_AVOID,
+    STATUS_UNAVAILABLE,
+    THRESHOLDS,
+)
+
+
+STATUS_ORDER = [
+    STATUS_AVAILABLE,
+    STATUS_MONITOR,
+    STATUS_LIMITED,
+    STATUS_AVOID,
+    STATUS_UNAVAILABLE,
+]
+
+CONFIDENCE_ORDER = ['high', 'medium', 'low']
+DATA_STATE_ORDER = ['fresh', 'stale', 'missing', 'incomplete', 'failed', 'historical', 'unknown']
+
+NUMERIC_INPUTS = [
+    'fatigue_score',
+    'pitches_yesterday',
+    'pitches_last_3_days',
+    'pitches_last_5_days',
+]
+
+APPEARANCE_INPUTS = [
+    'appearances_last_3_days',
+    'appearances_last_5_days',
+]
+
+BOUNDARIES = [
+    ('fatigue_score', 'Monitor fatigue', THRESHOLDS.monitor_fatigue_score),
+    ('fatigue_score', 'Limited fatigue', THRESHOLDS.limited_fatigue_score),
+    ('fatigue_score', 'Avoid fatigue', THRESHOLDS.avoid_fatigue_score),
+    ('fatigue_score', 'Unavailable fatigue', THRESHOLDS.unavailable_fatigue_score),
+    ('pitches_yesterday', 'Monitor yesterday pitches', THRESHOLDS.monitor_pitches_yesterday),
+    ('pitches_yesterday', 'Limited yesterday pitches', THRESHOLDS.limited_pitches_yesterday),
+    ('pitches_yesterday', 'Avoid yesterday pitches', THRESHOLDS.avoid_pitches_yesterday),
+    ('pitches_yesterday', 'Unavailable yesterday pitches', THRESHOLDS.unavailable_pitches_yesterday),
+    ('pitches_last_3_days', 'Monitor 3-day pitches', THRESHOLDS.monitor_pitches_last_3_days),
+    ('pitches_last_3_days', 'Limited 3-day pitches', THRESHOLDS.limited_pitches_last_3_days),
+    ('pitches_last_3_days', 'Avoid 3-day pitches', THRESHOLDS.avoid_pitches_last_3_days),
+    ('pitches_last_3_days', 'Unavailable 3-day pitches', THRESHOLDS.unavailable_pitches_last_3_days),
+    ('pitches_last_5_days', 'Limited 5-day pitches', THRESHOLDS.limited_pitches_last_5_days),
+    ('pitches_last_5_days', 'Avoid 5-day pitches', THRESHOLDS.avoid_pitches_last_5_days),
+    ('appearances_last_3_days', 'Limited 3-day appearances', THRESHOLDS.limited_appearances_last_3_days),
+    ('appearances_last_3_days', 'Avoid 3-day appearances', THRESHOLDS.avoid_appearances_last_3_days),
+    ('appearances_last_5_days', 'Monitor 5-day appearances', THRESHOLDS.monitor_appearances_last_5_days),
+    ('appearances_last_5_days', 'Limited 5-day appearances', THRESHOLDS.limited_appearances_last_5_days),
+    ('appearances_last_5_days', 'Avoid 5-day appearances', THRESHOLDS.avoid_appearances_last_5_days),
+]
+
+
+def normalize_record(record):
+    availability = record.get('availability', {})
+    inputs = availability.get('inputs') or record.get('inputs') or {}
+    return {
+        'pitcher_id': record.get('pitcher_id'),
+        'pitcher_name': record.get('pitcher_name') or 'Unknown pitcher',
+        'team': record.get('team'),
+        'availability_status': availability.get('availability_status') or record.get('availability_status'),
+        'confidence': availability.get('confidence') or record.get('confidence') or 'unknown',
+        'data_state': availability.get('data_state') or record.get('data_state') or 'unknown',
+        'reasons': list(availability.get('reasons') or record.get('reasons') or []),
+        'limitations': list(availability.get('limitations') or record.get('limitations') or []),
+        'inputs': inputs,
+    }
+
+
+def ordered_counts(counter, order=None):
+    result = {}
+    order = order or []
+    for key in order:
+        if counter.get(key, 0):
+            result[key] = counter[key]
+    for key in sorted(counter.keys(), key=lambda item: str(item)):
+        if key not in result:
+            result[key] = counter[key]
+    return result
+
+
+def median(values):
+    ordered = sorted(v for v in values if v is not None)
+    if not ordered:
+        return None
+    middle = len(ordered) // 2
+    if len(ordered) % 2:
+        return ordered[middle]
+    return (ordered[middle - 1] + ordered[middle]) / 2
+
+
+def summarize_numeric(values):
+    cleaned = [v for v in values if v is not None]
+    if not cleaned:
+        return {'count': 0, 'min': None, 'median': None, 'max': None}
+    return {
+        'count': len(cleaned),
+        'min': min(cleaned),
+        'median': median(cleaned),
+        'max': max(cleaned),
+    }
+
+
+def reason_frequencies(records):
+    counter = Counter()
+    for record in records:
+        counter.update(record['reasons'])
+    return counter
+
+
+def status_by_data_state(records):
+    table = defaultdict(Counter)
+    for record in records:
+        table[record['data_state']][record['availability_status']] += 1
+    state_totals = Counter({key: sum(value.values()) for key, value in table.items()})
+    return {
+        state: ordered_counts(table[state], STATUS_ORDER)
+        for state in ordered_counts(state_totals, DATA_STATE_ORDER)
+    }
+
+
+def select_near_threshold_examples(records, limit=12):
+    records = [normalize_record(record) for record in records]
+    candidates = []
+    for record in records:
+        inputs = record['inputs']
+        for input_name, boundary_name, threshold in BOUNDARIES:
+            value = inputs.get(input_name)
+            if value is None:
+                continue
+            distance = abs(float(value) - float(threshold))
+            candidates.append({
+                'pitcher_id': record['pitcher_id'],
+                'pitcher_name': record['pitcher_name'],
+                'team': record['team'],
+                'availability_status': record['availability_status'],
+                'confidence': record['confidence'],
+                'data_state': record['data_state'],
+                'input': input_name,
+                'boundary': boundary_name,
+                'value': value,
+                'threshold': threshold,
+                'distance': round(distance, 2),
+                'reasons': record['reasons'],
+            })
+
+    candidates.sort(key=lambda item: (item['distance'], item['pitcher_name'], item['boundary']))
+    return candidates[:limit]
+
+
+def summarize_records(records, near_threshold_limit=12, top_reason_limit=15):
+    normalized = [normalize_record(record) for record in records]
+    status_counts = Counter(record['availability_status'] for record in normalized)
+    confidence_counts = Counter(record['confidence'] for record in normalized)
+    data_state_counts = Counter(record['data_state'] for record in normalized)
+    reason_counts = reason_frequencies(normalized)
+
+    numeric_summary = {
+        key: summarize_numeric([record['inputs'].get(key) for record in normalized])
+        for key in NUMERIC_INPUTS
+    }
+
+    appearance_distribution = {
+        key: ordered_counts(Counter(record['inputs'].get(key) for record in normalized), [])
+        for key in APPEARANCE_INPUTS
+    }
+
+    return {
+        'total_pitchers': len(normalized),
+        'status_distribution': ordered_counts(status_counts, STATUS_ORDER),
+        'confidence_distribution': ordered_counts(confidence_counts, CONFIDENCE_ORDER),
+        'data_state_distribution': ordered_counts(data_state_counts, DATA_STATE_ORDER),
+        'status_by_data_state': status_by_data_state(normalized),
+        'top_reason_frequencies': reason_counts.most_common(top_reason_limit),
+        'workload_input_summary': numeric_summary,
+        'appearance_distributions': appearance_distribution,
+        'data_quality_counts': {
+            'stale': data_state_counts.get('stale', 0),
+            'missing': data_state_counts.get('missing', 0),
+            'incomplete': data_state_counts.get('incomplete', 0),
+        },
+        'near_threshold_examples': select_near_threshold_examples(normalized, limit=near_threshold_limit),
+    }
+
+
+def _format_value(value):
+    if value is None:
+        return 'n/a'
+    if isinstance(value, float):
+        return f'{value:.1f}'.rstrip('0').rstrip('.')
+    return str(value)
+
+
+def _markdown_counts(title, counts):
+    lines = [f'### {title}', '', '| Value | Count |', '|---|---:|']
+    if not counts:
+        lines.append('| none | 0 |')
+    else:
+        for key, count in counts.items():
+            lines.append(f'| {key} | {count} |')
+    lines.append('')
+    return lines
+
+
+def _markdown_numeric(summary):
+    lines = ['### Workload Input Summary', '', '| Input | Count | Min | Median | Max |', '|---|---:|---:|---:|---:|']
+    for key, values in summary.items():
+        lines.append(
+            f"| {key} | {values['count']} | {_format_value(values['min'])} | "
+            f"{_format_value(values['median'])} | {_format_value(values['max'])} |"
+        )
+    lines.append('')
+    return lines
+
+
+def _markdown_appearance(summary):
+    lines = ['### Appearance Distributions', '']
+    for key, counts in summary.items():
+        lines.extend([f'#### {key}', '', '| Appearances | Count |', '|---:|---:|'])
+        for appearances, count in counts.items():
+            lines.append(f'| {_format_value(appearances)} | {count} |')
+        lines.append('')
+    return lines
+
+
+def _markdown_reason_frequencies(reason_counts):
+    lines = ['### Top Reason Frequencies', '', '| Reason | Count |', '|---|---:|']
+    if not reason_counts:
+        lines.append('| none | 0 |')
+    else:
+        for reason, count in reason_counts:
+            lines.append(f'| {reason} | {count} |')
+    lines.append('')
+    return lines
+
+
+def _markdown_status_by_state(table):
+    lines = ['### Status By Data State', '', '| Data state | Status | Count |', '|---|---|---:|']
+    if not table:
+        lines.append('| none | none | 0 |')
+    else:
+        for state, statuses in table.items():
+            for status, count in statuses.items():
+                lines.append(f'| {state} | {status} | {count} |')
+    lines.append('')
+    return lines
+
+
+def _markdown_near_threshold(examples):
+    lines = [
+        '### Near-Threshold Examples',
+        '',
+        '| Pitcher | Team | Status | Data state | Boundary | Value | Threshold | Distance | Reasons |',
+        '|---|---|---|---|---|---:|---:|---:|---|',
+    ]
+    if not examples:
+        lines.append('| none |  |  |  |  |  |  |  |  |')
+    else:
+        for item in examples:
+            reasons = '; '.join(item['reasons']) if item['reasons'] else 'none'
+            lines.append(
+                f"| {item['pitcher_name']} | {item.get('team') or ''} | {item['availability_status']} | "
+                f"{item['data_state']} | {item['boundary']} | {_format_value(item['value'])} | "
+                f"{_format_value(item['threshold'])} | {_format_value(item['distance'])} | {reasons} |"
+            )
+    lines.append('')
+    return lines
+
+
+def render_markdown_report(current_summary, snapshot_summary=None, generated_at=None, reference_date=None):
+    generated_at = generated_at or datetime.now(timezone.utc)
+    lines = [
+        '# Availability Threshold Audit',
+        '',
+        f'Generated at: {generated_at.isoformat()}',
+        f'Current reference date: {reference_date or "today"}',
+        '',
+        'This report audits current Availability Engine output using the existing classifier.',
+        'It is evidence for later threshold review only; it does not change thresholds.',
+        '',
+        'Trust note: current classifications keep fresh, stale, missing, and incomplete data separate.',
+        'Stale or missing Monitor counts should not be read as workload-driven Monitor counts.',
+        'Latest-workload snapshot output anchors each pitcher to their latest game date to inspect',
+        'historical workload windows; it is not current bullpen availability.',
+        '',
+    ]
+
+    for title, summary in [
+        ('Current Availability Output', current_summary),
+        ('Latest-Workload Snapshot Output', snapshot_summary),
+    ]:
+        if summary is None:
+            continue
+        lines.extend([
+            f'## {title}',
+            '',
+            f"Total pitchers evaluated: {summary['total_pitchers']}",
+            '',
+        ])
+        lines.extend(_markdown_counts('Status Distribution', summary['status_distribution']))
+        lines.extend(_markdown_counts('Confidence Distribution', summary['confidence_distribution']))
+        lines.extend(_markdown_counts('Data State Distribution', summary['data_state_distribution']))
+        lines.extend(_markdown_status_by_state(summary['status_by_data_state']))
+        lines.extend(_markdown_reason_frequencies(summary['top_reason_frequencies']))
+        lines.extend(_markdown_numeric(summary['workload_input_summary']))
+        lines.extend(_markdown_appearance(summary['appearance_distributions']))
+        lines.extend(_markdown_counts('Stale/Incomplete/Missing Counts', summary['data_quality_counts']))
+        lines.extend(_markdown_near_threshold(summary['near_threshold_examples']))
+
+    return '\n'.join(lines).rstrip() + '\n'
+
+
+def render_json_report(current_summary, snapshot_summary=None, generated_at=None, reference_date=None):
+    generated_at = generated_at or datetime.now(timezone.utc)
+    payload = {
+        'generated_at': generated_at.isoformat(),
+        'reference_date': str(reference_date or 'today'),
+        'trust_note': 'Stale or missing Monitor counts are separated from workload-driven Monitor counts.',
+        'current': current_summary,
+        'latest_workload_snapshot': snapshot_summary,
+    }
+    return json.dumps(payload, indent=2, sort_keys=True)

--- a/backend/tests/test_availability_threshold_audit.py
+++ b/backend/tests/test_availability_threshold_audit.py
@@ -1,0 +1,144 @@
+from services.availability_threshold_audit import (
+    reason_frequencies,
+    select_near_threshold_examples,
+    summarize_records,
+)
+
+
+def _record(name, status, data_state, reasons, inputs, confidence='high'):
+    return {
+        'pitcher_id': hash(name) % 10000,
+        'pitcher_name': name,
+        'team': 'TST',
+        'availability': {
+            'availability_status': status,
+            'confidence': confidence,
+            'data_state': data_state,
+            'reasons': reasons,
+            'limitations': [],
+            'inputs': inputs,
+        },
+    }
+
+
+def test_audit_summary_keeps_stale_monitor_separate_from_fresh_monitor():
+    records = [
+        _record(
+            'Fresh Monitor',
+            'Monitor',
+            'fresh',
+            ['15 pitches yesterday', '1 day rest'],
+            {
+                'fatigue_score': 42,
+                'pitches_yesterday': 15,
+                'pitches_last_3_days': 28,
+                'pitches_last_5_days': 30,
+                'appearances_last_3_days': 1,
+                'appearances_last_5_days': 2,
+            },
+        ),
+        _record(
+            'Stale Monitor',
+            'Monitor',
+            'stale',
+            ['Latest game log is older than 14 days'],
+            {
+                'fatigue_score': 72,
+                'pitches_yesterday': 0,
+                'pitches_last_3_days': 0,
+                'pitches_last_5_days': 0,
+                'appearances_last_3_days': 0,
+                'appearances_last_5_days': 0,
+            },
+            confidence='low',
+        ),
+        _record(
+            'Avoid Workload',
+            'Avoid',
+            'fresh',
+            ['42 pitches yesterday', '4 appearances in last 5 days'],
+            {
+                'fatigue_score': 79,
+                'pitches_yesterday': 42,
+                'pitches_last_3_days': 61,
+                'pitches_last_5_days': 76,
+                'appearances_last_3_days': 2,
+                'appearances_last_5_days': 4,
+            },
+            confidence='medium',
+        ),
+    ]
+
+    summary = summarize_records(records)
+
+    assert summary['total_pitchers'] == 3
+    assert summary['status_distribution'] == {'Monitor': 2, 'Avoid': 1}
+    assert summary['data_state_distribution'] == {'fresh': 2, 'stale': 1}
+    assert summary['status_by_data_state']['fresh'] == {'Monitor': 1, 'Avoid': 1}
+    assert summary['status_by_data_state']['stale'] == {'Monitor': 1}
+    assert summary['data_quality_counts'] == {'stale': 1, 'missing': 0, 'incomplete': 0}
+    assert summary['workload_input_summary']['fatigue_score']['median'] == 72
+
+
+def test_reason_frequencies_count_repeated_rule_reasons():
+    records = [
+        {
+            'reasons': ['1 day rest', '15 pitches yesterday'],
+        },
+        {
+            'reasons': ['1 day rest', 'Fatigue score 55'],
+        },
+        {
+            'reasons': ['Fatigue score 55'],
+        },
+    ]
+
+    counts = reason_frequencies(records)
+
+    assert counts['1 day rest'] == 2
+    assert counts['Fatigue score 55'] == 2
+    assert counts['15 pitches yesterday'] == 1
+
+
+def test_near_threshold_examples_find_closest_boundary_inputs():
+    records = [
+        _record(
+            'Near Limited',
+            'Monitor',
+            'fresh',
+            ['24 pitches yesterday'],
+            {
+                'fatigue_score': 59.5,
+                'pitches_yesterday': 24,
+                'pitches_last_3_days': 44,
+                'pitches_last_5_days': 58,
+                'appearances_last_3_days': 1,
+                'appearances_last_5_days': 2,
+            },
+        ),
+        _record(
+            'Far Away',
+            'Available',
+            'fresh',
+            [],
+            {
+                'fatigue_score': 12,
+                'pitches_yesterday': 0,
+                'pitches_last_3_days': 0,
+                'pitches_last_5_days': 0,
+                'appearances_last_3_days': 0,
+                'appearances_last_5_days': 0,
+            },
+        ),
+    ]
+
+    examples = select_near_threshold_examples(records, limit=3)
+
+    assert examples[0]['pitcher_name'] == 'Near Limited'
+    assert examples[0]['distance'] <= 1
+    assert examples[0]['input'] in {
+        'fatigue_score',
+        'pitches_yesterday',
+        'pitches_last_3_days',
+        'appearances_last_5_days',
+    }

--- a/docs/BULLPEN_AVAILABILITY_ENGINE_V1.md
+++ b/docs/BULLPEN_AVAILABILITY_ENGINE_V1.md
@@ -258,6 +258,28 @@ Unavailable at the same time. These fixtures validate UI rendering, filtering,
 confidence display, data-state visibility, reasons, and limitations only. They
 are not threshold validation and must not be treated as production pitcher data.
 
+### Threshold Audit
+
+Availability thresholds should be tuned from evidence, not from one-off visual
+inspection. The repeatable audit script is:
+
+```powershell
+cd backend
+python scripts/audit_availability_thresholds.py
+```
+
+By default it writes `backend/reports/availability_threshold_audit.md`. The
+report summarizes current classifier output, confidence and data-state
+distributions, reason frequencies, workload inputs, and near-threshold
+examples. It also separates current freshness-aware classifications from a
+latest-workload snapshot so stale-data Monitor counts are not confused with
+workload-driven Monitor counts.
+
+The audit is allowed to inform future threshold review and test-case design. It
+must not change backend thresholds, fatigue scoring, API response shape, or
+frontend rendering. Any threshold changes should happen in a later branch after
+the audit evidence is reviewed.
+
 ## Explainability Contract
 
 Every status must be explainable by a small set of ordered reasons. Reasons are


### PR DESCRIPTION
Adds a repeatable audit for Availability Engine threshold behavior, including status distributions, confidence/data-state summaries, reason frequencies, workload summaries, and documentation for evidence-based tuning.