### PR TITLE
Experiment with unavailable thresholds

### DIFF
--- a/backend/reports/availability_unavailable_threshold_experiment.md
+++ b/backend/reports/availability_unavailable_threshold_experiment.md
@@ -1,0 +1,427 @@
+# Availability Unavailable Threshold Experiment
+
+Generated at: 2026-06-02T00:09:31.647946+00:00
+Reference date: 2026-06-01
+
+This experiment compares current Availability Engine thresholds against
+Unavailable-only candidate changes. It does not modify production
+thresholds, fatigue scoring, API behavior, dashboard behavior, or frontend behavior.
+
+## Current Unavailable Rules
+
+| Rule | Condition |
+|---|---|
+| Pitches yesterday | `pitches_yesterday >= 50` |
+| Three-day pitch volume | `pitches_last_3_days >= 80` |
+| Five-day appearance/workload combination | `appearances_last_5_days >= 4 and pitches_last_5_days >= 75` |
+| Critical fatigue plus heavy yesterday workload | `fatigue_score >= 85.0 and pitches_yesterday >= 35` |
+
+## Baseline Snapshot Distribution
+
+Latest-workload snapshot output is validation-only and not current bullpen availability.
+
+### Baseline Status Distribution
+
+| Value | Count |
+|---|---:|
+| Monitor | 268 |
+| Limited | 174 |
+| Avoid | 99 |
+| Unavailable | 163 |
+
+### Baseline Confidence Distribution
+
+| Value | Count |
+|---|---:|
+| high | 640 |
+| low | 64 |
+
+### Baseline Data State Distribution
+
+| Value | Count |
+|---|---:|
+| fresh | 640 |
+| missing | 64 |
+
+### Baseline Reason Categories
+
+| Category | Count |
+|---|---:|
+| pitch_count | 671 |
+| appearance_frequency | 1170 |
+| fatigue | 569 |
+| data_state | 64 |
+
+## Candidate Overview
+
+| Candidate | Changed rule | Unavailable | Delta | Moved from Unavailable |
+|---|---|---:|---:|---:|
+| Candidate A: raise Unavailable fatigue threshold | unavailable_fatigue_score: 85.0 -> 90.0 | 163 | 0 | 0 |
+| Candidate B: raise Unavailable yesterday pitch threshold | unavailable_pitches_yesterday: 50 -> 55 | 163 | 0 | 0 |
+| Candidate C: raise Unavailable three-day pitch threshold | unavailable_pitches_last_3_days: 80 -> 90 | 106 | -57 | 57 |
+| Candidate D: raise Unavailable five-day combo pitch threshold | unavailable_multi_day_pitch_threshold: 75 -> 85 when appearances_last_5_days >= 4 | 163 | 0 | 0 |
+| Candidate E: require two severe signals for Unavailable | Require at least two current Unavailable rule signals before preserving Unavailable | 0 | -163 | 163 |
+
+## Candidate A: raise Unavailable fatigue threshold
+
+Changed rule: unavailable_fatigue_score: 85.0 -> 90.0
+
+### Candidate Status Distribution
+
+| Value | Count |
+|---|---:|
+| Monitor | 268 |
+| Limited | 174 |
+| Avoid | 99 |
+| Unavailable | 163 |
+
+### Status Delta From Baseline
+
+| Status | Delta |
+|---|---:|
+| Available | 0 |
+| Monitor | 0 |
+| Limited | 0 |
+| Avoid | 0 |
+| Unavailable | 0 |
+
+### Transitions
+
+| Transition | Count |
+|---|---:|
+| Avoid -> Avoid | 99 |
+| Limited -> Limited | 174 |
+| Monitor -> Monitor | 268 |
+| Unavailable -> Unavailable | 163 |
+
+### Moved From Unavailable
+
+| Candidate status | Count |
+|---|---:|
+| none | 0 |
+
+### Reason Categories
+
+| Category | Count |
+|---|---:|
+| pitch_count | 671 |
+| appearance_frequency | 1170 |
+| fatigue | 569 |
+| data_state | 64 |
+
+### Changed Examples
+
+| Pitcher | Team | Baseline | Candidate | Fatigue | Yday | 3-day | 5-day | App 5 | Severe signals | Reasons |
+|---|---|---|---|---:|---:|---:|---:|---:|---|---|
+| none |  |  |  |  |  |  |  |  |  |  |
+
+### Boundary Examples
+
+| Pitcher | Team | Status | Input value | Distance | Severe signals | Reasons |
+|---|---|---|---:|---:|---|---|
+| Grayson Rodriguez | LAA | Unavailable | 85.9 | 4.1 | 4 appearances and 105 pitches in 5 days | 31 pitches yesterday; 76 pitches in 3 days; 105 pitches in 5 days; 3 appearances in 3 days; 4 appearances in 5 days; Back-to-back appearances; 3 appearances in 4 days; No rest since last appearance; Fatigue score is 85.9 |
+| Adam Mazur | MIA | Avoid | 85.5 | 4.5 | none | 63 pitches in 3 days; 63 pitches in 5 days; No rest since last appearance; Fatigue score is 85.5 |
+| Andrew Alvarez | WSH | Unavailable | 85.5 | 4.5 | 83 pitches in 3 days | 83 pitches in 3 days; 83 pitches in 5 days; No rest since last appearance; Fatigue score is 85.5 |
+| Bowden Francis | TOR | Avoid | 85.5 | 4.5 | none | 74 pitches in 3 days; 74 pitches in 5 days; No rest since last appearance; Fatigue score is 85.5 |
+| Bradley Blalock | MIA | Avoid | 85.5 | 4.5 | none | 73 pitches in 3 days; 73 pitches in 5 days; No rest since last appearance; Fatigue score is 85.5 |
+| Brandon Walter | HOU | Unavailable | 85.5 | 4.5 | 82 pitches in 3 days | 82 pitches in 3 days; 82 pitches in 5 days; No rest since last appearance; Fatigue score is 85.5 |
+| Braxton Garrett | MIA | Unavailable | 85.5 | 4.5 | 93 pitches in 3 days | 93 pitches in 3 days; 93 pitches in 5 days; No rest since last appearance; Fatigue score is 85.5 |
+| Bryce Miller | SEA | Avoid | 85.5 | 4.5 | none | 70 pitches in 3 days; 70 pitches in 5 days; No rest since last appearance; Fatigue score is 85.5 |
+
+## Candidate B: raise Unavailable yesterday pitch threshold
+
+Changed rule: unavailable_pitches_yesterday: 50 -> 55
+
+### Candidate Status Distribution
+
+| Value | Count |
+|---|---:|
+| Monitor | 268 |
+| Limited | 174 |
+| Avoid | 99 |
+| Unavailable | 163 |
+
+### Status Delta From Baseline
+
+| Status | Delta |
+|---|---:|
+| Available | 0 |
+| Monitor | 0 |
+| Limited | 0 |
+| Avoid | 0 |
+| Unavailable | 0 |
+
+### Transitions
+
+| Transition | Count |
+|---|---:|
+| Avoid -> Avoid | 99 |
+| Limited -> Limited | 174 |
+| Monitor -> Monitor | 268 |
+| Unavailable -> Unavailable | 163 |
+
+### Moved From Unavailable
+
+| Candidate status | Count |
+|---|---:|
+| none | 0 |
+
+### Reason Categories
+
+| Category | Count |
+|---|---:|
+| pitch_count | 671 |
+| appearance_frequency | 1170 |
+| fatigue | 569 |
+| data_state | 64 |
+
+### Changed Examples
+
+| Pitcher | Team | Baseline | Candidate | Fatigue | Yday | 3-day | 5-day | App 5 | Severe signals | Reasons |
+|---|---|---|---|---:|---:|---:|---:|---:|---|---|
+| none |  |  |  |  |  |  |  |  |  |  |
+
+### Boundary Examples
+
+| Pitcher | Team | Status | Input value | Distance | Severe signals | Reasons |
+|---|---|---|---:|---:|---|---|
+| Michael Kelly | ATH | Unavailable | 35 | 20 | 4 appearances and 106 pitches in 5 days | 35 pitches yesterday; 78 pitches in 3 days; 106 pitches in 5 days; 3 appearances in 3 days; 4 appearances in 5 days; Back-to-back appearances; 3 appearances in 4 days; No rest since last appearance; Fatigue score is 69.6 |
+| Cam Sanders | PIT | Avoid | 32 | 23 | none | 32 pitches yesterday; 37 pitches in 3 days; 2 appearances in 3 days; 2 appearances in 5 days; Back-to-back appearances; No rest since last appearance; Fatigue score is 45.5 |
+| Grayson Rodriguez | LAA | Unavailable | 31 | 24 | 4 appearances and 105 pitches in 5 days | 31 pitches yesterday; 76 pitches in 3 days; 105 pitches in 5 days; 3 appearances in 3 days; 4 appearances in 5 days; Back-to-back appearances; 3 appearances in 4 days; No rest since last appearance; Fatigue score is 85.9 |
+| Kyle Finnegan | DET | Avoid | 29 | 26 | none | 29 pitches yesterday; 46 pitches in 3 days; 62 pitches in 5 days; 2 appearances in 3 days; 3 appearances in 5 days; Back-to-back appearances; No rest since last appearance; Fatigue score is 50.3 |
+| Blake Snell | LAD | Avoid | 26 | 29 | none | 26 pitches yesterday; 40 pitches in 3 days; 74 pitches in 5 days; 2 appearances in 3 days; 3 appearances in 5 days; Back-to-back appearances; 3 appearances in 4 days; No rest since last appearance; Fatigue score is 53.2 |
+| Cade Winquest | NYY | Avoid | 26 | 29 | none | 26 pitches yesterday; 41 pitches in 3 days; 67 pitches in 5 days; 2 appearances in 3 days; 3 appearances in 5 days; Back-to-back appearances; 3 appearances in 4 days; No rest since last appearance; Fatigue score is 52.6 |
+| Michael Petersen | MIA | Avoid | 26 | 29 | none | 26 pitches yesterday; 35 pitches in 3 days; 2 appearances in 3 days; 2 appearances in 5 days; Back-to-back appearances; No rest since last appearance; Fatigue score is 43.9 |
+| Grant Anderson | MIL | Limited | 25 | 30 | none | 25 pitches yesterday; 33 pitches in 3 days; 2 appearances in 3 days; 2 appearances in 5 days; Back-to-back appearances; No rest since last appearance; Fatigue score is 42.2 |
+
+## Candidate C: raise Unavailable three-day pitch threshold
+
+Changed rule: unavailable_pitches_last_3_days: 80 -> 90
+
+### Candidate Status Distribution
+
+| Value | Count |
+|---|---:|
+| Monitor | 268 |
+| Limited | 174 |
+| Avoid | 156 |
+| Unavailable | 106 |
+
+### Status Delta From Baseline
+
+| Status | Delta |
+|---|---:|
+| Available | 0 |
+| Monitor | 0 |
+| Limited | 0 |
+| Avoid | +57 |
+| Unavailable | -57 |
+
+### Transitions
+
+| Transition | Count |
+|---|---:|
+| Avoid -> Avoid | 99 |
+| Limited -> Limited | 174 |
+| Monitor -> Monitor | 268 |
+| Unavailable -> Avoid | 57 |
+| Unavailable -> Unavailable | 106 |
+
+### Moved From Unavailable
+
+| Candidate status | Count |
+|---|---:|
+| Avoid | 57 |
+
+### Reason Categories
+
+| Category | Count |
+|---|---:|
+| pitch_count | 671 |
+| appearance_frequency | 1170 |
+| fatigue | 569 |
+| data_state | 64 |
+
+### Changed Examples
+
+| Pitcher | Team | Baseline | Candidate | Fatigue | Yday | 3-day | 5-day | App 5 | Severe signals | Reasons |
+|---|---|---|---|---:|---:|---:|---:|---:|---|---|
+| Aaron Civale | ATH | Unavailable | Avoid | 60.6 | 0 | 87 | 87 | 1 | 87 pitches in 3 days | 87 pitches in 3 days; 87 pitches in 5 days; No rest since last appearance; Fatigue score is 60.6 |
+| J.T. Ginn | ATH | Unavailable | Avoid | 85.1 | 0 | 88 | 88 | 1 | 88 pitches in 3 days | 88 pitches in 3 days; 88 pitches in 5 days; No rest since last appearance; Fatigue score is 85.1 |
+| Grant Holmes | ATL | Unavailable | Avoid | 60.6 | 0 | 87 | 87 | 1 | 87 pitches in 3 days | 87 pitches in 3 days; 87 pitches in 5 days; No rest since last appearance; Fatigue score is 60.6 |
+| Joey Wentz | ATL | Unavailable | Avoid | 85.5 | 0 | 86 | 86 | 1 | 86 pitches in 3 days | 86 pitches in 3 days; 86 pitches in 5 days; No rest since last appearance; Fatigue score is 85.5 |
+| Spencer Strider | ATL | Unavailable | Avoid | 85.5 | 0 | 85 | 85 | 1 | 85 pitches in 3 days | 85 pitches in 3 days; 85 pitches in 5 days; No rest since last appearance; Fatigue score is 85.5 |
+| Eduardo Rodriguez | AZ | Unavailable | Avoid | 58.1 | 0 | 87 | 87 | 1 | 87 pitches in 3 days | 87 pitches in 3 days; 87 pitches in 5 days; No rest since last appearance; Fatigue score is 58.1 |
+| Brandon Young | BAL | Unavailable | Avoid | 55.8 | 0 | 82 | 82 | 1 | 82 pitches in 3 days | 82 pitches in 3 days; 82 pitches in 5 days; No rest since last appearance; Fatigue score is 55.8 |
+| Dean Kremer | BAL | Unavailable | Avoid | 59.1 | 0 | 80 | 80 | 1 | 80 pitches in 3 days | 80 pitches in 3 days; 80 pitches in 5 days; No rest since last appearance; Fatigue score is 59.1 |
+| Kyle Bradish | BAL | Unavailable | Avoid | 61.3 | 0 | 88 | 88 | 1 | 88 pitches in 3 days | 88 pitches in 3 days; 88 pitches in 5 days; No rest since last appearance; Fatigue score is 61.3 |
+| Jake Bennett | BOS | Unavailable | Avoid | 60.2 | 0 | 85 | 85 | 1 | 85 pitches in 3 days | 85 pitches in 3 days; 85 pitches in 5 days; No rest since last appearance; Fatigue score is 60.2 |
+| Kutter Crawford | BOS | Unavailable | Avoid | 85.5 | 0 | 86 | 86 | 1 | 86 pitches in 3 days | 86 pitches in 3 days; 86 pitches in 5 days; No rest since last appearance; Fatigue score is 85.5 |
+| Andrew Abbott | CIN | Unavailable | Avoid | 64.2 | 0 | 86 | 86 | 1 | 86 pitches in 3 days | 86 pitches in 3 days; 86 pitches in 5 days; No rest since last appearance; Fatigue score is 64.2 |
+
+### Boundary Examples
+
+| Pitcher | Team | Status | Input value | Distance | Severe signals | Reasons |
+|---|---|---|---:|---:|---|---|
+| Anthony Kay | CWS | Unavailable | 90 | 0 | 90 pitches in 3 days | 90 pitches in 3 days; 90 pitches in 5 days; No rest since last appearance; Fatigue score is 58 |
+| Bryce Elder | ATL | Unavailable | 90 | 0 | 90 pitches in 3 days | 90 pitches in 3 days; 90 pitches in 5 days; No rest since last appearance; Fatigue score is 85.1 |
+| Cody Bradford | TEX | Unavailable | 90 | 0 | 90 pitches in 3 days | 90 pitches in 3 days; 90 pitches in 5 days; No rest since last appearance; Fatigue score is 85.5 |
+| Freddy Peralta | NYM | Unavailable | 90 | 0 | 90 pitches in 3 days | 90 pitches in 3 days; 90 pitches in 5 days; No rest since last appearance; Fatigue score is 65 |
+| Garrett Crochet | BOS | Unavailable | 90 | 0 | 90 pitches in 3 days | 90 pitches in 3 days; 90 pitches in 5 days; No rest since last appearance; Fatigue score is 65.5 |
+| Jack Kochanowicz | LAA | Unavailable | 90 | 0 | 90 pitches in 3 days | 90 pitches in 3 days; 90 pitches in 5 days; No rest since last appearance; Fatigue score is 65.5 |
+| Mick Abel | MIN | Unavailable | 90 | 0 | 90 pitches in 3 days | 90 pitches in 3 days; 90 pitches in 5 days; No rest since last appearance; Fatigue score is 85.1 |
+| Shane Bieber | TOR | Unavailable | 90 | 0 | 90 pitches in 3 days | 90 pitches in 3 days; 90 pitches in 5 days; No rest since last appearance; Fatigue score is 85.5 |
+
+## Candidate D: raise Unavailable five-day combo pitch threshold
+
+Changed rule: unavailable_multi_day_pitch_threshold: 75 -> 85 when appearances_last_5_days >= 4
+
+### Candidate Status Distribution
+
+| Value | Count |
+|---|---:|
+| Monitor | 268 |
+| Limited | 174 |
+| Avoid | 99 |
+| Unavailable | 163 |
+
+### Status Delta From Baseline
+
+| Status | Delta |
+|---|---:|
+| Available | 0 |
+| Monitor | 0 |
+| Limited | 0 |
+| Avoid | 0 |
+| Unavailable | 0 |
+
+### Transitions
+
+| Transition | Count |
+|---|---:|
+| Avoid -> Avoid | 99 |
+| Limited -> Limited | 174 |
+| Monitor -> Monitor | 268 |
+| Unavailable -> Unavailable | 163 |
+
+### Moved From Unavailable
+
+| Candidate status | Count |
+|---|---:|
+| none | 0 |
+
+### Reason Categories
+
+| Category | Count |
+|---|---:|
+| pitch_count | 671 |
+| appearance_frequency | 1170 |
+| fatigue | 569 |
+| data_state | 64 |
+
+### Changed Examples
+
+| Pitcher | Team | Baseline | Candidate | Fatigue | Yday | 3-day | 5-day | App 5 | Severe signals | Reasons |
+|---|---|---|---|---:|---:|---:|---:|---:|---|---|
+| none |  |  |  |  |  |  |  |  |  |  |
+
+### Boundary Examples
+
+| Pitcher | Team | Status | Input value | Distance | Severe signals | Reasons |
+|---|---|---|---:|---:|---|---|
+| Bubba Chandler | PIT | Unavailable | 85 | 0 | 85 pitches in 3 days | 85 pitches in 3 days; 85 pitches in 5 days; No rest since last appearance; Fatigue score is 60.2 |
+| Cristopher Sánchez | PHI | Unavailable | 85 | 0 | 85 pitches in 3 days | 85 pitches in 3 days; 85 pitches in 5 days; No rest since last appearance; Fatigue score is 64 |
+| Jacob Misiorowski | MIL | Unavailable | 85 | 0 | 85 pitches in 3 days | 85 pitches in 3 days; 85 pitches in 5 days; No rest since last appearance; Fatigue score is 85.1 |
+| Jake Bennett | BOS | Unavailable | 85 | 0 | 85 pitches in 3 days | 85 pitches in 3 days; 85 pitches in 5 days; No rest since last appearance; Fatigue score is 60.2 |
+| Jared Jones | PIT | Unavailable | 85 | 0 | 85 pitches in 3 days | 85 pitches in 3 days; 85 pitches in 5 days; No rest since last appearance; Fatigue score is 85.5 |
+| Joe Musgrove | SD | Unavailable | 85 | 0 | 85 pitches in 3 days | 85 pitches in 3 days; 85 pitches in 5 days; No rest since last appearance; Fatigue score is 85.5 |
+| Jose Quintana | COL | Unavailable | 85 | 0 | 85 pitches in 3 days | 85 pitches in 3 days; 85 pitches in 5 days; No rest since last appearance; Fatigue score is 85.1 |
+| Michael Lorenzen | COL | Unavailable | 85 | 0 | 85 pitches in 3 days | 85 pitches in 3 days; 85 pitches in 5 days; No rest since last appearance; Fatigue score is 60.6 |
+
+## Candidate E: require two severe signals for Unavailable
+
+Changed rule: Require at least two current Unavailable rule signals before preserving Unavailable
+
+### Candidate Status Distribution
+
+| Value | Count |
+|---|---:|
+| Monitor | 268 |
+| Limited | 174 |
+| Avoid | 262 |
+
+### Status Delta From Baseline
+
+| Status | Delta |
+|---|---:|
+| Available | 0 |
+| Monitor | 0 |
+| Limited | 0 |
+| Avoid | +163 |
+| Unavailable | -163 |
+
+### Transitions
+
+| Transition | Count |
+|---|---:|
+| Avoid -> Avoid | 99 |
+| Limited -> Limited | 174 |
+| Monitor -> Monitor | 268 |
+| Unavailable -> Avoid | 163 |
+
+### Moved From Unavailable
+
+| Candidate status | Count |
+|---|---:|
+| Avoid | 163 |
+
+### Reason Categories
+
+| Category | Count |
+|---|---:|
+| pitch_count | 671 |
+| appearance_frequency | 1170 |
+| fatigue | 569 |
+| data_state | 64 |
+
+### Changed Examples
+
+| Pitcher | Team | Baseline | Candidate | Fatigue | Yday | 3-day | 5-day | App 5 | Severe signals | Reasons |
+|---|---|---|---|---:|---:|---:|---:|---:|---|---|
+| Aaron Civale | ATH | Unavailable | Avoid | 60.6 | 0 | 87 | 87 | 1 | 87 pitches in 3 days | 87 pitches in 3 days; 87 pitches in 5 days; No rest since last appearance; Fatigue score is 60.6 |
+| J.T. Ginn | ATH | Unavailable | Avoid | 85.1 | 0 | 88 | 88 | 1 | 88 pitches in 3 days | 88 pitches in 3 days; 88 pitches in 5 days; No rest since last appearance; Fatigue score is 85.1 |
+| Luis Severino | ATH | Unavailable | Avoid | 72.6 | 0 | 103 | 103 | 1 | 103 pitches in 3 days | 103 pitches in 3 days; 103 pitches in 5 days; No rest since last appearance; Fatigue score is 72.6 |
+| Mason Barnett | ATH | Unavailable | Avoid | 66.6 | 0 | 97 | 97 | 1 | 97 pitches in 3 days | 97 pitches in 3 days; 97 pitches in 5 days; No rest since last appearance; Fatigue score is 66.6 |
+| Michael Kelly | ATH | Unavailable | Avoid | 69.6 | 35 | 78 | 106 | 4 | 4 appearances and 106 pitches in 5 days | 35 pitches yesterday; 78 pitches in 3 days; 106 pitches in 5 days; 3 appearances in 3 days; 4 appearances in 5 days; Back-to-back appearances; 3 appearances in 4 days; No rest since last appearance; Fatigue score is 69.6 |
+| Bryce Elder | ATL | Unavailable | Avoid | 85.1 | 0 | 90 | 90 | 1 | 90 pitches in 3 days | 90 pitches in 3 days; 90 pitches in 5 days; No rest since last appearance; Fatigue score is 85.1 |
+| Chris Sale | ATL | Unavailable | Avoid | 71.3 | 0 | 100 | 100 | 1 | 100 pitches in 3 days | 100 pitches in 3 days; 100 pitches in 5 days; No rest since last appearance; Fatigue score is 71.3 |
+| Grant Holmes | ATL | Unavailable | Avoid | 60.6 | 0 | 87 | 87 | 1 | 87 pitches in 3 days | 87 pitches in 3 days; 87 pitches in 5 days; No rest since last appearance; Fatigue score is 60.6 |
+| Hurston Waldrep | ATL | Unavailable | Avoid | 85.5 | 0 | 92 | 92 | 1 | 92 pitches in 3 days | 92 pitches in 3 days; 92 pitches in 5 days; No rest since last appearance; Fatigue score is 85.5 |
+| Joey Wentz | ATL | Unavailable | Avoid | 85.5 | 0 | 86 | 86 | 1 | 86 pitches in 3 days | 86 pitches in 3 days; 86 pitches in 5 days; No rest since last appearance; Fatigue score is 85.5 |
+| Spencer Schwellenbach | ATL | Unavailable | Avoid | 85.5 | 0 | 90 | 90 | 1 | 90 pitches in 3 days | 90 pitches in 3 days; 90 pitches in 5 days; No rest since last appearance; Fatigue score is 85.5 |
+| Spencer Strider | ATL | Unavailable | Avoid | 85.5 | 0 | 85 | 85 | 1 | 85 pitches in 3 days | 85 pitches in 3 days; 85 pitches in 5 days; No rest since last appearance; Fatigue score is 85.5 |
+
+### Boundary Examples
+
+| Pitcher | Team | Status | Input value | Distance | Severe signals | Reasons |
+|---|---|---|---:|---:|---|---|
+| Aaron Civale | ATH | Unavailable | 1 | 1 | 87 pitches in 3 days | 87 pitches in 3 days; 87 pitches in 5 days; No rest since last appearance; Fatigue score is 60.6 |
+| Aaron Nola | PHI | Unavailable | 1 | 1 | 101 pitches in 3 days | 101 pitches in 3 days; 101 pitches in 5 days; No rest since last appearance; Fatigue score is 65.2 |
+| Andre Pallante | STL | Unavailable | 1 | 1 | 91 pitches in 3 days | 91 pitches in 3 days; 91 pitches in 5 days; No rest since last appearance; Fatigue score is 65.6 |
+| Andrew Abbott | CIN | Unavailable | 1 | 1 | 86 pitches in 3 days | 86 pitches in 3 days; 86 pitches in 5 days; No rest since last appearance; Fatigue score is 64.2 |
+| Andrew Alvarez | WSH | Unavailable | 1 | 1 | 83 pitches in 3 days | 83 pitches in 3 days; 83 pitches in 5 days; No rest since last appearance; Fatigue score is 85.5 |
+| Andrew Painter | PHI | Unavailable | 1 | 1 | 80 pitches in 3 days | 80 pitches in 3 days; 80 pitches in 5 days; No rest since last appearance; Fatigue score is 59.1 |
+| Anthony Kay | CWS | Unavailable | 1 | 1 | 90 pitches in 3 days | 90 pitches in 3 days; 90 pitches in 5 days; No rest since last appearance; Fatigue score is 58 |
+| Bailey Ober | MIN | Unavailable | 1 | 1 | 88 pitches in 3 days | 88 pitches in 3 days; 88 pitches in 5 days; No rest since last appearance; Fatigue score is 85.1 |
+
+## Recommendation
+
+Recommendation: Needs more data
+
+- Current-mode output is stale/missing dominated, so production tuning should not rely on current-mode distribution alone.
+- Largest one-variable candidate moved 57 pitchers out of Unavailable.
+- The multi-signal gate moved 163 pitchers, but it changes rule semantics rather than one threshold.
+- Review near-boundary pitcher examples before adopting any production threshold change.
+
+Any candidate threshold still requires human review and approval before
+production adoption.

--- a/backend/scripts/experiment_unavailable_thresholds.py
+++ b/backend/scripts/experiment_unavailable_thresholds.py
@@ -1,0 +1,78 @@
+"""
+Run an Availability Engine Unavailable threshold comparison experiment.
+
+The script compares current thresholds against candidate Unavailable-only
+changes using latest-workload snapshot mode. It writes a report and does not
+change production thresholds or API behavior.
+"""
+
+from argparse import ArgumentParser
+from datetime import date, datetime, timezone
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from app import create_app  # noqa: E402
+from services.availability_snapshot import latest_fatigue_rows  # noqa: E402
+from services.availability_unavailable_experiment import (  # noqa: E402
+    build_experiment,
+    render_json_report,
+    render_markdown_report,
+)
+
+
+DEFAULT_OUTPUT = ROOT / 'reports' / 'availability_unavailable_threshold_experiment.md'
+
+
+def parse_date(value):
+    if value is None:
+        return None
+    return datetime.strptime(value, '%Y-%m-%d').date()
+
+
+def write_report(report_text, output_path):
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(report_text, encoding='utf-8')
+
+
+def print_summary(experiment, output_path):
+    print(f'Availability Unavailable threshold experiment written to {output_path}')
+    print(f"Baseline status distribution: {experiment['baseline_summary']['status_distribution']}")
+    for comparison in experiment['comparisons']:
+        candidate = comparison['candidate']
+        moved = sum(comparison['unavailable_moves'].values())
+        print(
+            f"{candidate.key}: {comparison['candidate_summary']['status_distribution']} "
+            f"(Unavailable delta {comparison['status_delta'].get('Unavailable', 0)}, moved {moved})"
+        )
+    print(f"Recommendation: {experiment['recommendation']['decision']}")
+
+
+def main():
+    parser = ArgumentParser(description='Compare Unavailable threshold candidates.')
+    parser.add_argument('--output', default=str(DEFAULT_OUTPUT), help='Report path to write.')
+    parser.add_argument('--format', choices=['markdown', 'json'], default='markdown', help='Report format.')
+    parser.add_argument('--reference-date', help='YYYY-MM-DD date for experiment. Defaults to today.')
+    args = parser.parse_args()
+
+    reference_date = parse_date(args.reference_date) or date.today()
+    output_path = Path(args.output)
+
+    app = create_app()
+    with app.app_context():
+        rows = latest_fatigue_rows()
+        generated_at = datetime.now(timezone.utc)
+        experiment = build_experiment(rows, reference_date=reference_date)
+        if args.format == 'json':
+            report = render_json_report(experiment, generated_at=generated_at)
+        else:
+            report = render_markdown_report(experiment, generated_at=generated_at)
+        write_report(report, output_path)
+        print_summary(experiment, output_path)
+
+
+if __name__ == '__main__':
+    main()

--- a/backend/services/availability_unavailable_experiment.py
+++ b/backend/services/availability_unavailable_experiment.py
@@ -1,0 +1,606 @@
+"""Experiment helpers for Availability Engine Unavailable threshold review.
+
+This module compares current thresholds against candidate Unavailable-only
+changes. It does not mutate production thresholds or API behavior.
+"""
+
+from collections import Counter
+from dataclasses import dataclass, replace
+from datetime import date, datetime, timezone
+import json
+
+from services.availability import (
+    ACTIVE_WINDOW_DAYS,
+    STATUS_AVOID,
+    STATUS_LIMITED,
+    STATUS_MONITOR,
+    STATUS_UNAVAILABLE,
+    THRESHOLDS,
+    AvailabilityThresholds,
+    classify_availability,
+)
+from services.availability_explanations import CATEGORY_ORDER, categorize_reason
+from services.availability_snapshot import (
+    LATEST_WORKLOAD_SNAPSHOT_MODE,
+    evaluation_date_for_mode,
+    latest_game_date_for,
+    logs_for_availability_window,
+)
+from services.availability_threshold_audit import (
+    STATUS_ORDER,
+    normalize_record,
+    ordered_counts,
+    summarize_records,
+)
+
+
+UNAVAILABLE_RULES = [
+    {
+        'key': 'pitches_yesterday',
+        'rule': 'Pitches yesterday',
+        'condition': 'pitches_yesterday >= 50',
+    },
+    {
+        'key': 'pitches_last_3_days',
+        'rule': 'Three-day pitch volume',
+        'condition': 'pitches_last_3_days >= 80',
+    },
+    {
+        'key': 'appearances_and_5_day_pitches',
+        'rule': 'Five-day appearance/workload combination',
+        'condition': 'appearances_last_5_days >= 4 and pitches_last_5_days >= 75',
+    },
+    {
+        'key': 'fatigue_and_yesterday',
+        'rule': 'Critical fatigue plus heavy yesterday workload',
+        'condition': 'fatigue_score >= 85.0 and pitches_yesterday >= 35',
+    },
+]
+
+
+@dataclass(frozen=True)
+class UnavailableCandidate:
+    key: str
+    label: str
+    changed_rule: str
+    thresholds: AvailabilityThresholds
+    focus_input: str | None = None
+    focus_threshold: float | None = None
+    require_multiple_severe_signals: bool = False
+
+
+def _with_threshold(**overrides):
+    return replace(THRESHOLDS, **overrides)
+
+
+def unavailable_candidates():
+    return [
+        UnavailableCandidate(
+            key='raise_fatigue_90',
+            label='Candidate A: raise Unavailable fatigue threshold',
+            changed_rule='unavailable_fatigue_score: 85.0 -> 90.0',
+            thresholds=_with_threshold(unavailable_fatigue_score=90.0),
+            focus_input='fatigue_score',
+            focus_threshold=90.0,
+        ),
+        UnavailableCandidate(
+            key='raise_yesterday_55',
+            label='Candidate B: raise Unavailable yesterday pitch threshold',
+            changed_rule='unavailable_pitches_yesterday: 50 -> 55',
+            thresholds=_with_threshold(unavailable_pitches_yesterday=55),
+            focus_input='pitches_yesterday',
+            focus_threshold=55,
+        ),
+        UnavailableCandidate(
+            key='raise_three_day_90',
+            label='Candidate C: raise Unavailable three-day pitch threshold',
+            changed_rule='unavailable_pitches_last_3_days: 80 -> 90',
+            thresholds=_with_threshold(unavailable_pitches_last_3_days=90),
+            focus_input='pitches_last_3_days',
+            focus_threshold=90,
+        ),
+        UnavailableCandidate(
+            key='raise_five_day_combo_85',
+            label='Candidate D: raise Unavailable five-day combo pitch threshold',
+            changed_rule='unavailable_multi_day_pitch_threshold: 75 -> 85 when appearances_last_5_days >= 4',
+            thresholds=_with_threshold(unavailable_multi_day_pitch_threshold=85),
+            focus_input='pitches_last_5_days',
+            focus_threshold=85,
+        ),
+        UnavailableCandidate(
+            key='require_two_severe_signals',
+            label='Candidate E: require two severe signals for Unavailable',
+            changed_rule='Require at least two current Unavailable rule signals before preserving Unavailable',
+            thresholds=THRESHOLDS,
+            require_multiple_severe_signals=True,
+        ),
+    ]
+
+
+def unavailable_severe_signals(inputs, thresholds=THRESHOLDS):
+    signals = []
+    fatigue = inputs.get('fatigue_score')
+    pitches_yesterday = inputs.get('pitches_yesterday') or 0
+    pitches_3 = inputs.get('pitches_last_3_days') or 0
+    pitches_5 = inputs.get('pitches_last_5_days') or 0
+    apps_5 = inputs.get('appearances_last_5_days') or 0
+
+    if pitches_yesterday >= thresholds.unavailable_pitches_yesterday:
+        signals.append(f'{pitches_yesterday} pitches yesterday')
+    if pitches_3 >= thresholds.unavailable_pitches_last_3_days:
+        signals.append(f'{pitches_3} pitches in 3 days')
+    if apps_5 >= 4 and pitches_5 >= thresholds.unavailable_multi_day_pitch_threshold:
+        signals.append(f'{apps_5} appearances and {pitches_5} pitches in 5 days')
+    if (
+        fatigue is not None
+        and fatigue >= thresholds.unavailable_fatigue_score
+        and pitches_yesterday >= thresholds.avoid_pitches_yesterday
+    ):
+        signals.append(f'fatigue score {fatigue} with {pitches_yesterday} pitches yesterday')
+
+    return signals
+
+
+def _disable_unavailable_thresholds(thresholds):
+    unreachable = 10**9
+    return replace(
+        thresholds,
+        unavailable_fatigue_score=float(unreachable),
+        unavailable_pitches_yesterday=unreachable,
+        unavailable_pitches_last_3_days=unreachable,
+        unavailable_multi_day_pitch_threshold=unreachable,
+    )
+
+
+def classify_for_candidate(
+    score,
+    game_logs,
+    reference_date,
+    latest_game_date,
+    candidate,
+    active_window_days=ACTIVE_WINDOW_DAYS,
+):
+    if not candidate.require_multiple_severe_signals:
+        return classify_availability(
+            score=score,
+            game_logs=game_logs,
+            reference_date=reference_date,
+            latest_game_date=latest_game_date,
+            active_window_days=active_window_days,
+            thresholds=candidate.thresholds,
+        )
+
+    baseline = classify_availability(
+        score=score,
+        game_logs=game_logs,
+        reference_date=reference_date,
+        latest_game_date=latest_game_date,
+        active_window_days=active_window_days,
+        thresholds=candidate.thresholds,
+    )
+    if baseline['data_state'] != 'fresh' or baseline['availability_status'] != STATUS_UNAVAILABLE:
+        return baseline
+
+    signals = unavailable_severe_signals(baseline['inputs'], candidate.thresholds)
+    if len(signals) >= 2:
+        return baseline
+
+    return classify_availability(
+        score=score,
+        game_logs=game_logs,
+        reference_date=reference_date,
+        latest_game_date=latest_game_date,
+        active_window_days=active_window_days,
+        thresholds=_disable_unavailable_thresholds(candidate.thresholds),
+    )
+
+
+def classify_rows_for_candidate(rows, candidate, reference_date=None, mode=LATEST_WORKLOAD_SNAPSHOT_MODE):
+    current_reference_date = reference_date or date.today()
+    records = []
+    for score, pitcher in rows:
+        latest_game_date = latest_game_date_for(pitcher.id)
+        evaluation_date = evaluation_date_for_mode(
+            mode,
+            latest_game_date=latest_game_date,
+            current_reference_date=current_reference_date,
+        )
+        logs = logs_for_availability_window(pitcher.id, evaluation_date)
+        availability = classify_for_candidate(
+            score=score,
+            game_logs=logs,
+            reference_date=evaluation_date,
+            latest_game_date=latest_game_date,
+            candidate=candidate,
+        )
+        records.append({
+            'pitcher_id': pitcher.id,
+            'pitcher_name': pitcher.full_name,
+            'team': pitcher.team_abbreviation,
+            'score': score,
+            'pitcher': pitcher,
+            'availability': availability,
+            'mode': mode,
+            'evaluation_date': evaluation_date,
+            'latest_game_date': latest_game_date,
+            'candidate': candidate.key,
+        })
+    return records
+
+
+def reason_category_counts(records):
+    counter = Counter()
+    for record in [normalize_record(item) for item in records]:
+        for reason in record['reasons']:
+            counter[categorize_reason(reason)] += 1
+    return ordered_counts(counter, CATEGORY_ORDER)
+
+
+def _status_delta(candidate_counts, baseline_counts):
+    return {
+        status: candidate_counts.get(status, 0) - baseline_counts.get(status, 0)
+        for status in STATUS_ORDER
+    }
+
+
+def _transition_key(baseline_status, candidate_status):
+    return f'{baseline_status} -> {candidate_status}'
+
+
+def compare_records(baseline_records, candidate_records, candidate):
+    baseline = [normalize_record(record) for record in baseline_records]
+    proposed = [normalize_record(record) for record in candidate_records]
+    baseline_by_id = {record['pitcher_id']: record for record in baseline}
+    proposed_by_id = {record['pitcher_id']: record for record in proposed}
+
+    transitions = Counter()
+    unavailable_moves = Counter()
+    changed_examples = []
+
+    for pitcher_id, baseline_record in baseline_by_id.items():
+        candidate_record = proposed_by_id.get(pitcher_id)
+        if candidate_record is None:
+            continue
+        baseline_status = baseline_record['availability_status']
+        candidate_status = candidate_record['availability_status']
+        transitions[_transition_key(baseline_status, candidate_status)] += 1
+        if baseline_status == STATUS_UNAVAILABLE and candidate_status != STATUS_UNAVAILABLE:
+            unavailable_moves[candidate_status] += 1
+        if baseline_status != candidate_status:
+            changed_examples.append(_example_row(baseline_record, candidate_record, candidate))
+
+    baseline_summary = summarize_records(baseline_records, near_threshold_limit=12, top_reason_limit=10)
+    candidate_summary = summarize_records(candidate_records, near_threshold_limit=12, top_reason_limit=10)
+
+    return {
+        'candidate': candidate,
+        'baseline_summary': baseline_summary,
+        'candidate_summary': candidate_summary,
+        'status_delta': _status_delta(
+            candidate_summary['status_distribution'],
+            baseline_summary['status_distribution'],
+        ),
+        'transitions': ordered_counts(transitions, []),
+        'unavailable_moves': ordered_counts(unavailable_moves, [
+            STATUS_AVOID,
+            STATUS_LIMITED,
+            STATUS_MONITOR,
+        ]),
+        'changed_examples': changed_examples[:12],
+        'boundary_examples': select_boundary_examples(baseline_records, candidate, limit=8),
+        'reason_category_distribution': reason_category_counts(candidate_records),
+    }
+
+
+def _example_row(baseline_record, candidate_record, candidate):
+    inputs = baseline_record['inputs']
+    return {
+        'pitcher_name': baseline_record['pitcher_name'],
+        'team': baseline_record['team'],
+        'baseline_status': baseline_record['availability_status'],
+        'candidate_status': candidate_record['availability_status'],
+        'fatigue_score': inputs.get('fatigue_score'),
+        'pitches_yesterday': inputs.get('pitches_yesterday'),
+        'pitches_last_3_days': inputs.get('pitches_last_3_days'),
+        'pitches_last_5_days': inputs.get('pitches_last_5_days'),
+        'appearances_last_5_days': inputs.get('appearances_last_5_days'),
+        'severe_signals': unavailable_severe_signals(inputs, THRESHOLDS),
+        'reasons': baseline_record['reasons'],
+    }
+
+
+def select_boundary_examples(records, candidate, limit=8):
+    normalized = [normalize_record(record) for record in records]
+    examples = []
+    if candidate.require_multiple_severe_signals:
+        for record in normalized:
+            if record['availability_status'] != STATUS_UNAVAILABLE:
+                continue
+            signals = unavailable_severe_signals(record['inputs'], candidate.thresholds)
+            examples.append({
+                'pitcher_name': record['pitcher_name'],
+                'team': record['team'],
+                'availability_status': record['availability_status'],
+                'input_value': len(signals),
+                'distance': abs(len(signals) - 2),
+                'severe_signals': signals,
+                'reasons': record['reasons'],
+            })
+        examples.sort(key=lambda item: (item['distance'], item['input_value'], item['pitcher_name']))
+        return examples[:limit]
+
+    input_name = candidate.focus_input
+    threshold = candidate.focus_threshold
+    if input_name is None or threshold is None:
+        return []
+
+    for record in normalized:
+        value = record['inputs'].get(input_name)
+        if value is None:
+            continue
+        examples.append({
+            'pitcher_name': record['pitcher_name'],
+            'team': record['team'],
+            'availability_status': record['availability_status'],
+            'input_value': value,
+            'distance': abs(float(value) - float(threshold)),
+            'severe_signals': unavailable_severe_signals(record['inputs'], candidate.thresholds),
+            'reasons': record['reasons'],
+        })
+    examples.sort(key=lambda item: (item['distance'], item['pitcher_name']))
+    return examples[:limit]
+
+
+def build_experiment(rows, reference_date=None, candidates=None):
+    reference_date = reference_date or date.today()
+    baseline_candidate = UnavailableCandidate(
+        key='baseline',
+        label='Baseline',
+        changed_rule='Current production thresholds',
+        thresholds=THRESHOLDS,
+    )
+    candidates = list(candidates or unavailable_candidates())
+    baseline_records = classify_rows_for_candidate(rows, baseline_candidate, reference_date=reference_date)
+    comparisons = []
+    for candidate in candidates:
+        candidate_records = classify_rows_for_candidate(rows, candidate, reference_date=reference_date)
+        comparisons.append(compare_records(baseline_records, candidate_records, candidate))
+
+    return {
+        'reference_date': reference_date,
+        'baseline_records': baseline_records,
+        'baseline_summary': summarize_records(baseline_records, near_threshold_limit=12, top_reason_limit=10),
+        'baseline_reason_categories': reason_category_counts(baseline_records),
+        'comparisons': comparisons,
+        'recommendation': recommend(comparisons),
+    }
+
+
+def recommend(comparisons):
+    single_variable_changes = [
+        item for item in comparisons
+        if not item['candidate'].require_multiple_severe_signals
+    ]
+    largest_single_variable_move = max(
+        (sum(item['unavailable_moves'].values()) for item in single_variable_changes),
+        default=0,
+    )
+    multi_signal = next(
+        (item for item in comparisons if item['candidate'].require_multiple_severe_signals),
+        None,
+    )
+    multi_signal_moves = sum(multi_signal['unavailable_moves'].values()) if multi_signal else 0
+
+    rationale = [
+        'Current-mode output is stale/missing dominated, so production tuning should not rely on current-mode distribution alone.',
+        f'Largest one-variable candidate moved {largest_single_variable_move} pitchers out of Unavailable.',
+    ]
+    if multi_signal is not None:
+        rationale.append(
+            f'The multi-signal gate moved {multi_signal_moves} pitchers, but it changes rule semantics rather than one threshold.'
+        )
+    rationale.append('Review near-boundary pitcher examples before adopting any production threshold change.')
+
+    return {
+        'decision': 'Needs more data',
+        'rationale': rationale,
+    }
+
+
+def _format_value(value):
+    if value is None:
+        return 'n/a'
+    if isinstance(value, float):
+        return f'{value:.1f}'.rstrip('0').rstrip('.')
+    return str(value)
+
+
+def _markdown_counts(title, counts, first_column='Value'):
+    lines = [f'### {title}', '', f'| {first_column} | Count |', '|---|---:|']
+    if not counts:
+        lines.append('| none | 0 |')
+    else:
+        for key, count in counts.items():
+            lines.append(f'| {key} | {count} |')
+    lines.append('')
+    return lines
+
+
+def _markdown_status_delta(delta):
+    lines = ['### Status Delta From Baseline', '', '| Status | Delta |', '|---|---:|']
+    for status in STATUS_ORDER:
+        value = delta.get(status, 0)
+        sign = '+' if value > 0 else ''
+        lines.append(f'| {status} | {sign}{value} |')
+    lines.append('')
+    return lines
+
+
+def _markdown_rule_table():
+    lines = ['## Current Unavailable Rules', '', '| Rule | Condition |', '|---|---|']
+    for rule in UNAVAILABLE_RULES:
+        lines.append(f"| {rule['rule']} | `{rule['condition']}` |")
+    lines.append('')
+    return lines
+
+
+def _markdown_comparison_overview(comparisons):
+    lines = [
+        '## Candidate Overview',
+        '',
+        '| Candidate | Changed rule | Unavailable | Delta | Moved from Unavailable |',
+        '|---|---|---:|---:|---:|',
+    ]
+    for comparison in comparisons:
+        candidate = comparison['candidate']
+        status_counts = comparison['candidate_summary']['status_distribution']
+        unavailable = status_counts.get(STATUS_UNAVAILABLE, 0)
+        delta = comparison['status_delta'].get(STATUS_UNAVAILABLE, 0)
+        moved = sum(comparison['unavailable_moves'].values())
+        sign = '+' if delta > 0 else ''
+        lines.append(
+            f'| {candidate.label} | {candidate.changed_rule} | {unavailable} | {sign}{delta} | {moved} |'
+        )
+    lines.append('')
+    return lines
+
+
+def _markdown_example_table(title, examples):
+    lines = [
+        f'### {title}',
+        '',
+        '| Pitcher | Team | Baseline | Candidate | Fatigue | Yday | 3-day | 5-day | App 5 | Severe signals | Reasons |',
+        '|---|---|---|---|---:|---:|---:|---:|---:|---|---|',
+    ]
+    if not examples:
+        lines.append('| none |  |  |  |  |  |  |  |  |  |  |')
+    else:
+        for item in examples:
+            signals = '; '.join(item.get('severe_signals') or []) or 'none'
+            reasons = '; '.join(item.get('reasons') or []) or 'none'
+            lines.append(
+                f"| {item['pitcher_name']} | {item.get('team') or ''} | "
+                f"{item.get('baseline_status', item.get('availability_status', ''))} | "
+                f"{item.get('candidate_status', '')} | "
+                f"{_format_value(item.get('fatigue_score'))} | "
+                f"{_format_value(item.get('pitches_yesterday'))} | "
+                f"{_format_value(item.get('pitches_last_3_days'))} | "
+                f"{_format_value(item.get('pitches_last_5_days'))} | "
+                f"{_format_value(item.get('appearances_last_5_days'))} | "
+                f"{signals} | {reasons} |"
+            )
+    lines.append('')
+    return lines
+
+
+def _markdown_boundary_table(examples):
+    lines = [
+        '### Boundary Examples',
+        '',
+        '| Pitcher | Team | Status | Input value | Distance | Severe signals | Reasons |',
+        '|---|---|---|---:|---:|---|---|',
+    ]
+    if not examples:
+        lines.append('| none |  |  |  |  |  |  |')
+    else:
+        for item in examples:
+            signals = '; '.join(item.get('severe_signals') or []) or 'none'
+            reasons = '; '.join(item.get('reasons') or []) or 'none'
+            lines.append(
+                f"| {item['pitcher_name']} | {item.get('team') or ''} | "
+                f"{item['availability_status']} | {_format_value(item.get('input_value'))} | "
+                f"{_format_value(item.get('distance'))} | {signals} | {reasons} |"
+            )
+    lines.append('')
+    return lines
+
+
+def render_markdown_report(experiment, generated_at=None):
+    generated_at = generated_at or datetime.now(timezone.utc)
+    recommendation = experiment['recommendation']
+    lines = [
+        '# Availability Unavailable Threshold Experiment',
+        '',
+        f'Generated at: {generated_at.isoformat()}',
+        f"Reference date: {experiment['reference_date']}",
+        '',
+        'This experiment compares current Availability Engine thresholds against',
+        'Unavailable-only candidate changes. It does not modify production',
+        'thresholds, fatigue scoring, API behavior, dashboard behavior, or frontend behavior.',
+        '',
+    ]
+    lines.extend(_markdown_rule_table())
+    lines.extend([
+        '## Baseline Snapshot Distribution',
+        '',
+        'Latest-workload snapshot output is validation-only and not current bullpen availability.',
+        '',
+    ])
+    lines.extend(_markdown_counts('Baseline Status Distribution', experiment['baseline_summary']['status_distribution']))
+    lines.extend(_markdown_counts('Baseline Confidence Distribution', experiment['baseline_summary']['confidence_distribution']))
+    lines.extend(_markdown_counts('Baseline Data State Distribution', experiment['baseline_summary']['data_state_distribution']))
+    lines.extend(_markdown_counts('Baseline Reason Categories', experiment['baseline_reason_categories'], first_column='Category'))
+    lines.extend(_markdown_comparison_overview(experiment['comparisons']))
+
+    for comparison in experiment['comparisons']:
+        candidate = comparison['candidate']
+        lines.extend([
+            f'## {candidate.label}',
+            '',
+            f'Changed rule: {candidate.changed_rule}',
+            '',
+        ])
+        lines.extend(_markdown_counts('Candidate Status Distribution', comparison['candidate_summary']['status_distribution']))
+        lines.extend(_markdown_status_delta(comparison['status_delta']))
+        lines.extend(_markdown_counts('Transitions', comparison['transitions'], first_column='Transition'))
+        lines.extend(_markdown_counts('Moved From Unavailable', comparison['unavailable_moves'], first_column='Candidate status'))
+        lines.extend(_markdown_counts('Reason Categories', comparison['reason_category_distribution'], first_column='Category'))
+        lines.extend(_markdown_example_table('Changed Examples', comparison['changed_examples']))
+        lines.extend(_markdown_boundary_table(comparison['boundary_examples']))
+
+    lines.extend([
+        '## Recommendation',
+        '',
+        f"Recommendation: {recommendation['decision']}",
+        '',
+    ])
+    for item in recommendation['rationale']:
+        lines.append(f'- {item}')
+    lines.extend([
+        '',
+        'Any candidate threshold still requires human review and approval before',
+        'production adoption.',
+        '',
+    ])
+    return '\n'.join(lines).rstrip() + '\n'
+
+
+def render_json_report(experiment, generated_at=None):
+    generated_at = generated_at or datetime.now(timezone.utc)
+    payload = {
+        'generated_at': generated_at.isoformat(),
+        'reference_date': str(experiment['reference_date']),
+        'unavailable_rules': UNAVAILABLE_RULES,
+        'baseline_summary': experiment['baseline_summary'],
+        'baseline_reason_categories': experiment['baseline_reason_categories'],
+        'recommendation': experiment['recommendation'],
+        'comparisons': [
+            {
+                'candidate': {
+                    'key': item['candidate'].key,
+                    'label': item['candidate'].label,
+                    'changed_rule': item['candidate'].changed_rule,
+                    'require_multiple_severe_signals': item['candidate'].require_multiple_severe_signals,
+                },
+                'candidate_summary': item['candidate_summary'],
+                'status_delta': item['status_delta'],
+                'transitions': item['transitions'],
+                'unavailable_moves': item['unavailable_moves'],
+                'changed_examples': item['changed_examples'],
+                'boundary_examples': item['boundary_examples'],
+                'reason_category_distribution': item['reason_category_distribution'],
+            }
+            for item in experiment['comparisons']
+        ],
+    }
+    return json.dumps(payload, indent=2, sort_keys=True, default=str)

--- a/backend/tests/test_availability_unavailable_experiment.py
+++ b/backend/tests/test_availability_unavailable_experiment.py
@@ -1,0 +1,205 @@
+from dataclasses import dataclass
+from datetime import date, timedelta
+
+from services.availability import (
+    CONFIDENCE_LOW,
+    STATUS_AVOID,
+    STATUS_MONITOR,
+    STATUS_UNAVAILABLE,
+    THRESHOLDS,
+)
+from services.availability_unavailable_experiment import (
+    UnavailableCandidate,
+    classify_for_candidate,
+    compare_records,
+    unavailable_candidates,
+    unavailable_severe_signals,
+)
+
+
+@dataclass
+class ScoreStub:
+    raw_score: float
+    risk_level: str = 'LOW'
+
+
+def _candidate(key):
+    return next(candidate for candidate in unavailable_candidates() if candidate.key == key)
+
+
+def _baseline_candidate():
+    return UnavailableCandidate(
+        key='baseline',
+        label='Baseline',
+        changed_rule='Current thresholds',
+        thresholds=THRESHOLDS,
+    )
+
+
+def _record(pitcher_id, name, status, inputs, reasons=None, data_state='fresh', confidence='high'):
+    return {
+        'pitcher_id': pitcher_id,
+        'pitcher_name': name,
+        'team': 'TST',
+        'availability': {
+            'availability_status': status,
+            'confidence': confidence,
+            'data_state': data_state,
+            'reasons': reasons or [],
+            'limitations': [],
+            'inputs': inputs,
+        },
+    }
+
+
+def test_baseline_candidate_preserves_current_unavailable_outcome(make_log):
+    ref = date(2026, 6, 1)
+    logs = [
+        make_log(ref, pitches_thrown=30),
+        make_log(ref - timedelta(days=1), pitches_thrown=30),
+        make_log(ref - timedelta(days=2), pitches_thrown=25),
+    ]
+
+    result = classify_for_candidate(
+        score=ScoreStub(raw_score=20.0),
+        game_logs=logs,
+        reference_date=ref,
+        latest_game_date=ref,
+        candidate=_baseline_candidate(),
+    )
+
+    assert result['availability_status'] == STATUS_UNAVAILABLE
+    assert result['inputs']['pitches_last_3_days'] == 85
+
+
+def test_three_day_candidate_changes_only_intended_unavailable_behavior(make_log):
+    ref = date(2026, 6, 1)
+    candidate = _candidate('raise_three_day_90')
+    logs = [
+        make_log(ref, pitches_thrown=30),
+        make_log(ref - timedelta(days=1), pitches_thrown=30),
+        make_log(ref - timedelta(days=2), pitches_thrown=25),
+    ]
+
+    result = classify_for_candidate(
+        score=ScoreStub(raw_score=20.0),
+        game_logs=logs,
+        reference_date=ref,
+        latest_game_date=ref,
+        candidate=candidate,
+    )
+
+    assert candidate.thresholds.avoid_pitches_last_3_days == THRESHOLDS.avoid_pitches_last_3_days
+    assert candidate.thresholds.unavailable_pitches_last_3_days == 90
+    assert result['availability_status'] == STATUS_AVOID
+    assert result['inputs']['pitches_last_3_days'] == 85
+
+
+def test_multi_signal_candidate_preserves_unavailable_only_with_multiple_severe_signals(make_log):
+    ref = date(2026, 6, 1)
+    candidate = _candidate('require_two_severe_signals')
+    single_signal_logs = [
+        make_log(ref, pitches_thrown=30),
+        make_log(ref - timedelta(days=1), pitches_thrown=30),
+        make_log(ref - timedelta(days=2), pitches_thrown=25),
+    ]
+    two_signal_logs = [
+        make_log(ref, pitches_thrown=20),
+        make_log(ref - timedelta(days=1), pitches_thrown=35),
+        make_log(ref - timedelta(days=2), pitches_thrown=30),
+    ]
+
+    single_signal = classify_for_candidate(
+        score=ScoreStub(raw_score=20.0),
+        game_logs=single_signal_logs,
+        reference_date=ref,
+        latest_game_date=ref,
+        candidate=candidate,
+    )
+    two_signal = classify_for_candidate(
+        score=ScoreStub(raw_score=86.0),
+        game_logs=two_signal_logs,
+        reference_date=ref,
+        latest_game_date=ref,
+        candidate=candidate,
+    )
+
+    assert single_signal['availability_status'] == STATUS_AVOID
+    assert unavailable_severe_signals(single_signal['inputs']) == ['85 pitches in 3 days']
+    assert two_signal['availability_status'] == STATUS_UNAVAILABLE
+    assert len(unavailable_severe_signals(two_signal['inputs'])) == 2
+
+
+def test_candidate_thresholds_do_not_change_stale_or_missing_semantics(make_log):
+    ref = date(2026, 6, 1)
+    candidate = _candidate('raise_three_day_90')
+
+    stale = classify_for_candidate(
+        score=ScoreStub(raw_score=20.0),
+        game_logs=[],
+        reference_date=ref,
+        latest_game_date=ref - timedelta(days=30),
+        candidate=candidate,
+    )
+    missing = classify_for_candidate(
+        score=None,
+        game_logs=[],
+        reference_date=ref,
+        latest_game_date=None,
+        candidate=candidate,
+    )
+
+    assert stale['availability_status'] == STATUS_MONITOR
+    assert stale['confidence'] == CONFIDENCE_LOW
+    assert stale['data_state'] == 'stale'
+    assert missing['availability_status'] == STATUS_MONITOR
+    assert missing['confidence'] == CONFIDENCE_LOW
+    assert missing['data_state'] == 'missing'
+
+
+def test_compare_records_counts_unavailable_transitions():
+    candidate = _candidate('raise_three_day_90')
+    baseline = [
+        _record(
+            1,
+            'Moved Pitcher',
+            STATUS_UNAVAILABLE,
+            {
+                'fatigue_score': 20,
+                'pitches_yesterday': 0,
+                'pitches_last_3_days': 85,
+                'pitches_last_5_days': 85,
+                'appearances_last_5_days': 3,
+            },
+            reasons=['85 pitches in 3 days'],
+        ),
+        _record(
+            2,
+            'Stable Pitcher',
+            STATUS_MONITOR,
+            {
+                'fatigue_score': 42,
+                'pitches_yesterday': 0,
+                'pitches_last_3_days': 20,
+                'pitches_last_5_days': 20,
+                'appearances_last_5_days': 1,
+            },
+        ),
+    ]
+    proposed = [
+        _record(
+            1,
+            'Moved Pitcher',
+            STATUS_AVOID,
+            baseline[0]['availability']['inputs'],
+            reasons=['85 pitches in 3 days'],
+        ),
+        baseline[1],
+    ]
+
+    comparison = compare_records(baseline, proposed, candidate)
+
+    assert comparison['status_delta'][STATUS_UNAVAILABLE] == -1
+    assert comparison['status_delta'][STATUS_AVOID] == 1
+    assert comparison['unavailable_moves'] == {STATUS_AVOID: 1}
+    assert comparison['transitions']['Unavailable -> Avoid'] == 1

--- a/docs/AVAILABILITY_THRESHOLD_TUNING_PLAN.md
+++ b/docs/AVAILABILITY_THRESHOLD_TUNING_PLAN.md
@@ -284,6 +284,19 @@ Investigate why Unavailable is more common than Avoid in latest-workload
 snapshot output and whether that reflects valid workload severity or threshold
 compression.
 
+An initial experiment is documented in
+`backend/reports/availability_unavailable_threshold_experiment.md`. It compares
+baseline Unavailable rules against one-variable candidate adjustments and a
+separate multi-signal gate. The report recommendation is `Needs more data`.
+Candidate C, raising the 3-day Unavailable pitch threshold from 80 to 90, is the
+only one-variable candidate in that report that materially changes the
+Unavailable bucket. It moves 57 pitchers from Unavailable to Avoid in
+latest-workload snapshot mode.
+
+This experiment is not production approval. Any candidate threshold still
+requires human review, near-boundary example review, and a production tuning
+branch before adoption.
+
 ### Confidence Assignment Review
 
 Investigate whether confidence should distinguish missing workload history,


### PR DESCRIPTION
Adds a one-variable threshold comparison experiment for Availability Engine unavailable classifications, generates baseline-versus-candidate audit output, and documents evidence-based tuning review requirements.