### PR TITLE
Harden availability snapshot access

### DIFF
--- a/backend/api/bullpen.py
+++ b/backend/api/bullpen.py
@@ -251,7 +251,10 @@ def get_latest_workload_snapshot():
             'risk_level': risk_level.upper() if risk_level else None,
         },
     })
-    return jsonify({'data': data, 'meta': meta})
+    response = jsonify({'data': data, 'meta': meta})
+    response.headers['X-BaseballOS-Data-Mode'] = LATEST_WORKLOAD_SNAPSHOT_MODE
+    response.headers['X-BaseballOS-Current-Availability'] = 'false'
+    return response
 
 
 @bullpen_bp.route('/fatigue/<int:pitcher_id>', methods=['GET'])

--- a/backend/tests/test_availability_snapshot_mode.py
+++ b/backend/tests/test_availability_snapshot_mode.py
@@ -23,20 +23,49 @@ from utils.db import db
 
 @pytest.fixture
 def client():
-    app = Flask(__name__)
-    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
-    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
-    app.config['APP_ENV'] = 'development'
-    app.config['ADMIN_API_TOKEN'] = 'secret'
-    db.init_app(app)
-    app.register_blueprint(bullpen_bp, url_prefix='/api/bullpen')
-    with app.app_context():
+    with _SnapshotAppClient() as test_client:
+        yield test_client
+
+
+@pytest.fixture
+def production_client():
+    with _SnapshotAppClient(app_env='production', admin_token='secret') as test_client:
+        yield test_client
+
+
+@pytest.fixture
+def development_open_client():
+    with _SnapshotAppClient(app_env='development', admin_token=None) as test_client:
+        yield test_client
+
+
+@pytest.fixture
+def production_no_token_client():
+    with _SnapshotAppClient(app_env='production', admin_token=None) as test_client:
+        yield test_client
+
+
+class _SnapshotAppClient:
+    def __init__(self, app_env='development', admin_token='secret'):
+        self.app = Flask(__name__)
+        self.app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+        self.app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+        self.app.config['APP_ENV'] = app_env
+        self.app.config['ADMIN_API_TOKEN'] = admin_token
+        db.init_app(self.app)
+        self.app.register_blueprint(bullpen_bp, url_prefix='/api/bullpen')
+        self.context = None
+
+    def __enter__(self):
+        self.context = self.app.app_context()
+        self.context.push()
         db.create_all()
-        try:
-            yield app.test_client()
-        finally:
-            db.session.remove()
-            db.drop_all()
+        return self.app.test_client()
+
+    def __exit__(self, exc_type, exc, tb):
+        db.session.remove()
+        db.drop_all()
+        self.context.pop()
 
 
 def _risk_for_score(raw_score):
@@ -235,9 +264,88 @@ def test_snapshot_endpoint_is_admin_gated_and_marks_non_current(client):
     assert body['meta']['snapshot_date'] == '2026-05-01'
     assert body['meta']['is_current_availability'] is False
     assert body['meta']['warning'] == SNAPSHOT_WARNING
+    assert accepted.headers['X-BaseballOS-Data-Mode'] == LATEST_WORKLOAD_SNAPSHOT_MODE
+    assert accepted.headers['X-BaseballOS-Current-Availability'] == 'false'
     assert body['data'][0]['availability_mode']['mode'] == LATEST_WORKLOAD_SNAPSHOT_MODE
     assert body['data'][0]['availability_mode']['is_current_availability'] is False
     assert body['data'][0]['availability']['data_state'] == 'fresh'
+
+
+def test_snapshot_endpoint_denies_unauthorized_production_without_leaking_data(production_client):
+    with production_client.application.app_context():
+        _add_pitcher(
+            'Protected Snapshot Workload',
+            latest_game_date=date(2026, 5, 1),
+            raw_score=64.0,
+            log_pitches=[45],
+        )
+
+    res = production_client.get('/api/bullpen/fatigue/snapshot')
+
+    assert res.status_code == 401
+    body = res.get_json()
+    assert 'error' in body
+    assert 'data' not in body
+    assert 'meta' not in body
+    assert 'X-BaseballOS-Data-Mode' not in res.headers
+    assert 'X-BaseballOS-Current-Availability' not in res.headers
+
+
+def test_snapshot_endpoint_denies_production_when_admin_token_is_not_configured(production_no_token_client):
+    with production_no_token_client.application.app_context():
+        _add_pitcher(
+            'Disabled Snapshot Workload',
+            latest_game_date=date(2026, 5, 1),
+            raw_score=64.0,
+            log_pitches=[45],
+        )
+
+    res = production_no_token_client.get('/api/bullpen/fatigue/snapshot')
+
+    assert res.status_code == 403
+    body = res.get_json()
+    assert 'error' in body
+    assert 'ADMIN_API_TOKEN' in body['error']
+    assert 'data' not in body
+    assert 'meta' not in body
+
+
+def test_snapshot_endpoint_allows_development_without_token_when_unconfigured(development_open_client):
+    with development_open_client.application.app_context():
+        _add_pitcher(
+            'Development Snapshot Workload',
+            latest_game_date=date(2026, 5, 1),
+            raw_score=64.0,
+            log_pitches=[45],
+        )
+
+    res = development_open_client.get('/api/bullpen/fatigue/snapshot')
+
+    assert res.status_code == 200
+    body = res.get_json()
+    assert body['meta']['mode'] == LATEST_WORKLOAD_SNAPSHOT_MODE
+    assert body['meta']['is_current_availability'] is False
+    assert body['meta']['warning'] == SNAPSHOT_WARNING
+    assert res.headers['X-BaseballOS-Data-Mode'] == LATEST_WORKLOAD_SNAPSHOT_MODE
+    assert res.headers['X-BaseballOS-Current-Availability'] == 'false'
+
+
+def test_public_current_fatigue_endpoint_remains_open_with_admin_token_configured(production_client):
+    with production_client.application.app_context():
+        _add_pitcher(
+            'Public Current Workload',
+            latest_game_date=date.today(),
+            raw_score=24.0,
+            log_pitches=[8],
+        )
+
+    res = production_client.get('/api/bullpen/fatigue?include_stale=true')
+
+    assert res.status_code == 200
+    body = res.get_json()
+    assert isinstance(body, list)
+    assert len(body) == 1
+    assert body[0]['availability']['inputs']['reference_date'] == date.today().isoformat()
 
 
 def test_audit_script_uses_shared_snapshot_path():

--- a/backend/utils/auth.py
+++ b/backend/utils/auth.py
@@ -1,10 +1,10 @@
 """
-Lightweight admin-token guard for operational write endpoints.
+Lightweight admin-token guard for operational/admin endpoints.
 
 This is intentionally NOT a user auth system — no accounts, sessions, or OAuth.
-It is a single shared admin token used to gate routes that mutate data or
-trigger expensive work (sync, recalculation) so a public/hosted demo can't be
-driven by anonymous callers.
+It is a single shared admin token used to gate routes that mutate data, trigger
+expensive work (sync, recalculation), or expose validation-only data so a
+public/hosted demo can't be driven or inspected by anonymous callers.
 
 Behavior (token comes from app.config['ADMIN_API_TOKEN'], set from the
 ADMIN_API_TOKEN env var):

--- a/docs/BULLPEN_AVAILABILITY_ENGINE_V1.md
+++ b/docs/BULLPEN_AVAILABILITY_ENGINE_V1.md
@@ -294,8 +294,11 @@ GET /api/bullpen/fatigue/snapshot
 ```
 
 The route is gated by the same `X-Admin-Token` / `ADMIN_API_TOKEN` guard used by
-operational admin endpoints. It is not a public Bullpen UI mode and must not be
-presented as live availability.
+operational admin endpoints. Production access requires a configured
+`ADMIN_API_TOKEN` and a matching `X-Admin-Token` request header. Local
+development may allow the endpoint without a token when `ADMIN_API_TOKEN` is
+unset, matching the existing admin-endpoint development convention. It is not a
+public Bullpen UI mode and must not be presented as live availability.
 
 Responses include explicit non-current metadata:
 
@@ -309,6 +312,13 @@ Responses include explicit non-current metadata:
 }
 ```
 
+Authorized responses also include defensive headers:
+
+```text
+X-BaseballOS-Data-Mode: latest_workload_snapshot
+X-BaseballOS-Current-Availability: false
+```
+
 `snapshot_date` is the latest game-log date represented by the response. Each
 pitcher row also carries its own evaluation date because the validation strategy
 is per-pitcher latest workload, not a claim that every pitcher has current data
@@ -319,6 +329,10 @@ latest-workload section. Snapshot output is allowed to support visual
 validation, regression fixtures, and later threshold review. It is not allowed
 to tune thresholds by itself, replace current-calendar freshness filtering, or
 hide stale/missing data states.
+
+Public frontend code must not consume this endpoint for current availability.
+Use current-mode endpoints for public UI and reserve snapshot responses for
+admin/development validation workflows.
 
 ### System-Level Availability Summary
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -163,19 +163,25 @@ The one optional frontend variable lives in `frontend/.env`
 | `MLB_API_BASE` | backend | No | `https://statsapi.mlb.com/api/v1` | MLB Stats API base URL. The default is correct for everyone. |
 | `AUTO_SYNC` | backend | No | off | `1`/`true`/`yes` enables the in-process daily sync scheduler (06:00 ET). Leave off for dev/tests. |
 | `CORS_ORIGINS` | backend | No | (none) | Extra comma-separated allowed origins, added to the built-in localhost + Vercel demo origins. |
-| `ADMIN_API_TOKEN` | backend | No (required in production) | (none) | Token gating the write endpoints (`POST /api/bullpen/sync`, `POST /api/bullpen/fatigue/recalculate`) via the `X-Admin-Token` header. Unset locally → those routes are allowed in development (with a warning). |
+| `ADMIN_API_TOKEN` | backend | No (required in production) | (none) | Token gating admin endpoints (`POST /api/bullpen/sync`, `POST /api/bullpen/fatigue/recalculate`, `GET /api/bullpen/fatigue/snapshot`) via the `X-Admin-Token` header. Unset locally -> those routes are allowed in development (with a warning). |
 | `VITE_API_BASE_URL` | frontend | No | (uses dev proxy) | Backend origin for the frontend to call (no trailing `/api`). Only needed when the backend is hosted separately. |
 | `VITE_ADMIN_API_TOKEN` | frontend | No | (none) | Sends `X-Admin-Token` from the frontend for the operator "Recalculate" action. Usually unset — it ends up in the public bundle, so prefer curl for protected calls. |
 
-### Protected (operational) endpoints
+### Protected admin endpoints
 
-Two endpoints mutate data / trigger expensive MLB pulls and are gated by
-`ADMIN_API_TOKEN`:
+These endpoints mutate data, trigger expensive MLB pulls, or expose
+validation-only historical workload data and are gated by `ADMIN_API_TOKEN`:
 
 - `POST /api/bullpen/sync`
 - `POST /api/bullpen/fatigue/recalculate`
+- `GET /api/bullpen/fatigue/snapshot`
 
-All other endpoints are read-only `GET`s and stay public. Behavior:
+The snapshot endpoint is admin/dev validation only. It returns
+`mode: latest_workload_snapshot`, `is_current_availability: false`, and a
+historical warning; public UI must use current-mode endpoints such as
+`GET /api/bullpen/fatigue` and `GET /api/bullpen/stats/overview`.
+
+All other read-only `GET`s stay public. Behavior:
 
 - **Token unset (development):** the protected routes are allowed (a warning is
   logged) so local work isn't painful.

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -46,6 +46,8 @@ export const getTeamBullpen    = (teamId, params = {}) => {
 export const getBullpenOverview = () => request('/bullpen/stats/overview')
 export const getSyncStatus     = () => request('/bullpen/sync/status')
 export const getFatigueEraInsight = () => request('/bullpen/insights/fatigue-era')
+// No public helper for /bullpen/fatigue/snapshot: latest-workload snapshot mode
+// is admin/dev validation only and must not power current-availability UI.
 
 // ── Prospects ───────────────────────────────────────────────
 export const getProspects        = (params = {}) => {


### PR DESCRIPTION
Protects latest-workload snapshot validation mode behind production admin authorization, preserves explicit non-current metadata, adds safety tests, and documents admin-only usage.