### PR TITLE
Add availability snapshot validation mode

### DIFF
--- a/backend/api/bullpen.py
+++ b/backend/api/bullpen.py
@@ -11,6 +11,12 @@ from models.game_log import GameLog
 from models.fatigue_score import FatigueScore
 from services.fatigue import calculate_fatigue, get_risk_level
 from services.availability import ACTIVE_WINDOW_DAYS, classify_availability
+from services.availability_snapshot import (
+    LATEST_WORKLOAD_SNAPSHOT_MODE,
+    availability_mode_metadata,
+    classify_latest_fatigue_rows,
+    latest_fatigue_rows as snapshot_latest_fatigue_rows,
+)
 from services.mlb_api import mlb_client
 from services import sync as sync_service
 from utils.auth import require_admin_token
@@ -192,6 +198,58 @@ def get_fatigue_scores():
             risk_level=risk_level,
         ),
     })
+
+
+@bullpen_bp.route('/fatigue/snapshot', methods=['GET'])
+@require_admin_token
+def get_latest_workload_snapshot():
+    """
+    Admin/development-only validation view of the latest known workload window.
+
+    This intentionally does not represent current bullpen availability. It
+    anchors each pitcher on their own most recent game log so local historical
+    datasets can exercise availability thresholds without changing public
+    calendar-based freshness behavior.
+    """
+    team_id    = request.args.get('team_id', type=int)
+    risk_level = request.args.get('risk_level')
+    limit      = request.args.get('limit', 750, type=int)
+
+    rows = snapshot_latest_fatigue_rows(
+        team_id=team_id,
+        risk_level=risk_level,
+        limit=limit,
+        order_by_score=True,
+    )
+    records = classify_latest_fatigue_rows(rows, mode=LATEST_WORKLOAD_SNAPSHOT_MODE)
+
+    data = []
+    for record in records:
+        score = record['score']
+        pitcher = record['pitcher']
+        data.append({
+            **score.to_dict(),
+            'pitcher': pitcher.to_dict(),
+            'availability': record['availability'],
+            'availability_mode': {
+                'mode': LATEST_WORKLOAD_SNAPSHOT_MODE,
+                'evaluation_date': record['evaluation_date'].isoformat() if record['evaluation_date'] else None,
+                'latest_game_date': record['latest_game_date'].isoformat() if record['latest_game_date'] else None,
+                'is_current_availability': False,
+            },
+        })
+
+    meta = availability_mode_metadata(LATEST_WORKLOAD_SNAPSHOT_MODE, records=records)
+    meta.update({
+        'total_pitchers': len(records),
+        'returned_pitchers': len(data),
+        'active_window_days': ACTIVE_WINDOW_DAYS,
+        'filters': {
+            'team_id': team_id,
+            'risk_level': risk_level.upper() if risk_level else None,
+        },
+    })
+    return jsonify({'data': data, 'meta': meta})
 
 
 @bullpen_bp.route('/fatigue/<int:pitcher_id>', methods=['GET'])

--- a/backend/reports/availability_threshold_audit.md
+++ b/backend/reports/availability_threshold_audit.md
@@ -1,6 +1,6 @@
 # Availability Threshold Audit
 
-Generated at: 2026-06-01T22:54:12.674737+00:00
+Generated at: 2026-06-01T23:06:04.308378+00:00
 Current reference date: 2026-06-01
 
 This report audits current Availability Engine output using the existing classifier.

--- a/backend/scripts/audit_availability_thresholds.py
+++ b/backend/scripts/audit_availability_thresholds.py
@@ -7,7 +7,7 @@ thresholds, fatigue scoring, API responses, or frontend output.
 """
 
 from argparse import ArgumentParser
-from datetime import date, datetime, timedelta, timezone
+from datetime import date, datetime, timezone
 from pathlib import Path
 import sys
 
@@ -16,16 +16,17 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from app import create_app  # noqa: E402
-from models.fatigue_score import FatigueScore  # noqa: E402
-from models.game_log import GameLog  # noqa: E402
-from models.pitcher import Pitcher  # noqa: E402
-from services.availability import ACTIVE_WINDOW_DAYS, classify_availability  # noqa: E402
+from services.availability_snapshot import (  # noqa: E402
+    CURRENT_AVAILABILITY_MODE,
+    LATEST_WORKLOAD_SNAPSHOT_MODE,
+    classify_latest_fatigue_rows,
+    latest_fatigue_rows,
+)
 from services.availability_threshold_audit import (  # noqa: E402
     render_json_report,
     render_markdown_report,
     summarize_records,
 )
-from utils.db import db  # noqa: E402
 
 
 DEFAULT_OUTPUT = ROOT / 'reports' / 'availability_threshold_audit.md'
@@ -37,82 +38,19 @@ def parse_date(value):
     return datetime.strptime(value, '%Y-%m-%d').date()
 
 
-def latest_fatigue_rows():
-    subq = (
-        db.session.query(
-            FatigueScore.pitcher_id,
-            db.func.max(FatigueScore.calculated_at).label('max_calc'),
-        )
-        .group_by(FatigueScore.pitcher_id)
-        .subquery()
-    )
-
-    return (
-        db.session.query(FatigueScore, Pitcher)
-        .join(
-            subq,
-            (FatigueScore.pitcher_id == subq.c.pitcher_id)
-            & (FatigueScore.calculated_at == subq.c.max_calc),
-        )
-        .join(Pitcher, FatigueScore.pitcher_id == Pitcher.id)
-        .order_by(Pitcher.team_abbreviation, Pitcher.full_name)
-        .all()
-    )
-
-
-def latest_game_date_for(pitcher_id):
-    return (
-        db.session.query(db.func.max(GameLog.game_date))
-        .filter(GameLog.pitcher_id == pitcher_id)
-        .scalar()
-    )
-
-
-def logs_for_window(pitcher_id, reference_date):
-    window_start = reference_date - timedelta(days=4)
-    return (
-        GameLog.query
-        .filter(
-            GameLog.pitcher_id == pitcher_id,
-            GameLog.game_date >= window_start,
-            GameLog.game_date <= reference_date,
-        )
-        .order_by(GameLog.game_date.desc())
-        .all()
-    )
-
-
-def classify_rows(rows, reference_date, mode):
-    records = []
-    for score, pitcher in rows:
-        latest_game_date = latest_game_date_for(pitcher.id)
-        if mode == 'latest_workload_snapshot':
-            ref = latest_game_date or reference_date
-        else:
-            ref = reference_date
-
-        logs = logs_for_window(pitcher.id, ref)
-        availability = classify_availability(
-            score=score,
-            game_logs=logs,
-            reference_date=ref,
-            latest_game_date=latest_game_date,
-            active_window_days=ACTIVE_WINDOW_DAYS,
-        )
-        records.append({
-            'pitcher_id': pitcher.id,
-            'pitcher_name': pitcher.full_name,
-            'team': pitcher.team_abbreviation,
-            'availability': availability,
-        })
-    return records
-
-
 def build_audit(reference_date=None, near_threshold_limit=12):
     ref = reference_date or date.today()
     rows = latest_fatigue_rows()
-    current_records = classify_rows(rows, reference_date=ref, mode='current')
-    snapshot_records = classify_rows(rows, reference_date=ref, mode='latest_workload_snapshot')
+    current_records = classify_latest_fatigue_rows(
+        rows,
+        reference_date=ref,
+        mode=CURRENT_AVAILABILITY_MODE,
+    )
+    snapshot_records = classify_latest_fatigue_rows(
+        rows,
+        reference_date=ref,
+        mode=LATEST_WORKLOAD_SNAPSHOT_MODE,
+    )
     return {
         'reference_date': ref,
         'current': summarize_records(current_records, near_threshold_limit=near_threshold_limit),

--- a/backend/services/availability_snapshot.py
+++ b/backend/services/availability_snapshot.py
@@ -1,0 +1,159 @@
+"""
+Shared Availability Engine evaluation modes.
+
+Normal API output remains calendar-based current availability. The latest
+workload snapshot mode is explicitly non-current and exists only for
+admin/development validation and threshold review.
+"""
+
+from datetime import date, timedelta
+
+from sqlalchemy import desc
+
+from models.fatigue_score import FatigueScore
+from models.game_log import GameLog
+from models.pitcher import Pitcher
+from services.availability import ACTIVE_WINDOW_DAYS, classify_availability
+from utils.db import db
+
+
+CURRENT_AVAILABILITY_MODE = 'current_availability'
+LATEST_WORKLOAD_SNAPSHOT_MODE = 'latest_workload_snapshot'
+SNAPSHOT_REFERENCE_STRATEGY = 'per_pitcher_latest_game_date'
+SNAPSHOT_WARNING = (
+    'Historical workload snapshot for validation only. '
+    'Do not treat as current bullpen availability.'
+)
+
+
+def _iso_or_none(value):
+    return value.isoformat() if value else None
+
+
+def _truthy_limit(limit):
+    return limit if isinstance(limit, int) and limit > 0 else None
+
+
+def availability_mode_metadata(mode, records=None, reference_date=None):
+    records = list(records or [])
+    if mode == LATEST_WORKLOAD_SNAPSHOT_MODE:
+        snapshot_date = max(
+            (record.get('latest_game_date') for record in records if record.get('latest_game_date')),
+            default=None,
+        )
+        return {
+            'mode': LATEST_WORKLOAD_SNAPSHOT_MODE,
+            'snapshot_date': _iso_or_none(snapshot_date),
+            'reference_strategy': SNAPSHOT_REFERENCE_STRATEGY,
+            'is_current_availability': False,
+            'warning': SNAPSHOT_WARNING,
+        }
+
+    return {
+        'mode': CURRENT_AVAILABILITY_MODE,
+        'reference_date': _iso_or_none(reference_date or date.today()),
+        'is_current_availability': True,
+    }
+
+
+def latest_fatigue_rows(team_id=None, risk_level=None, limit=None, order_by_score=False):
+    subq = (
+        db.session.query(
+            FatigueScore.pitcher_id,
+            db.func.max(FatigueScore.calculated_at).label('max_calc'),
+        )
+        .group_by(FatigueScore.pitcher_id)
+        .subquery()
+    )
+
+    query = (
+        db.session.query(FatigueScore, Pitcher)
+        .join(
+            subq,
+            (FatigueScore.pitcher_id == subq.c.pitcher_id)
+            & (FatigueScore.calculated_at == subq.c.max_calc),
+        )
+        .join(Pitcher, FatigueScore.pitcher_id == Pitcher.id)
+    )
+
+    if team_id:
+        query = query.filter(Pitcher.team_id == team_id)
+    if risk_level:
+        query = query.filter(FatigueScore.risk_level == risk_level.upper())
+
+    if order_by_score:
+        query = query.order_by(desc(FatigueScore.raw_score), Pitcher.full_name)
+    else:
+        query = query.order_by(Pitcher.team_abbreviation, Pitcher.full_name)
+
+    limit = _truthy_limit(limit)
+    if limit:
+        query = query.limit(limit)
+
+    return query.all()
+
+
+def latest_game_date_for(pitcher_id):
+    return (
+        db.session.query(db.func.max(GameLog.game_date))
+        .filter(GameLog.pitcher_id == pitcher_id)
+        .scalar()
+    )
+
+
+def logs_for_availability_window(pitcher_id, reference_date):
+    window_start = reference_date - timedelta(days=4)
+    return (
+        GameLog.query
+        .filter(
+            GameLog.pitcher_id == pitcher_id,
+            GameLog.game_date >= window_start,
+            GameLog.game_date <= reference_date,
+        )
+        .order_by(desc(GameLog.game_date))
+        .all()
+    )
+
+
+def evaluation_date_for_mode(mode, latest_game_date, current_reference_date=None):
+    current_reference_date = current_reference_date or date.today()
+    if mode == LATEST_WORKLOAD_SNAPSHOT_MODE:
+        return latest_game_date or current_reference_date
+    return current_reference_date
+
+
+def classify_fatigue_row(score, pitcher, reference_date=None, mode=CURRENT_AVAILABILITY_MODE):
+    current_reference_date = reference_date or date.today()
+    latest_game_date = latest_game_date_for(pitcher.id)
+    evaluation_date = evaluation_date_for_mode(
+        mode,
+        latest_game_date=latest_game_date,
+        current_reference_date=current_reference_date,
+    )
+    logs = logs_for_availability_window(pitcher.id, evaluation_date)
+    availability = classify_availability(
+        score=score,
+        game_logs=logs,
+        reference_date=evaluation_date,
+        latest_game_date=latest_game_date,
+        active_window_days=ACTIVE_WINDOW_DAYS,
+    )
+
+    return {
+        'pitcher_id': pitcher.id,
+        'pitcher_name': pitcher.full_name,
+        'team': pitcher.team_abbreviation,
+        'score': score,
+        'pitcher': pitcher,
+        'availability': availability,
+        'mode': mode,
+        'evaluation_date': evaluation_date,
+        'latest_game_date': latest_game_date,
+    }
+
+
+def classify_latest_fatigue_rows(rows, reference_date=None, mode=CURRENT_AVAILABILITY_MODE):
+    return [
+        classify_fatigue_row(score, pitcher, reference_date=reference_date, mode=mode)
+        for score, pitcher in rows
+    ]

--- a/backend/tests/test_availability_snapshot_mode.py
+++ b/backend/tests/test_availability_snapshot_mode.py
@@ -1,0 +1,297 @@
+from datetime import date, datetime, timedelta
+
+import pytest
+from flask import Flask
+
+import models.prospect  # noqa: F401  (register on db.metadata)
+from api.bullpen import bullpen_bp
+from models.fatigue_score import FatigueScore
+from models.game_log import GameLog
+from models.pitcher import Pitcher
+from services.availability_snapshot import (
+    CURRENT_AVAILABILITY_MODE,
+    LATEST_WORKLOAD_SNAPSHOT_MODE,
+    SNAPSHOT_REFERENCE_STRATEGY,
+    SNAPSHOT_WARNING,
+    availability_mode_metadata,
+    classify_latest_fatigue_rows,
+    latest_fatigue_rows,
+)
+from utils.auth import ADMIN_TOKEN_HEADER
+from utils.db import db
+
+
+@pytest.fixture
+def client():
+    app = Flask(__name__)
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+    app.config['APP_ENV'] = 'development'
+    app.config['ADMIN_API_TOKEN'] = 'secret'
+    db.init_app(app)
+    app.register_blueprint(bullpen_bp, url_prefix='/api/bullpen')
+    with app.app_context():
+        db.create_all()
+        try:
+            yield app.test_client()
+        finally:
+            db.session.remove()
+            db.drop_all()
+
+
+def _risk_for_score(raw_score):
+    if raw_score >= 85:
+        return 'CRITICAL'
+    if raw_score >= 70:
+        return 'HIGH'
+    if raw_score >= 40:
+        return 'MODERATE'
+    return 'LOW'
+
+
+def _add_pitcher(name, latest_game_date=None, raw_score=20.0, log_pitches=None, mlb_seed=1):
+    pitcher = Pitcher(
+        mlb_id=700000 + mlb_seed,
+        full_name=name,
+        team_id=1,
+        team_name='Snapshot Club',
+        team_abbreviation='SNP',
+        active=True,
+    )
+    db.session.add(pitcher)
+    db.session.flush()
+
+    for index, pitches in enumerate(log_pitches or []):
+        db.session.add(GameLog(
+            pitcher_id=pitcher.id,
+            mlb_game_pk=800000 + (mlb_seed * 100) + index,
+            game_date=latest_game_date - timedelta(days=index),
+            pitches_thrown=pitches,
+            innings_pitched=1.0,
+        ))
+
+    db.session.add(FatigueScore(
+        pitcher_id=pitcher.id,
+        calculated_at=datetime.utcnow(),
+        raw_score=raw_score,
+        pitch_count_score=0.0,
+        rest_days_score=0.0,
+        appearances_score=0.0,
+        innings_score=0.0,
+        leverage_score=0.0,
+        days_since_last_appearance=0,
+        appearances_last_7=len(log_pitches or []),
+        appearances_last_14=len(log_pitches or []),
+        pitches_last_7_days=sum(log_pitches or []),
+        innings_last_7_days=float(len(log_pitches or [])),
+        risk_level=_risk_for_score(raw_score),
+    ))
+    db.session.commit()
+    return pitcher
+
+
+def test_current_mode_remains_calendar_based_and_can_be_available(client):
+    with client.application.app_context():
+        ref = date.today()
+        _add_pitcher(
+            'Light Current Workload',
+            latest_game_date=ref - timedelta(days=3),
+            raw_score=18.0,
+            log_pitches=[8],
+        )
+
+        records = classify_latest_fatigue_rows(
+            latest_fatigue_rows(),
+            reference_date=ref,
+            mode=CURRENT_AVAILABILITY_MODE,
+        )
+
+    assert records[0]['evaluation_date'] == ref
+    assert records[0]['availability']['availability_status'] == 'Available'
+    assert records[0]['availability']['confidence'] == 'high'
+    assert records[0]['availability']['data_state'] == 'fresh'
+
+
+def test_snapshot_mode_uses_latest_workload_date_and_non_current_metadata(client):
+    with client.application.app_context():
+        latest = date.today() - timedelta(days=30)
+        _add_pitcher(
+            'Historical Snapshot Workload',
+            latest_game_date=latest,
+            raw_score=32.0,
+            log_pitches=[18],
+        )
+
+        rows = latest_fatigue_rows()
+        records = classify_latest_fatigue_rows(
+            rows,
+            reference_date=date.today(),
+            mode=LATEST_WORKLOAD_SNAPSHOT_MODE,
+        )
+        meta = availability_mode_metadata(LATEST_WORKLOAD_SNAPSHOT_MODE, records=records)
+
+    assert records[0]['evaluation_date'] == latest
+    assert records[0]['availability']['inputs']['reference_date'] == latest.isoformat()
+    assert records[0]['availability']['data_state'] == 'fresh'
+    assert meta == {
+        'mode': LATEST_WORKLOAD_SNAPSHOT_MODE,
+        'snapshot_date': latest.isoformat(),
+        'reference_strategy': SNAPSHOT_REFERENCE_STRATEGY,
+        'is_current_availability': False,
+        'warning': SNAPSHOT_WARNING,
+    }
+
+
+def test_snapshot_mode_produces_mixed_workload_statuses_from_sample_data(client):
+    with client.application.app_context():
+        anchor = date(2026, 5, 1)
+        _add_pitcher('Snapshot Monitor', latest_game_date=anchor, raw_score=20.0, log_pitches=[5], mlb_seed=1)
+        _add_pitcher('Snapshot Limited', latest_game_date=anchor, raw_score=20.0, log_pitches=[45], mlb_seed=2)
+        _add_pitcher('Snapshot Avoid', latest_game_date=anchor, raw_score=20.0, log_pitches=[65], mlb_seed=3)
+        _add_pitcher('Snapshot Unavailable', latest_game_date=anchor, raw_score=20.0, log_pitches=[85], mlb_seed=4)
+
+        records = classify_latest_fatigue_rows(
+            latest_fatigue_rows(),
+            reference_date=date.today(),
+            mode=LATEST_WORKLOAD_SNAPSHOT_MODE,
+        )
+        by_name = {
+            record['pitcher_name']: record['availability']
+            for record in records
+        }
+
+    assert by_name['Snapshot Monitor']['availability_status'] == 'Monitor'
+    assert by_name['Snapshot Limited']['availability_status'] == 'Limited'
+    assert by_name['Snapshot Avoid']['availability_status'] == 'Avoid'
+    assert by_name['Snapshot Unavailable']['availability_status'] == 'Unavailable'
+    for availability in by_name.values():
+        assert availability['data_state'] == 'fresh'
+        assert availability['reasons']
+
+
+def test_current_mode_keeps_stale_data_truthful(client):
+    with client.application.app_context():
+        _add_pitcher(
+            'Stale Calendar Workload',
+            latest_game_date=date.today() - timedelta(days=30),
+            raw_score=78.0,
+            log_pitches=[44],
+        )
+
+        records = classify_latest_fatigue_rows(
+            latest_fatigue_rows(),
+            reference_date=date.today(),
+            mode=CURRENT_AVAILABILITY_MODE,
+        )
+
+    availability = records[0]['availability']
+    assert availability['availability_status'] == 'Monitor'
+    assert availability['confidence'] == 'low'
+    assert availability['data_state'] == 'stale'
+    assert 'Stale data must not be treated as current availability' in availability['limitations']
+
+
+def test_snapshot_mode_keeps_missing_data_truthful(client):
+    with client.application.app_context():
+        _add_pitcher(
+            'Missing Workload History',
+            latest_game_date=None,
+            raw_score=22.0,
+            log_pitches=[],
+        )
+
+        records = classify_latest_fatigue_rows(
+            latest_fatigue_rows(),
+            reference_date=date.today(),
+            mode=LATEST_WORKLOAD_SNAPSHOT_MODE,
+        )
+
+    availability = records[0]['availability']
+    assert availability['availability_status'] == 'Monitor'
+    assert availability['confidence'] == 'low'
+    assert availability['data_state'] == 'missing'
+    assert availability['reasons'] == ['Missing workload history or fatigue score']
+
+
+def test_snapshot_endpoint_is_admin_gated_and_marks_non_current(client):
+    with client.application.app_context():
+        _add_pitcher(
+            'Endpoint Snapshot Workload',
+            latest_game_date=date(2026, 5, 1),
+            raw_score=64.0,
+            log_pitches=[45],
+        )
+
+    rejected = client.get('/api/bullpen/fatigue/snapshot')
+    accepted = client.get(
+        '/api/bullpen/fatigue/snapshot',
+        headers={ADMIN_TOKEN_HEADER: 'secret'},
+    )
+
+    assert rejected.status_code == 401
+    assert accepted.status_code == 200
+    body = accepted.get_json()
+    assert body['meta']['mode'] == LATEST_WORKLOAD_SNAPSHOT_MODE
+    assert body['meta']['snapshot_date'] == '2026-05-01'
+    assert body['meta']['is_current_availability'] is False
+    assert body['meta']['warning'] == SNAPSHOT_WARNING
+    assert body['data'][0]['availability_mode']['mode'] == LATEST_WORKLOAD_SNAPSHOT_MODE
+    assert body['data'][0]['availability_mode']['is_current_availability'] is False
+    assert body['data'][0]['availability']['data_state'] == 'fresh'
+
+
+def test_audit_script_uses_shared_snapshot_path():
+    import scripts.audit_availability_thresholds as audit_script
+
+    assert audit_script.LATEST_WORKLOAD_SNAPSHOT_MODE == LATEST_WORKLOAD_SNAPSHOT_MODE
+    assert audit_script.classify_latest_fatigue_rows is classify_latest_fatigue_rows
+
+
+def test_audit_build_uses_shared_current_and_snapshot_modes(monkeypatch):
+    import scripts.audit_availability_thresholds as audit_script
+
+    calls = []
+
+    def fake_latest_fatigue_rows():
+        return [('score', 'pitcher')]
+
+    def fake_classify_latest_fatigue_rows(rows, reference_date=None, mode=None):
+        calls.append({
+            'rows': rows,
+            'reference_date': reference_date,
+            'mode': mode,
+        })
+        return [{
+            'pitcher_id': 1,
+            'pitcher_name': mode,
+            'team': 'TST',
+            'availability': {
+                'availability_status': 'Available',
+                'confidence': 'high',
+                'data_state': 'fresh',
+                'reasons': [],
+                'limitations': [],
+                'inputs': {
+                    'fatigue_score': 10,
+                    'pitches_yesterday': 0,
+                    'pitches_last_3_days': 0,
+                    'pitches_last_5_days': 0,
+                    'appearances_last_3_days': 0,
+                    'appearances_last_5_days': 0,
+                },
+            },
+        }]
+
+    monkeypatch.setattr(audit_script, 'latest_fatigue_rows', fake_latest_fatigue_rows)
+    monkeypatch.setattr(audit_script, 'classify_latest_fatigue_rows', fake_classify_latest_fatigue_rows)
+
+    ref = date(2026, 6, 1)
+    audit = audit_script.build_audit(reference_date=ref, near_threshold_limit=1)
+
+    assert [call['mode'] for call in calls] == [
+        CURRENT_AVAILABILITY_MODE,
+        LATEST_WORKLOAD_SNAPSHOT_MODE,
+    ]
+    assert all(call['reference_date'] == ref for call in calls)
+    assert audit['current']['total_pitchers'] == 1
+    assert audit['latest_workload_snapshot']['total_pitchers'] == 1

--- a/docs/BULLPEN_AVAILABILITY_ENGINE_V1.md
+++ b/docs/BULLPEN_AVAILABILITY_ENGINE_V1.md
@@ -280,6 +280,46 @@ must not change backend thresholds, fatigue scoring, API response shape, or
 frontend rendering. Any threshold changes should happen in a later branch after
 the audit evidence is reviewed.
 
+### Latest Workload Snapshot Validation Mode
+
+Local historical datasets can make all public current-availability rows appear
+stale even when useful workload examples exist. BaseballOS therefore includes a
+development/admin validation mode that anchors each pitcher to their latest
+known game-log date and reuses the same Availability Engine classifier.
+
+This mode is exposed through the protected backend endpoint:
+
+```powershell
+GET /api/bullpen/fatigue/snapshot
+```
+
+The route is gated by the same `X-Admin-Token` / `ADMIN_API_TOKEN` guard used by
+operational admin endpoints. It is not a public Bullpen UI mode and must not be
+presented as live availability.
+
+Responses include explicit non-current metadata:
+
+```json
+{
+  "mode": "latest_workload_snapshot",
+  "snapshot_date": "2026-05-01",
+  "reference_strategy": "per_pitcher_latest_game_date",
+  "is_current_availability": false,
+  "warning": "Historical workload snapshot for validation only. Do not treat as current bullpen availability."
+}
+```
+
+`snapshot_date` is the latest game-log date represented by the response. Each
+pitcher row also carries its own evaluation date because the validation strategy
+is per-pitcher latest workload, not a claim that every pitcher has current data
+on the same date.
+
+The threshold audit script uses this same shared snapshot path for its
+latest-workload section. Snapshot output is allowed to support visual
+validation, regression fixtures, and later threshold review. It is not allowed
+to tune thresholds by itself, replace current-calendar freshness filtering, or
+hide stale/missing data states.
+
 ## Explainability Contract
 
 Every status must be explainable by a small set of ordered reasons. Reasons are


### PR DESCRIPTION
Adds a non-current latest-workload snapshot mode for Availability Engine validation, reuses classification logic with controlled evaluation dates, updates audit tooling, tests, and documentation.