### PR TITLE
Adopt unavailable 3-day threshold 90

### DIFF
--- a/backend/reports/availability_explanation_audit.md
+++ b/backend/reports/availability_explanation_audit.md
@@ -1,6 +1,6 @@
 # Availability Explanation Quality Audit
 
-Generated at: 2026-06-01T23:44:04.503283+00:00
+Generated at: 2026-06-02T00:29:25.376441+00:00
 Current reference date: 2026-06-01
 
 This report audits Availability Engine explanation text using existing classified records.

--- a/backend/reports/availability_threshold_adoption_candidate_c.md
+++ b/backend/reports/availability_threshold_adoption_candidate_c.md
@@ -1,0 +1,118 @@
+# Availability Threshold Adoption: Candidate C
+
+Reference date: 2026-06-01
+
+This report records the first governed production threshold change for the
+BaseballOS Availability Engine.
+
+## Adopted Change
+
+| Threshold | Previous value | Adopted value |
+|---|---:|---:|
+| Unavailable pitches in 3 days | >= 80 | >= 90 |
+
+No other thresholds changed.
+
+## Reason For Adoption
+
+Candidate C was evaluated through the threshold audit, unavailable-threshold
+experiment, and boundary-review process. The change addresses threshold
+compression between Avoid and Unavailable without weakening other Unavailable
+rules.
+
+The boundary review found that all moved pitchers had:
+
+- 80-89 pitches in 3 days.
+- No pitches yesterday.
+- No 4+ appearances in 5 days.
+- No remaining Candidate C Unavailable severe signal.
+
+This supports treating those cases as Avoid unless another Unavailable rule
+fires.
+
+## Before Distribution
+
+Latest-workload snapshot before Candidate C adoption:
+
+| Status | Count |
+|---|---:|
+| Monitor | 268 |
+| Limited | 174 |
+| Avoid | 99 |
+| Unavailable | 163 |
+
+## After Distribution
+
+Latest-workload snapshot after Candidate C adoption:
+
+| Status | Count |
+|---|---:|
+| Monitor | 268 |
+| Limited | 174 |
+| Avoid | 156 |
+| Unavailable | 106 |
+
+Current freshness-aware mode remains stale/missing dominated in local data:
+
+| Status | Count |
+|---|---:|
+| Monitor | 704 |
+
+## Moved Pitcher Count
+
+| Transition | Count |
+|---|---:|
+| Unavailable -> Avoid | 57 |
+
+Candidate C affected 35.0% of the pre-adoption Unavailable bucket.
+
+## Boundary Review Summary
+
+Representative moved cases:
+
+| Pitcher | 3-day pitches | Transition |
+|---|---:|---|
+| Andrew Painter | 80 | Unavailable -> Avoid |
+| DJ Herz | 81 | Unavailable -> Avoid |
+| Max Fried | 89 | Unavailable -> Avoid |
+
+Representative retained Unavailable case:
+
+| Pitcher | 3-day pitches | Transition |
+|---|---:|---|
+| Anthony Kay | 90 | Unavailable -> Unavailable |
+
+Supporting artifacts:
+
+- `backend/reports/availability_threshold_audit.md`
+- `backend/reports/availability_unavailable_threshold_experiment.md`
+- `backend/reports/availability_unavailable_boundary_review.md`
+- `backend/reports/availability_threshold_baseline.md`
+
+## Risks
+
+- The local current-mode dataset remains stale/missing dominated, so adoption is
+  based on latest-workload snapshot evidence rather than current live bullpen
+  availability.
+- The change reduces Unavailable classifications driven only by 80-89 pitches
+  in 3 days. Other workload signals may still justify Unavailable through
+  separate rules.
+- Future data syncs may change distribution counts and should be audited against
+  the adopted baseline before any additional threshold changes.
+- BaseballOS still does not include injury, clubhouse, medical, or team-reported
+  availability data. Unavailable remains workload-unavailable only.
+
+## Adoption Decision
+
+Candidate C is adopted into production Availability Engine thresholds.
+
+The effective production rule is:
+
+```text
+Unavailable when pitches_last_3_days >= 90
+```
+
+This adoption does not change fatigue scoring, yesterday pitch thresholds,
+five-day thresholds, appearance thresholds, confidence logic, stale/missing data
+handling, API response shape, frontend behavior, dashboard behavior, or snapshot
+mode.

--- a/backend/reports/availability_threshold_audit.md
+++ b/backend/reports/availability_threshold_audit.md
@@ -1,6 +1,6 @@
 # Availability Threshold Audit
 
-Generated at: 2026-06-01T23:44:11.795127+00:00
+Generated at: 2026-06-02T00:29:15.200189+00:00
 Current reference date: 2026-06-01
 
 This report audits current Availability Engine output using the existing classifier.
@@ -106,8 +106,8 @@ Total pitchers evaluated: 704
 |---|---:|
 | Monitor | 268 |
 | Limited | 174 |
-| Avoid | 99 |
-| Unavailable | 163 |
+| Avoid | 156 |
+| Unavailable | 106 |
 
 ### Confidence Distribution
 
@@ -129,8 +129,8 @@ Total pitchers evaluated: 704
 |---|---|---:|
 | fresh | Monitor | 204 |
 | fresh | Limited | 174 |
-| fresh | Avoid | 99 |
-| fresh | Unavailable | 163 |
+| fresh | Avoid | 156 |
+| fresh | Unavailable | 106 |
 | missing | Monitor | 64 |
 
 ### Top Reason Frequencies

--- a/backend/reports/availability_threshold_baseline.md
+++ b/backend/reports/availability_threshold_baseline.md
@@ -1,7 +1,7 @@
 # Availability Threshold Baseline
 
 Generated from the current Availability Engine V1 thresholds and audit outputs
-on 2026-06-01.
+with reference date 2026-06-01. Updated after Candidate C adoption.
 
 This artifact is a comparison baseline for future threshold tuning branches. It
 does not change thresholds, fatigue scoring, API behavior, snapshot mode,
@@ -12,6 +12,7 @@ dashboard behavior, or frontend behavior.
 - Threshold implementation: `backend/services/availability.py`
 - Threshold audit: `backend/reports/availability_threshold_audit.md`
 - Explanation audit: `backend/reports/availability_explanation_audit.md`
+- Candidate C adoption: `backend/reports/availability_threshold_adoption_candidate_c.md`
 - Governance plan: `docs/AVAILABILITY_THRESHOLD_TUNING_PLAN.md`
 
 ## Current Thresholds
@@ -30,7 +31,7 @@ dashboard behavior, or frontend behavior.
 | Input | Monitor | Limited | Avoid | Unavailable |
 |---|---:|---:|---:|---:|
 | Pitches yesterday | >= 15 | >= 25 | >= 35 | >= 50 |
-| Pitches in 3 days | >= 30 | >= 45 | >= 60 | >= 80 |
+| Pitches in 3 days | >= 30 | >= 45 | >= 60 | >= 90 |
 | Pitches in 5 days | n/a | >= 60 | >= 75 | n/a |
 
 Unavailable also triggers when `appearances_last_5_days >= 4` and
@@ -100,8 +101,8 @@ availability.
 |---|---:|
 | Monitor | 268 |
 | Limited | 174 |
-| Avoid | 99 |
-| Unavailable | 163 |
+| Avoid | 156 |
+| Unavailable | 106 |
 
 | Confidence | Count |
 |---|---:|
@@ -119,8 +120,8 @@ availability.
 |---|---:|
 | Monitor | 204 |
 | Limited | 174 |
-| Avoid | 99 |
-| Unavailable | 163 |
+| Avoid | 156 |
+| Unavailable | 106 |
 
 ### Snapshot Workload Input Summary
 
@@ -176,8 +177,8 @@ availability.
 - Current mode is entirely Monitor because local data is stale or missing.
 - Current mode has 704 low-confidence classifications.
 - Latest-workload snapshot has no Available bucket.
-- Latest-workload snapshot has more Unavailable classifications than Avoid
-  classifications.
+- Latest-workload snapshot has more Avoid classifications than Unavailable
+  classifications after Candidate C adoption.
 - Limited, Avoid, and Unavailable together account for 436 of 640 fresh
   latest-workload snapshot pitchers.
 - Appearance-frequency reasons are the most common reason category.
@@ -185,6 +186,9 @@ availability.
   because snapshot mode evaluates each pitcher at their latest workload date.
   This is a validation-mode artifact, not current rest evidence.
 - Missing workload history remains visible as low-confidence Monitor.
+- Candidate C adoption moved the Unavailable three-day pitch threshold from 80
+  to 90. The adopted baseline keeps 80-89 three-day pitch workloads in Avoid
+  unless another Unavailable rule fires.
 
 ## Use In Future Tuning
 

--- a/backend/reports/availability_unavailable_boundary_review.md
+++ b/backend/reports/availability_unavailable_boundary_review.md
@@ -1,6 +1,6 @@
 # Availability Unavailable Boundary Review
 
-Generated at: 2026-06-02T00:19:57.537692+00:00
+Generated at: 2026-06-02T00:29:44.411429+00:00
 Reference date: 2026-06-01
 
 This report reviews pitchers moved by Candidate C from the unavailable-threshold experiment.

--- a/backend/reports/availability_unavailable_threshold_experiment.md
+++ b/backend/reports/availability_unavailable_threshold_experiment.md
@@ -1,6 +1,6 @@
 # Availability Unavailable Threshold Experiment
 
-Generated at: 2026-06-02T00:09:31.647946+00:00
+Generated at: 2026-06-02T00:33:33.772221+00:00
 Reference date: 2026-06-01
 
 This experiment compares current Availability Engine thresholds against
@@ -12,7 +12,7 @@ thresholds, fatigue scoring, API behavior, dashboard behavior, or frontend behav
 | Rule | Condition |
 |---|---|
 | Pitches yesterday | `pitches_yesterday >= 50` |
-| Three-day pitch volume | `pitches_last_3_days >= 80` |
+| Three-day pitch volume | `pitches_last_3_days >= 90` |
 | Five-day appearance/workload combination | `appearances_last_5_days >= 4 and pitches_last_5_days >= 75` |
 | Critical fatigue plus heavy yesterday workload | `fatigue_score >= 85.0 and pitches_yesterday >= 35` |
 
@@ -26,8 +26,8 @@ Latest-workload snapshot output is validation-only and not current bullpen avail
 |---|---:|
 | Monitor | 268 |
 | Limited | 174 |
-| Avoid | 99 |
-| Unavailable | 163 |
+| Avoid | 156 |
+| Unavailable | 106 |
 
 ### Baseline Confidence Distribution
 
@@ -56,11 +56,11 @@ Latest-workload snapshot output is validation-only and not current bullpen avail
 
 | Candidate | Changed rule | Unavailable | Delta | Moved from Unavailable |
 |---|---|---:|---:|---:|
-| Candidate A: raise Unavailable fatigue threshold | unavailable_fatigue_score: 85.0 -> 90.0 | 163 | 0 | 0 |
-| Candidate B: raise Unavailable yesterday pitch threshold | unavailable_pitches_yesterday: 50 -> 55 | 163 | 0 | 0 |
-| Candidate C: raise Unavailable three-day pitch threshold | unavailable_pitches_last_3_days: 80 -> 90 | 106 | -57 | 57 |
-| Candidate D: raise Unavailable five-day combo pitch threshold | unavailable_multi_day_pitch_threshold: 75 -> 85 when appearances_last_5_days >= 4 | 163 | 0 | 0 |
-| Candidate E: require two severe signals for Unavailable | Require at least two current Unavailable rule signals before preserving Unavailable | 0 | -163 | 163 |
+| Candidate A: raise Unavailable fatigue threshold | unavailable_fatigue_score: 85.0 -> 90.0 | 106 | 0 | 0 |
+| Candidate B: raise Unavailable yesterday pitch threshold | unavailable_pitches_yesterday: 50 -> 55 | 106 | 0 | 0 |
+| Candidate C: adopted Unavailable three-day pitch threshold | adopted production baseline: unavailable_pitches_last_3_days = 90 | 106 | 0 | 0 |
+| Candidate D: raise Unavailable five-day combo pitch threshold | unavailable_multi_day_pitch_threshold: 75 -> 85 when appearances_last_5_days >= 4 | 106 | 0 | 0 |
+| Candidate E: require two severe signals for Unavailable | Require at least two current Unavailable rule signals before preserving Unavailable | 0 | -106 | 106 |
 
 ## Candidate A: raise Unavailable fatigue threshold
 
@@ -72,8 +72,8 @@ Changed rule: unavailable_fatigue_score: 85.0 -> 90.0
 |---|---:|
 | Monitor | 268 |
 | Limited | 174 |
-| Avoid | 99 |
-| Unavailable | 163 |
+| Avoid | 156 |
+| Unavailable | 106 |
 
 ### Status Delta From Baseline
 
@@ -89,10 +89,10 @@ Changed rule: unavailable_fatigue_score: 85.0 -> 90.0
 
 | Transition | Count |
 |---|---:|
-| Avoid -> Avoid | 99 |
+| Avoid -> Avoid | 156 |
 | Limited -> Limited | 174 |
 | Monitor -> Monitor | 268 |
-| Unavailable -> Unavailable | 163 |
+| Unavailable -> Unavailable | 106 |
 
 ### Moved From Unavailable
 
@@ -121,10 +121,10 @@ Changed rule: unavailable_fatigue_score: 85.0 -> 90.0
 |---|---|---|---:|---:|---|---|
 | Grayson Rodriguez | LAA | Unavailable | 85.9 | 4.1 | 4 appearances and 105 pitches in 5 days | 31 pitches yesterday; 76 pitches in 3 days; 105 pitches in 5 days; 3 appearances in 3 days; 4 appearances in 5 days; Back-to-back appearances; 3 appearances in 4 days; No rest since last appearance; Fatigue score is 85.9 |
 | Adam Mazur | MIA | Avoid | 85.5 | 4.5 | none | 63 pitches in 3 days; 63 pitches in 5 days; No rest since last appearance; Fatigue score is 85.5 |
-| Andrew Alvarez | WSH | Unavailable | 85.5 | 4.5 | 83 pitches in 3 days | 83 pitches in 3 days; 83 pitches in 5 days; No rest since last appearance; Fatigue score is 85.5 |
+| Andrew Alvarez | WSH | Avoid | 85.5 | 4.5 | none | 83 pitches in 3 days; 83 pitches in 5 days; No rest since last appearance; Fatigue score is 85.5 |
 | Bowden Francis | TOR | Avoid | 85.5 | 4.5 | none | 74 pitches in 3 days; 74 pitches in 5 days; No rest since last appearance; Fatigue score is 85.5 |
 | Bradley Blalock | MIA | Avoid | 85.5 | 4.5 | none | 73 pitches in 3 days; 73 pitches in 5 days; No rest since last appearance; Fatigue score is 85.5 |
-| Brandon Walter | HOU | Unavailable | 85.5 | 4.5 | 82 pitches in 3 days | 82 pitches in 3 days; 82 pitches in 5 days; No rest since last appearance; Fatigue score is 85.5 |
+| Brandon Walter | HOU | Avoid | 85.5 | 4.5 | none | 82 pitches in 3 days; 82 pitches in 5 days; No rest since last appearance; Fatigue score is 85.5 |
 | Braxton Garrett | MIA | Unavailable | 85.5 | 4.5 | 93 pitches in 3 days | 93 pitches in 3 days; 93 pitches in 5 days; No rest since last appearance; Fatigue score is 85.5 |
 | Bryce Miller | SEA | Avoid | 85.5 | 4.5 | none | 70 pitches in 3 days; 70 pitches in 5 days; No rest since last appearance; Fatigue score is 85.5 |
 
@@ -138,8 +138,8 @@ Changed rule: unavailable_pitches_yesterday: 50 -> 55
 |---|---:|
 | Monitor | 268 |
 | Limited | 174 |
-| Avoid | 99 |
-| Unavailable | 163 |
+| Avoid | 156 |
+| Unavailable | 106 |
 
 ### Status Delta From Baseline
 
@@ -155,10 +155,10 @@ Changed rule: unavailable_pitches_yesterday: 50 -> 55
 
 | Transition | Count |
 |---|---:|
-| Avoid -> Avoid | 99 |
+| Avoid -> Avoid | 156 |
 | Limited -> Limited | 174 |
 | Monitor -> Monitor | 268 |
-| Unavailable -> Unavailable | 163 |
+| Unavailable -> Unavailable | 106 |
 
 ### Moved From Unavailable
 
@@ -194,9 +194,9 @@ Changed rule: unavailable_pitches_yesterday: 50 -> 55
 | Michael Petersen | MIA | Avoid | 26 | 29 | none | 26 pitches yesterday; 35 pitches in 3 days; 2 appearances in 3 days; 2 appearances in 5 days; Back-to-back appearances; No rest since last appearance; Fatigue score is 43.9 |
 | Grant Anderson | MIL | Limited | 25 | 30 | none | 25 pitches yesterday; 33 pitches in 3 days; 2 appearances in 3 days; 2 appearances in 5 days; Back-to-back appearances; No rest since last appearance; Fatigue score is 42.2 |
 
-## Candidate C: raise Unavailable three-day pitch threshold
+## Candidate C: adopted Unavailable three-day pitch threshold
 
-Changed rule: unavailable_pitches_last_3_days: 80 -> 90
+Changed rule: adopted production baseline: unavailable_pitches_last_3_days = 90
 
 ### Candidate Status Distribution
 
@@ -214,84 +214,6 @@ Changed rule: unavailable_pitches_last_3_days: 80 -> 90
 | Available | 0 |
 | Monitor | 0 |
 | Limited | 0 |
-| Avoid | +57 |
-| Unavailable | -57 |
-
-### Transitions
-
-| Transition | Count |
-|---|---:|
-| Avoid -> Avoid | 99 |
-| Limited -> Limited | 174 |
-| Monitor -> Monitor | 268 |
-| Unavailable -> Avoid | 57 |
-| Unavailable -> Unavailable | 106 |
-
-### Moved From Unavailable
-
-| Candidate status | Count |
-|---|---:|
-| Avoid | 57 |
-
-### Reason Categories
-
-| Category | Count |
-|---|---:|
-| pitch_count | 671 |
-| appearance_frequency | 1170 |
-| fatigue | 569 |
-| data_state | 64 |
-
-### Changed Examples
-
-| Pitcher | Team | Baseline | Candidate | Fatigue | Yday | 3-day | 5-day | App 5 | Severe signals | Reasons |
-|---|---|---|---|---:|---:|---:|---:|---:|---|---|
-| Aaron Civale | ATH | Unavailable | Avoid | 60.6 | 0 | 87 | 87 | 1 | 87 pitches in 3 days | 87 pitches in 3 days; 87 pitches in 5 days; No rest since last appearance; Fatigue score is 60.6 |
-| J.T. Ginn | ATH | Unavailable | Avoid | 85.1 | 0 | 88 | 88 | 1 | 88 pitches in 3 days | 88 pitches in 3 days; 88 pitches in 5 days; No rest since last appearance; Fatigue score is 85.1 |
-| Grant Holmes | ATL | Unavailable | Avoid | 60.6 | 0 | 87 | 87 | 1 | 87 pitches in 3 days | 87 pitches in 3 days; 87 pitches in 5 days; No rest since last appearance; Fatigue score is 60.6 |
-| Joey Wentz | ATL | Unavailable | Avoid | 85.5 | 0 | 86 | 86 | 1 | 86 pitches in 3 days | 86 pitches in 3 days; 86 pitches in 5 days; No rest since last appearance; Fatigue score is 85.5 |
-| Spencer Strider | ATL | Unavailable | Avoid | 85.5 | 0 | 85 | 85 | 1 | 85 pitches in 3 days | 85 pitches in 3 days; 85 pitches in 5 days; No rest since last appearance; Fatigue score is 85.5 |
-| Eduardo Rodriguez | AZ | Unavailable | Avoid | 58.1 | 0 | 87 | 87 | 1 | 87 pitches in 3 days | 87 pitches in 3 days; 87 pitches in 5 days; No rest since last appearance; Fatigue score is 58.1 |
-| Brandon Young | BAL | Unavailable | Avoid | 55.8 | 0 | 82 | 82 | 1 | 82 pitches in 3 days | 82 pitches in 3 days; 82 pitches in 5 days; No rest since last appearance; Fatigue score is 55.8 |
-| Dean Kremer | BAL | Unavailable | Avoid | 59.1 | 0 | 80 | 80 | 1 | 80 pitches in 3 days | 80 pitches in 3 days; 80 pitches in 5 days; No rest since last appearance; Fatigue score is 59.1 |
-| Kyle Bradish | BAL | Unavailable | Avoid | 61.3 | 0 | 88 | 88 | 1 | 88 pitches in 3 days | 88 pitches in 3 days; 88 pitches in 5 days; No rest since last appearance; Fatigue score is 61.3 |
-| Jake Bennett | BOS | Unavailable | Avoid | 60.2 | 0 | 85 | 85 | 1 | 85 pitches in 3 days | 85 pitches in 3 days; 85 pitches in 5 days; No rest since last appearance; Fatigue score is 60.2 |
-| Kutter Crawford | BOS | Unavailable | Avoid | 85.5 | 0 | 86 | 86 | 1 | 86 pitches in 3 days | 86 pitches in 3 days; 86 pitches in 5 days; No rest since last appearance; Fatigue score is 85.5 |
-| Andrew Abbott | CIN | Unavailable | Avoid | 64.2 | 0 | 86 | 86 | 1 | 86 pitches in 3 days | 86 pitches in 3 days; 86 pitches in 5 days; No rest since last appearance; Fatigue score is 64.2 |
-
-### Boundary Examples
-
-| Pitcher | Team | Status | Input value | Distance | Severe signals | Reasons |
-|---|---|---|---:|---:|---|---|
-| Anthony Kay | CWS | Unavailable | 90 | 0 | 90 pitches in 3 days | 90 pitches in 3 days; 90 pitches in 5 days; No rest since last appearance; Fatigue score is 58 |
-| Bryce Elder | ATL | Unavailable | 90 | 0 | 90 pitches in 3 days | 90 pitches in 3 days; 90 pitches in 5 days; No rest since last appearance; Fatigue score is 85.1 |
-| Cody Bradford | TEX | Unavailable | 90 | 0 | 90 pitches in 3 days | 90 pitches in 3 days; 90 pitches in 5 days; No rest since last appearance; Fatigue score is 85.5 |
-| Freddy Peralta | NYM | Unavailable | 90 | 0 | 90 pitches in 3 days | 90 pitches in 3 days; 90 pitches in 5 days; No rest since last appearance; Fatigue score is 65 |
-| Garrett Crochet | BOS | Unavailable | 90 | 0 | 90 pitches in 3 days | 90 pitches in 3 days; 90 pitches in 5 days; No rest since last appearance; Fatigue score is 65.5 |
-| Jack Kochanowicz | LAA | Unavailable | 90 | 0 | 90 pitches in 3 days | 90 pitches in 3 days; 90 pitches in 5 days; No rest since last appearance; Fatigue score is 65.5 |
-| Mick Abel | MIN | Unavailable | 90 | 0 | 90 pitches in 3 days | 90 pitches in 3 days; 90 pitches in 5 days; No rest since last appearance; Fatigue score is 85.1 |
-| Shane Bieber | TOR | Unavailable | 90 | 0 | 90 pitches in 3 days | 90 pitches in 3 days; 90 pitches in 5 days; No rest since last appearance; Fatigue score is 85.5 |
-
-## Candidate D: raise Unavailable five-day combo pitch threshold
-
-Changed rule: unavailable_multi_day_pitch_threshold: 75 -> 85 when appearances_last_5_days >= 4
-
-### Candidate Status Distribution
-
-| Value | Count |
-|---|---:|
-| Monitor | 268 |
-| Limited | 174 |
-| Avoid | 99 |
-| Unavailable | 163 |
-
-### Status Delta From Baseline
-
-| Status | Delta |
-|---|---:|
-| Available | 0 |
-| Monitor | 0 |
-| Limited | 0 |
 | Avoid | 0 |
 | Unavailable | 0 |
 
@@ -299,10 +221,10 @@ Changed rule: unavailable_multi_day_pitch_threshold: 75 -> 85 when appearances_l
 
 | Transition | Count |
 |---|---:|
-| Avoid -> Avoid | 99 |
+| Avoid -> Avoid | 156 |
 | Limited -> Limited | 174 |
 | Monitor -> Monitor | 268 |
-| Unavailable -> Unavailable | 163 |
+| Unavailable -> Unavailable | 106 |
 
 ### Moved From Unavailable
 
@@ -329,14 +251,80 @@ Changed rule: unavailable_multi_day_pitch_threshold: 75 -> 85 when appearances_l
 
 | Pitcher | Team | Status | Input value | Distance | Severe signals | Reasons |
 |---|---|---|---:|---:|---|---|
-| Bubba Chandler | PIT | Unavailable | 85 | 0 | 85 pitches in 3 days | 85 pitches in 3 days; 85 pitches in 5 days; No rest since last appearance; Fatigue score is 60.2 |
-| Cristopher Sánchez | PHI | Unavailable | 85 | 0 | 85 pitches in 3 days | 85 pitches in 3 days; 85 pitches in 5 days; No rest since last appearance; Fatigue score is 64 |
-| Jacob Misiorowski | MIL | Unavailable | 85 | 0 | 85 pitches in 3 days | 85 pitches in 3 days; 85 pitches in 5 days; No rest since last appearance; Fatigue score is 85.1 |
-| Jake Bennett | BOS | Unavailable | 85 | 0 | 85 pitches in 3 days | 85 pitches in 3 days; 85 pitches in 5 days; No rest since last appearance; Fatigue score is 60.2 |
-| Jared Jones | PIT | Unavailable | 85 | 0 | 85 pitches in 3 days | 85 pitches in 3 days; 85 pitches in 5 days; No rest since last appearance; Fatigue score is 85.5 |
-| Joe Musgrove | SD | Unavailable | 85 | 0 | 85 pitches in 3 days | 85 pitches in 3 days; 85 pitches in 5 days; No rest since last appearance; Fatigue score is 85.5 |
-| Jose Quintana | COL | Unavailable | 85 | 0 | 85 pitches in 3 days | 85 pitches in 3 days; 85 pitches in 5 days; No rest since last appearance; Fatigue score is 85.1 |
-| Michael Lorenzen | COL | Unavailable | 85 | 0 | 85 pitches in 3 days | 85 pitches in 3 days; 85 pitches in 5 days; No rest since last appearance; Fatigue score is 60.6 |
+| Anthony Kay | CWS | Unavailable | 90 | 0 | 90 pitches in 3 days | 90 pitches in 3 days; 90 pitches in 5 days; No rest since last appearance; Fatigue score is 58 |
+| Bryce Elder | ATL | Unavailable | 90 | 0 | 90 pitches in 3 days | 90 pitches in 3 days; 90 pitches in 5 days; No rest since last appearance; Fatigue score is 85.1 |
+| Cody Bradford | TEX | Unavailable | 90 | 0 | 90 pitches in 3 days | 90 pitches in 3 days; 90 pitches in 5 days; No rest since last appearance; Fatigue score is 85.5 |
+| Freddy Peralta | NYM | Unavailable | 90 | 0 | 90 pitches in 3 days | 90 pitches in 3 days; 90 pitches in 5 days; No rest since last appearance; Fatigue score is 65 |
+| Garrett Crochet | BOS | Unavailable | 90 | 0 | 90 pitches in 3 days | 90 pitches in 3 days; 90 pitches in 5 days; No rest since last appearance; Fatigue score is 65.5 |
+| Jack Kochanowicz | LAA | Unavailable | 90 | 0 | 90 pitches in 3 days | 90 pitches in 3 days; 90 pitches in 5 days; No rest since last appearance; Fatigue score is 65.5 |
+| Mick Abel | MIN | Unavailable | 90 | 0 | 90 pitches in 3 days | 90 pitches in 3 days; 90 pitches in 5 days; No rest since last appearance; Fatigue score is 85.1 |
+| Shane Bieber | TOR | Unavailable | 90 | 0 | 90 pitches in 3 days | 90 pitches in 3 days; 90 pitches in 5 days; No rest since last appearance; Fatigue score is 85.5 |
+
+## Candidate D: raise Unavailable five-day combo pitch threshold
+
+Changed rule: unavailable_multi_day_pitch_threshold: 75 -> 85 when appearances_last_5_days >= 4
+
+### Candidate Status Distribution
+
+| Value | Count |
+|---|---:|
+| Monitor | 268 |
+| Limited | 174 |
+| Avoid | 156 |
+| Unavailable | 106 |
+
+### Status Delta From Baseline
+
+| Status | Delta |
+|---|---:|
+| Available | 0 |
+| Monitor | 0 |
+| Limited | 0 |
+| Avoid | 0 |
+| Unavailable | 0 |
+
+### Transitions
+
+| Transition | Count |
+|---|---:|
+| Avoid -> Avoid | 156 |
+| Limited -> Limited | 174 |
+| Monitor -> Monitor | 268 |
+| Unavailable -> Unavailable | 106 |
+
+### Moved From Unavailable
+
+| Candidate status | Count |
+|---|---:|
+| none | 0 |
+
+### Reason Categories
+
+| Category | Count |
+|---|---:|
+| pitch_count | 671 |
+| appearance_frequency | 1170 |
+| fatigue | 569 |
+| data_state | 64 |
+
+### Changed Examples
+
+| Pitcher | Team | Baseline | Candidate | Fatigue | Yday | 3-day | 5-day | App 5 | Severe signals | Reasons |
+|---|---|---|---|---:|---:|---:|---:|---:|---|---|
+| none |  |  |  |  |  |  |  |  |  |  |
+
+### Boundary Examples
+
+| Pitcher | Team | Status | Input value | Distance | Severe signals | Reasons |
+|---|---|---|---:|---:|---|---|
+| Bubba Chandler | PIT | Avoid | 85 | 0 | none | 85 pitches in 3 days; 85 pitches in 5 days; No rest since last appearance; Fatigue score is 60.2 |
+| Cristopher Sánchez | PHI | Avoid | 85 | 0 | none | 85 pitches in 3 days; 85 pitches in 5 days; No rest since last appearance; Fatigue score is 64 |
+| Jacob Misiorowski | MIL | Avoid | 85 | 0 | none | 85 pitches in 3 days; 85 pitches in 5 days; No rest since last appearance; Fatigue score is 85.1 |
+| Jake Bennett | BOS | Avoid | 85 | 0 | none | 85 pitches in 3 days; 85 pitches in 5 days; No rest since last appearance; Fatigue score is 60.2 |
+| Jared Jones | PIT | Avoid | 85 | 0 | none | 85 pitches in 3 days; 85 pitches in 5 days; No rest since last appearance; Fatigue score is 85.5 |
+| Joe Musgrove | SD | Avoid | 85 | 0 | none | 85 pitches in 3 days; 85 pitches in 5 days; No rest since last appearance; Fatigue score is 85.5 |
+| Jose Quintana | COL | Avoid | 85 | 0 | none | 85 pitches in 3 days; 85 pitches in 5 days; No rest since last appearance; Fatigue score is 85.1 |
+| Michael Lorenzen | COL | Avoid | 85 | 0 | none | 85 pitches in 3 days; 85 pitches in 5 days; No rest since last appearance; Fatigue score is 60.6 |
 
 ## Candidate E: require two severe signals for Unavailable
 
@@ -357,23 +345,23 @@ Changed rule: Require at least two current Unavailable rule signals before prese
 | Available | 0 |
 | Monitor | 0 |
 | Limited | 0 |
-| Avoid | +163 |
-| Unavailable | -163 |
+| Avoid | +106 |
+| Unavailable | -106 |
 
 ### Transitions
 
 | Transition | Count |
 |---|---:|
-| Avoid -> Avoid | 99 |
+| Avoid -> Avoid | 156 |
 | Limited -> Limited | 174 |
 | Monitor -> Monitor | 268 |
-| Unavailable -> Avoid | 163 |
+| Unavailable -> Avoid | 106 |
 
 ### Moved From Unavailable
 
 | Candidate status | Count |
 |---|---:|
-| Avoid | 163 |
+| Avoid | 106 |
 
 ### Reason Categories
 
@@ -388,40 +376,40 @@ Changed rule: Require at least two current Unavailable rule signals before prese
 
 | Pitcher | Team | Baseline | Candidate | Fatigue | Yday | 3-day | 5-day | App 5 | Severe signals | Reasons |
 |---|---|---|---|---:|---:|---:|---:|---:|---|---|
-| Aaron Civale | ATH | Unavailable | Avoid | 60.6 | 0 | 87 | 87 | 1 | 87 pitches in 3 days | 87 pitches in 3 days; 87 pitches in 5 days; No rest since last appearance; Fatigue score is 60.6 |
-| J.T. Ginn | ATH | Unavailable | Avoid | 85.1 | 0 | 88 | 88 | 1 | 88 pitches in 3 days | 88 pitches in 3 days; 88 pitches in 5 days; No rest since last appearance; Fatigue score is 85.1 |
 | Luis Severino | ATH | Unavailable | Avoid | 72.6 | 0 | 103 | 103 | 1 | 103 pitches in 3 days | 103 pitches in 3 days; 103 pitches in 5 days; No rest since last appearance; Fatigue score is 72.6 |
 | Mason Barnett | ATH | Unavailable | Avoid | 66.6 | 0 | 97 | 97 | 1 | 97 pitches in 3 days | 97 pitches in 3 days; 97 pitches in 5 days; No rest since last appearance; Fatigue score is 66.6 |
 | Michael Kelly | ATH | Unavailable | Avoid | 69.6 | 35 | 78 | 106 | 4 | 4 appearances and 106 pitches in 5 days | 35 pitches yesterday; 78 pitches in 3 days; 106 pitches in 5 days; 3 appearances in 3 days; 4 appearances in 5 days; Back-to-back appearances; 3 appearances in 4 days; No rest since last appearance; Fatigue score is 69.6 |
 | Bryce Elder | ATL | Unavailable | Avoid | 85.1 | 0 | 90 | 90 | 1 | 90 pitches in 3 days | 90 pitches in 3 days; 90 pitches in 5 days; No rest since last appearance; Fatigue score is 85.1 |
 | Chris Sale | ATL | Unavailable | Avoid | 71.3 | 0 | 100 | 100 | 1 | 100 pitches in 3 days | 100 pitches in 3 days; 100 pitches in 5 days; No rest since last appearance; Fatigue score is 71.3 |
-| Grant Holmes | ATL | Unavailable | Avoid | 60.6 | 0 | 87 | 87 | 1 | 87 pitches in 3 days | 87 pitches in 3 days; 87 pitches in 5 days; No rest since last appearance; Fatigue score is 60.6 |
 | Hurston Waldrep | ATL | Unavailable | Avoid | 85.5 | 0 | 92 | 92 | 1 | 92 pitches in 3 days | 92 pitches in 3 days; 92 pitches in 5 days; No rest since last appearance; Fatigue score is 85.5 |
-| Joey Wentz | ATL | Unavailable | Avoid | 85.5 | 0 | 86 | 86 | 1 | 86 pitches in 3 days | 86 pitches in 3 days; 86 pitches in 5 days; No rest since last appearance; Fatigue score is 85.5 |
 | Spencer Schwellenbach | ATL | Unavailable | Avoid | 85.5 | 0 | 90 | 90 | 1 | 90 pitches in 3 days | 90 pitches in 3 days; 90 pitches in 5 days; No rest since last appearance; Fatigue score is 85.5 |
-| Spencer Strider | ATL | Unavailable | Avoid | 85.5 | 0 | 85 | 85 | 1 | 85 pitches in 3 days | 85 pitches in 3 days; 85 pitches in 5 days; No rest since last appearance; Fatigue score is 85.5 |
+| Merrill Kelly | AZ | Unavailable | Avoid | 69.9 | 0 | 104 | 104 | 1 | 104 pitches in 3 days | 104 pitches in 3 days; 104 pitches in 5 days; No rest since last appearance; Fatigue score is 69.9 |
+| Ryne Nelson | AZ | Unavailable | Avoid | 63.5 | 0 | 93 | 93 | 1 | 93 pitches in 3 days | 93 pitches in 3 days; 93 pitches in 5 days; No rest since last appearance; Fatigue score is 63.5 |
+| Zac Gallen | AZ | Unavailable | Avoid | 85.1 | 0 | 95 | 95 | 1 | 95 pitches in 3 days | 95 pitches in 3 days; 95 pitches in 5 days; No rest since last appearance; Fatigue score is 85.1 |
+| Chris Bassitt | BAL | Unavailable | Avoid | 67.4 | 0 | 94 | 94 | 1 | 94 pitches in 3 days | 94 pitches in 3 days; 94 pitches in 5 days; No rest since last appearance; Fatigue score is 67.4 |
+| Shane Baz | BAL | Unavailable | Avoid | 67.2 | 0 | 98 | 98 | 1 | 98 pitches in 3 days | 98 pitches in 3 days; 98 pitches in 5 days; No rest since last appearance; Fatigue score is 67.2 |
 
 ### Boundary Examples
 
 | Pitcher | Team | Status | Input value | Distance | Severe signals | Reasons |
 |---|---|---|---:|---:|---|---|
-| Aaron Civale | ATH | Unavailable | 1 | 1 | 87 pitches in 3 days | 87 pitches in 3 days; 87 pitches in 5 days; No rest since last appearance; Fatigue score is 60.6 |
 | Aaron Nola | PHI | Unavailable | 1 | 1 | 101 pitches in 3 days | 101 pitches in 3 days; 101 pitches in 5 days; No rest since last appearance; Fatigue score is 65.2 |
 | Andre Pallante | STL | Unavailable | 1 | 1 | 91 pitches in 3 days | 91 pitches in 3 days; 91 pitches in 5 days; No rest since last appearance; Fatigue score is 65.6 |
-| Andrew Abbott | CIN | Unavailable | 1 | 1 | 86 pitches in 3 days | 86 pitches in 3 days; 86 pitches in 5 days; No rest since last appearance; Fatigue score is 64.2 |
-| Andrew Alvarez | WSH | Unavailable | 1 | 1 | 83 pitches in 3 days | 83 pitches in 3 days; 83 pitches in 5 days; No rest since last appearance; Fatigue score is 85.5 |
-| Andrew Painter | PHI | Unavailable | 1 | 1 | 80 pitches in 3 days | 80 pitches in 3 days; 80 pitches in 5 days; No rest since last appearance; Fatigue score is 59.1 |
 | Anthony Kay | CWS | Unavailable | 1 | 1 | 90 pitches in 3 days | 90 pitches in 3 days; 90 pitches in 5 days; No rest since last appearance; Fatigue score is 58 |
-| Bailey Ober | MIN | Unavailable | 1 | 1 | 88 pitches in 3 days | 88 pitches in 3 days; 88 pitches in 5 days; No rest since last appearance; Fatigue score is 85.1 |
+| Braxton Garrett | MIA | Unavailable | 1 | 1 | 93 pitches in 3 days | 93 pitches in 3 days; 93 pitches in 5 days; No rest since last appearance; Fatigue score is 85.5 |
+| Bryce Elder | ATL | Unavailable | 1 | 1 | 90 pitches in 3 days | 90 pitches in 3 days; 90 pitches in 5 days; No rest since last appearance; Fatigue score is 85.1 |
+| Cade Cavalli | WSH | Unavailable | 1 | 1 | 97 pitches in 3 days | 97 pitches in 3 days; 97 pitches in 5 days; No rest since last appearance; Fatigue score is 69.1 |
+| Cam Schlittler | NYY | Unavailable | 1 | 1 | 92 pitches in 3 days | 92 pitches in 3 days; 92 pitches in 5 days; No rest since last appearance; Fatigue score is 66.2 |
+| Chad Patrick | MIL | Unavailable | 1 | 1 | 98 pitches in 3 days | 98 pitches in 3 days; 98 pitches in 5 days; No rest since last appearance; Fatigue score is 66.4 |
 
 ## Recommendation
 
 Recommendation: Needs more data
 
 - Current-mode output is stale/missing dominated, so production tuning should not rely on current-mode distribution alone.
-- Largest one-variable candidate moved 57 pitchers out of Unavailable.
-- The multi-signal gate moved 163 pitchers, but it changes rule semantics rather than one threshold.
-- Review near-boundary pitcher examples before adopting any production threshold change.
+- Largest one-variable candidate moved 0 pitchers out of Unavailable.
+- The multi-signal gate moved 106 pitchers, but it changes rule semantics rather than one threshold.
+- Review near-boundary pitcher examples before adopting any future production threshold change.
 
 Any candidate threshold still requires human review and approval before
 production adoption.

--- a/backend/services/availability.py
+++ b/backend/services/availability.py
@@ -55,7 +55,7 @@ class AvailabilityThresholds:
     monitor_pitches_last_3_days: int = 30
     limited_pitches_last_3_days: int = 45
     avoid_pitches_last_3_days: int = 60
-    unavailable_pitches_last_3_days: int = 80
+    unavailable_pitches_last_3_days: int = 90
 
     limited_pitches_last_5_days: int = 60
     avoid_pitches_last_5_days: int = 75

--- a/backend/services/availability_unavailable_boundary_review.py
+++ b/backend/services/availability_unavailable_boundary_review.py
@@ -12,12 +12,11 @@ import json
 from services.availability import (
     STATUS_AVOID,
     STATUS_UNAVAILABLE,
-    THRESHOLDS,
 )
 from services.availability_threshold_audit import normalize_record, ordered_counts
 from services.availability_unavailable_experiment import (
-    UnavailableCandidate,
     classify_rows_for_candidate,
+    pre_adoption_candidate_c_baseline,
     unavailable_candidates,
     unavailable_severe_signals,
 )
@@ -30,12 +29,7 @@ REVIEW_AGAINST = 'Evidence against change'
 
 
 def baseline_candidate():
-    return UnavailableCandidate(
-        key='baseline',
-        label='Baseline',
-        changed_rule='Current production thresholds',
-        thresholds=THRESHOLDS,
-    )
+    return pre_adoption_candidate_c_baseline()
 
 
 def candidate_c():
@@ -55,6 +49,7 @@ def _transition_key(original_status, candidate_status):
 
 def case_from_records(baseline_record, candidate_record):
     inputs = baseline_record['inputs']
+    baseline_thresholds = baseline_candidate().thresholds
     return {
         'pitcher_id': baseline_record['pitcher_id'],
         'pitcher_name': baseline_record['pitcher_name'],
@@ -68,7 +63,7 @@ def case_from_records(baseline_record, candidate_record):
         'appearances_last_3_days': inputs.get('appearances_last_3_days'),
         'appearances_last_5_days': inputs.get('appearances_last_5_days'),
         'days_rest': inputs.get('days_rest'),
-        'baseline_severe_signals': unavailable_severe_signals(inputs, THRESHOLDS),
+        'baseline_severe_signals': unavailable_severe_signals(inputs, baseline_thresholds),
         'candidate_severe_signals': unavailable_severe_signals(inputs, candidate_c().thresholds),
         'reasons': baseline_record['reasons'],
     }

--- a/backend/services/availability_unavailable_experiment.py
+++ b/backend/services/availability_unavailable_experiment.py
@@ -43,7 +43,7 @@ UNAVAILABLE_RULES = [
     {
         'key': 'pitches_last_3_days',
         'rule': 'Three-day pitch volume',
-        'condition': 'pitches_last_3_days >= 80',
+        'condition': 'pitches_last_3_days >= 90',
     },
     {
         'key': 'appearances_and_5_day_pitches',
@@ -56,6 +56,8 @@ UNAVAILABLE_RULES = [
         'condition': 'fatigue_score >= 85.0 and pitches_yesterday >= 35',
     },
 ]
+
+PRE_ADOPTION_UNAVAILABLE_PITCHES_LAST_3_DAYS = 80
 
 
 @dataclass(frozen=True)
@@ -71,6 +73,19 @@ class UnavailableCandidate:
 
 def _with_threshold(**overrides):
     return replace(THRESHOLDS, **overrides)
+
+
+def pre_adoption_candidate_c_baseline():
+    return UnavailableCandidate(
+        key='pre_adoption_baseline',
+        label='Pre-adoption baseline',
+        changed_rule='Historical production threshold before Candidate C adoption',
+        thresholds=_with_threshold(
+            unavailable_pitches_last_3_days=PRE_ADOPTION_UNAVAILABLE_PITCHES_LAST_3_DAYS,
+        ),
+        focus_input='pitches_last_3_days',
+        focus_threshold=PRE_ADOPTION_UNAVAILABLE_PITCHES_LAST_3_DAYS,
+    )
 
 
 def unavailable_candidates():
@@ -93,8 +108,8 @@ def unavailable_candidates():
         ),
         UnavailableCandidate(
             key='raise_three_day_90',
-            label='Candidate C: raise Unavailable three-day pitch threshold',
-            changed_rule='unavailable_pitches_last_3_days: 80 -> 90',
+            label='Candidate C: adopted Unavailable three-day pitch threshold',
+            changed_rule='adopted production baseline: unavailable_pitches_last_3_days = 90',
             thresholds=_with_threshold(unavailable_pitches_last_3_days=90),
             focus_input='pitches_last_3_days',
             focus_threshold=90,
@@ -399,7 +414,7 @@ def recommend(comparisons):
         rationale.append(
             f'The multi-signal gate moved {multi_signal_moves} pitchers, but it changes rule semantics rather than one threshold.'
         )
-    rationale.append('Review near-boundary pitcher examples before adopting any production threshold change.')
+    rationale.append('Review near-boundary pitcher examples before adopting any future production threshold change.')
 
     return {
         'decision': 'Needs more data',

--- a/backend/tests/test_availability.py
+++ b/backend/tests/test_availability.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass
 from datetime import date, timedelta
 
+import pytest
+
 from services.availability import (
     CONFIDENCE_HIGH,
     CONFIDENCE_LOW,
@@ -103,6 +105,32 @@ class TestAvailabilityClassification:
         assert '54 pitches in 3 days' in result['reasons']
         assert '3 appearances in 4 days' in result['reasons']
         assert result['inputs']['three_in_four'] is True
+
+    @pytest.mark.parametrize(
+        ('three_day_pitches', 'expected_status'),
+        [
+            (79, STATUS_AVOID),
+            (80, STATUS_AVOID),
+            (89, STATUS_AVOID),
+            (90, STATUS_UNAVAILABLE),
+            (91, STATUS_UNAVAILABLE),
+        ],
+    )
+    def test_three_day_unavailable_boundary_uses_adopted_90_pitch_threshold(
+        self,
+        make_log,
+        three_day_pitches,
+        expected_status,
+    ):
+        ref = date(2026, 6, 1)
+        result = classify(
+            ScoreStub(raw_score=20.0),
+            [make_log(ref - timedelta(days=2), pitches_thrown=three_day_pitches)],
+            reference_date=ref,
+        )
+
+        assert result['availability_status'] == expected_status
+        assert f'{three_day_pitches} pitches in 3 days' in result['reasons']
 
     def test_missing_data_is_low_confidence_monitor(self):
         result = classify_availability(

--- a/backend/tests/test_availability_snapshot_mode.py
+++ b/backend/tests/test_availability_snapshot_mode.py
@@ -177,7 +177,7 @@ def test_snapshot_mode_produces_mixed_workload_statuses_from_sample_data(client)
         _add_pitcher('Snapshot Monitor', latest_game_date=anchor, raw_score=20.0, log_pitches=[5], mlb_seed=1)
         _add_pitcher('Snapshot Limited', latest_game_date=anchor, raw_score=20.0, log_pitches=[45], mlb_seed=2)
         _add_pitcher('Snapshot Avoid', latest_game_date=anchor, raw_score=20.0, log_pitches=[65], mlb_seed=3)
-        _add_pitcher('Snapshot Unavailable', latest_game_date=anchor, raw_score=20.0, log_pitches=[85], mlb_seed=4)
+        _add_pitcher('Snapshot Unavailable', latest_game_date=anchor, raw_score=20.0, log_pitches=[90], mlb_seed=4)
 
         records = classify_latest_fatigue_rows(
             latest_fatigue_rows(),

--- a/backend/tests/test_availability_unavailable_boundary_review.py
+++ b/backend/tests/test_availability_unavailable_boundary_review.py
@@ -9,6 +9,7 @@ from services.availability import (
 from services.availability_unavailable_boundary_review import (
     REVIEW_NEUTRAL,
     REVIEW_SUPPORTS,
+    baseline_candidate,
     boundary_sensitivity,
     build_review,
     candidate_c,
@@ -47,9 +48,11 @@ def _inputs(pitches_last_3_days, *, fatigue_score=40, pitches_yesterday=0, appea
 
 
 def test_candidate_c_only_raises_three_day_unavailable_threshold():
+    baseline = baseline_candidate()
     candidate = candidate_c()
 
-    assert THRESHOLDS.unavailable_pitches_last_3_days == 80
+    assert THRESHOLDS.unavailable_pitches_last_3_days == 90
+    assert baseline.thresholds.unavailable_pitches_last_3_days == 80
     assert candidate.thresholds.unavailable_pitches_last_3_days == 90
     assert candidate.thresholds.avoid_pitches_last_3_days == THRESHOLDS.avoid_pitches_last_3_days
 

--- a/backend/tests/test_availability_unavailable_experiment.py
+++ b/backend/tests/test_availability_unavailable_experiment.py
@@ -52,7 +52,7 @@ def _record(pitcher_id, name, status, inputs, reasons=None, data_state='fresh', 
     }
 
 
-def test_baseline_candidate_preserves_current_unavailable_outcome(make_log):
+def test_baseline_candidate_uses_adopted_three_day_threshold(make_log):
     ref = date(2026, 6, 1)
     logs = [
         make_log(ref, pitches_thrown=30),
@@ -68,11 +68,11 @@ def test_baseline_candidate_preserves_current_unavailable_outcome(make_log):
         candidate=_baseline_candidate(),
     )
 
-    assert result['availability_status'] == STATUS_UNAVAILABLE
+    assert result['availability_status'] == STATUS_AVOID
     assert result['inputs']['pitches_last_3_days'] == 85
 
 
-def test_three_day_candidate_changes_only_intended_unavailable_behavior(make_log):
+def test_adopted_three_day_candidate_matches_current_production_behavior(make_log):
     ref = date(2026, 6, 1)
     candidate = _candidate('raise_three_day_90')
     logs = [
@@ -101,12 +101,12 @@ def test_multi_signal_candidate_preserves_unavailable_only_with_multiple_severe_
     single_signal_logs = [
         make_log(ref, pitches_thrown=30),
         make_log(ref - timedelta(days=1), pitches_thrown=30),
-        make_log(ref - timedelta(days=2), pitches_thrown=25),
+        make_log(ref - timedelta(days=2), pitches_thrown=32),
     ]
     two_signal_logs = [
         make_log(ref, pitches_thrown=20),
         make_log(ref - timedelta(days=1), pitches_thrown=35),
-        make_log(ref - timedelta(days=2), pitches_thrown=30),
+        make_log(ref - timedelta(days=2), pitches_thrown=35),
     ]
 
     single_signal = classify_for_candidate(
@@ -125,7 +125,7 @@ def test_multi_signal_candidate_preserves_unavailable_only_with_multiple_severe_
     )
 
     assert single_signal['availability_status'] == STATUS_AVOID
-    assert unavailable_severe_signals(single_signal['inputs']) == ['85 pitches in 3 days']
+    assert unavailable_severe_signals(single_signal['inputs']) == ['92 pitches in 3 days']
     assert two_signal['availability_status'] == STATUS_UNAVAILABLE
     assert len(unavailable_severe_signals(two_signal['inputs'])) == 2
 

--- a/docs/AVAILABILITY_THRESHOLD_TUNING_PLAN.md
+++ b/docs/AVAILABILITY_THRESHOLD_TUNING_PLAN.md
@@ -80,7 +80,7 @@ future tuning branches.
 | Input | Monitor | Limited | Avoid | Unavailable |
 |---|---:|---:|---:|---:|
 | Pitches yesterday | >= 15 | >= 25 | >= 35 | >= 50 |
-| Pitches in 3 days | >= 30 | >= 45 | >= 60 | >= 80 |
+| Pitches in 3 days | >= 30 | >= 45 | >= 60 | >= 90 |
 | Pitches in 5 days | n/a | >= 60 | >= 75 | n/a |
 
 Unavailable can also trigger when `appearances_last_5_days >= 4` and
@@ -127,6 +127,7 @@ Baseline artifacts:
 - `backend/reports/availability_threshold_audit.md`
 - `backend/reports/availability_explanation_audit.md`
 - `backend/reports/availability_threshold_baseline.md`
+- `backend/reports/availability_threshold_adoption_candidate_c.md`
 
 The current audit reference date is 2026-06-01.
 
@@ -165,8 +166,8 @@ availability.
 |---|---:|
 | Monitor | 268 |
 | Limited | 174 |
-| Avoid | 99 |
-| Unavailable | 163 |
+| Avoid | 156 |
+| Unavailable | 106 |
 
 | Confidence | Count |
 |---|---:|
@@ -184,8 +185,8 @@ Fresh snapshot statuses:
 |---|---:|
 | Monitor | 204 |
 | Limited | 174 |
-| Avoid | 99 |
-| Unavailable | 163 |
+| Avoid | 156 |
+| Unavailable | 106 |
 
 Top snapshot reasons:
 
@@ -215,8 +216,8 @@ Reason-category snapshot totals from the explanation audit:
 - Current mode is not workload-informative for tuning because all 704 pitchers
   are Monitor due to stale or missing data.
 - Latest-workload snapshot output has no Available bucket in the local dataset.
-- Unavailable classifications are more common than Avoid classifications in
-  latest-workload snapshot output.
+- Avoid classifications are now more common than Unavailable classifications in
+  latest-workload snapshot output after Candidate C adoption.
 - Limited, Avoid, and Unavailable together account for 436 of 640 fresh
   latest-workload snapshot pitchers.
 - Appearance-frequency reasons are the most common reason category in the
@@ -235,7 +236,8 @@ These are evidence prompts, not tuning decisions.
 Potentially aggressive signals to investigate:
 
 - Latest-workload snapshot has no Available bucket.
-- Unavailable classifications outnumber Avoid classifications.
+- The Unavailable bucket remains large enough to monitor after Candidate C
+  adoption, but it no longer outnumbers Avoid in latest-workload snapshot mode.
 - Limited, Avoid, and Unavailable together represent most fresh snapshot rows.
 - Appearance-frequency reasons dominate the explanation audit.
 - Any back-to-back appearance currently produces at least Limited.
@@ -280,9 +282,8 @@ or whether pitch volume and role context should carry more weight.
 
 ### Unavailable Bucket Review
 
-Investigate why Unavailable is more common than Avoid in latest-workload
-snapshot output and whether that reflects valid workload severity or threshold
-compression.
+Investigate whether the adopted Unavailable bucket reflects valid workload
+severity or remaining threshold compression in latest-workload snapshot output.
 
 An initial experiment is documented in
 `backend/reports/availability_unavailable_threshold_experiment.md`. It compares
@@ -293,9 +294,11 @@ only one-variable candidate in that report that materially changes the
 Unavailable bucket. It moves 57 pitchers from Unavailable to Avoid in
 latest-workload snapshot mode.
 
-This experiment is not production approval. Any candidate threshold still
-requires human review, near-boundary example review, and a production tuning
-branch before adoption.
+Candidate C has now been adopted as the first governed threshold change. The
+production Unavailable three-day pitch threshold is 90. The adoption record is
+documented in `backend/reports/availability_threshold_adoption_candidate_c.md`.
+Any future candidate threshold still requires human review, near-boundary
+example review, and a production tuning branch before adoption.
 
 Candidate C boundary review is documented in
 `backend/reports/availability_unavailable_boundary_review.md`. The required

--- a/docs/BULLPEN_AVAILABILITY_ENGINE_V1.md
+++ b/docs/BULLPEN_AVAILABILITY_ENGINE_V1.md
@@ -215,16 +215,20 @@ Current threshold references:
 |------------|---------|---------|-------|-------------|
 | Fatigue score | >= 40 | >= 60 | >= 75 | >= 85 with heavy yesterday workload |
 | Pitches yesterday | >= 15 | >= 25 | >= 35 | >= 50 |
-| Pitches over last 3 days | >= 30 | >= 45 | >= 60 | >= 80 |
+| Pitches over last 3 days | >= 30 | >= 45 | >= 60 | >= 90 |
 | Pitches over last 5 days | n/a | >= 60 | >= 75 | >= 75 with 4+ appearances |
 | Appearances over last 3 days | n/a | >= 2 | >= 3 | n/a |
 | Appearances over last 5 days | >= 2 | >= 3 | >= 4 | >= 4 with 75+ pitches |
 | Back-to-back appearances | Monitor or higher by context | Any back-to-back appearance sequence | Back-to-back plus 35+ pitches in 3 days | n/a |
 | Freshness | n/a | n/a | n/a | Stale data returns Monitor with low confidence, not a current workload label |
 
-These thresholds are intentionally conservative starting points. They are
-centralized in `AvailabilityThresholds` so future tuning can happen in one
-place with focused regression coverage.
+The Unavailable three-day pitch threshold was adopted from Candidate C after
+audit and boundary review. The governed adoption moved that value from 80 to 90,
+allowing 80-89 pitches in 3 days to classify as Avoid unless another
+Unavailable rule fires, while 90+ pitches in 3 days remains Unavailable.
+
+These thresholds are centralized in `AvailabilityThresholds` so future tuning
+can happen in one place with focused regression coverage.
 
 ### Implemented V1 UI Presentation
 
@@ -285,6 +289,12 @@ Threshold tuning governance is documented in
 is `backend/reports/availability_threshold_baseline.md`. Future tuning branches
 should compare against that baseline, change one threshold variable at a time,
 and include before/after audit evidence before review.
+
+The first governed threshold adoption is documented in
+`backend/reports/availability_threshold_adoption_candidate_c.md`. The supporting
+experiment is `backend/reports/availability_unavailable_threshold_experiment.md`
+and the boundary review is
+`backend/reports/availability_unavailable_boundary_review.md`.
 
 ### Latest Workload Snapshot Validation Mode
 


### PR DESCRIPTION
Adopts the approved Availability Engine Candidate C threshold change, increasing the unavailable 3-day workload threshold from 80 to 90 pitches, updates audits and documentation, and records the first governed threshold adoption.