### PR TITLE
feat: add durable sync metadata

### DIFF
--- a/.github/workflows/baseballos-sync.yml
+++ b/.github/workflows/baseballos-sync.yml
@@ -47,7 +47,7 @@ jobs:
             -X POST "$SYNC_URL" \
             -H 'Content-Type: application/json' \
             -H "X-Admin-Token: $ADMIN_TOKEN" \
-            -d '{"days_back": 7}')
+            -d '{"days_back": 7, "source": "github_actions"}')
           echo "HTTP $http_code"
           echo "Response body:"
           cat response.json || true

--- a/backend/api/bullpen.py
+++ b/backend/api/bullpen.py
@@ -21,6 +21,7 @@ from services.availability_snapshot import (
 from services.availability_summary import summarize_availability_records
 from services.mlb_api import mlb_client
 from services import sync as sync_service
+from services import sync_metadata
 from utils.auth import require_admin_token
 
 bullpen_bp = Blueprint('bullpen', __name__)
@@ -373,16 +374,27 @@ def sync_recent_logs():
     """
     body      = request.get_json(silent=True) or {}
     days_back = body.get('days_back', 7)
+    source    = str(body.get('source') or sync_metadata.SOURCE_MANUAL)[:30]
     started   = datetime.now(timezone.utc)
+    sync_run_id = sync_metadata.start_sync_run(
+        source=source,
+        started_at=started.replace(tzinfo=None),
+    )
 
     try:
         pull = sync_service.sync_recent_logs(days_back=days_back)
     except Exception as e:
         db.session.rollback()
+        sync_metadata.finish_sync_run(
+            sync_run_id,
+            status=sync_metadata.STATUS_FAILED,
+            errors=1,
+            error_message=str(e),
+        )
         # Persist failure status so the dashboard reflects the bad state.
         sync_service.write_status({
             'last_sync':       started.isoformat(),
-            'status':          'error',
+            'status':          sync_metadata.STATUS_FAILED,
             'pitchers_updated': 0,
             'new_logs_added':  0,
             'errors':          1,
@@ -394,11 +406,20 @@ def sync_recent_logs():
     # Live mode: score against today — same behavior as before.
     fatigue_updated = sync_service.recalculate_all_fatigue(use_last_game_date=False)
     finished        = datetime.now(timezone.utc)
+    sync_metadata.finish_sync_run(
+        sync_run_id,
+        status=sync_metadata.STATUS_SUCCESS,
+        completed_at=finished.replace(tzinfo=None),
+        records_processed=pull['new_logs_added'],
+        new_logs_added=pull['new_logs_added'],
+        pitchers_updated=fatigue_updated,
+        errors=pull['errors'],
+    )
 
     # Mirror what the daily APScheduler job writes so /sync/status stays accurate.
     sync_service.write_status({
         'last_sync':       started.isoformat(),
-        'status':          'ok',
+        'status':          sync_metadata.STATUS_SUCCESS,
         'pitchers_updated': fatigue_updated,
         'new_logs_added':  pull['new_logs_added'],
         'errors':          pull['errors'],
@@ -412,6 +433,7 @@ def sync_recent_logs():
         'fatigue_recalculated': fatigue_updated,
         'errors':               pull['errors'],
         'synced_at':            finished.isoformat(),
+        'sync_run_id':          sync_run_id,
         'days_back':            days_back,
     })
 
@@ -428,18 +450,23 @@ def get_sync_status():
     genuinely empty system. The snapshot date is real DB data, never a faked
     sync timestamp.
     """
-    status = sync_service.read_status()
+    legacy_status = sync_service.read_status()
     try:
-        latest    = db.session.query(db.func.max(GameLog.game_date)).scalar()
-        log_count = db.session.query(db.func.count(GameLog.id)).scalar() or 0
-        status['data'] = {
-            'game_logs':        int(log_count),
-            'latest_game_date': latest.isoformat() if latest else None,
-        }
+        return jsonify(sync_metadata.build_sync_status_payload(legacy_status=legacy_status))
     except Exception:
         # A DB hiccup must never turn the status pill into a hard error.
-        status['data'] = {'game_logs': None, 'latest_game_date': None}
-    return jsonify(status)
+        legacy_status['data'] = {
+            'game_logs': None,
+            'latest_game_date': None,
+            'latest_workload_date': None,
+            'latest_fatigue_calculated_at': None,
+        }
+        legacy_status['freshness'] = {
+            'is_current': False,
+            'label': 'Freshness metadata unavailable.',
+            'limitations': ['Could not read durable sync metadata.'],
+        }
+        return jsonify(legacy_status)
 
 
 # ─── Pitchers ─────────────────────────────────────────────────────────────────

--- a/backend/app.py
+++ b/backend/app.py
@@ -110,6 +110,7 @@ def create_app(config_name=None):
     from models.game_log import GameLog
     from models.prospect import Prospect
     from models.fatigue_score import FatigueScore
+    from models.sync_run import SyncRun
 
     from api.bullpen import bullpen_bp
     from api.prospects import prospects_bp

--- a/backend/migrations/versions/41f4f9a8d6c2_add_sync_runs.py
+++ b/backend/migrations/versions/41f4f9a8d6c2_add_sync_runs.py
@@ -1,0 +1,47 @@
+"""add sync runs
+
+Revision ID: 41f4f9a8d6c2
+Revises: 9f3c1a7b2d4e
+Create Date: 2026-06-02 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '41f4f9a8d6c2'
+down_revision = '9f3c1a7b2d4e'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'sync_runs',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('started_at', sa.DateTime(), nullable=False),
+        sa.Column('completed_at', sa.DateTime(), nullable=True),
+        sa.Column('status', sa.String(length=20), nullable=False),
+        sa.Column('source', sa.String(length=30), nullable=False),
+        sa.Column('latest_game_date', sa.Date(), nullable=True),
+        sa.Column('latest_workload_date', sa.Date(), nullable=True),
+        sa.Column('latest_fatigue_calculated_at', sa.DateTime(), nullable=True),
+        sa.Column('records_processed', sa.Integer(), nullable=True),
+        sa.Column('new_logs_added', sa.Integer(), nullable=True),
+        sa.Column('pitchers_updated', sa.Integer(), nullable=True),
+        sa.Column('errors', sa.Integer(), nullable=True),
+        sa.Column('error_message', sa.Text(), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    with op.batch_alter_table('sync_runs', schema=None) as batch_op:
+        batch_op.create_index('ix_sync_runs_started_at', ['started_at'], unique=False)
+        batch_op.create_index('ix_sync_runs_status_completed', ['status', 'completed_at'], unique=False)
+
+
+def downgrade():
+    with op.batch_alter_table('sync_runs', schema=None) as batch_op:
+        batch_op.drop_index('ix_sync_runs_status_completed')
+        batch_op.drop_index('ix_sync_runs_started_at')
+    op.drop_table('sync_runs')

--- a/backend/models/sync_run.py
+++ b/backend/models/sync_run.py
@@ -1,0 +1,47 @@
+from datetime import datetime
+
+from utils.db import db
+
+
+class SyncRun(db.Model):
+    __tablename__ = 'sync_runs'
+
+    __table_args__ = (
+        db.Index('ix_sync_runs_started_at', 'started_at'),
+        db.Index('ix_sync_runs_status_completed', 'status', 'completed_at'),
+    )
+
+    id = db.Column(db.Integer, primary_key=True)
+    started_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
+    completed_at = db.Column(db.DateTime)
+    status = db.Column(db.String(20), nullable=False, default='running')
+    source = db.Column(db.String(30), nullable=False, default='manual')
+
+    latest_game_date = db.Column(db.Date)
+    latest_workload_date = db.Column(db.Date)
+    latest_fatigue_calculated_at = db.Column(db.DateTime)
+
+    records_processed = db.Column(db.Integer, default=0)
+    new_logs_added = db.Column(db.Integer, default=0)
+    pitchers_updated = db.Column(db.Integer, default=0)
+    errors = db.Column(db.Integer, default=0)
+    error_message = db.Column(db.Text)
+    created_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
+
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'started_at': self.started_at.isoformat() if self.started_at else None,
+            'completed_at': self.completed_at.isoformat() if self.completed_at else None,
+            'status': self.status,
+            'source': self.source,
+            'latest_game_date': self.latest_game_date.isoformat() if self.latest_game_date else None,
+            'latest_workload_date': self.latest_workload_date.isoformat() if self.latest_workload_date else None,
+            'latest_fatigue_calculated_at': self.latest_fatigue_calculated_at.isoformat() if self.latest_fatigue_calculated_at else None,
+            'records_processed': self.records_processed or 0,
+            'new_logs_added': self.new_logs_added or 0,
+            'pitchers_updated': self.pitchers_updated or 0,
+            'errors': self.errors or 0,
+            'error_message': self.error_message,
+            'created_at': self.created_at.isoformat() if self.created_at else None,
+        }

--- a/backend/reports/durable_sync_metadata_implementation.md
+++ b/backend/reports/durable_sync_metadata_implementation.md
@@ -1,0 +1,175 @@
+# Durable Sync Metadata Implementation
+
+## Root Cause
+
+The public backend had valid workload data through May 31, 2026 and fatigue
+rows calculated during the successful June 1 sync window, but
+`/api/bullpen/sync/status` reported:
+
+```json
+{
+  "last_sync": null,
+  "status": "never"
+}
+```
+
+The sync timestamp was stored only in `backend/logs/sync_status.json`, which is
+runtime-local state. It can disappear across restarts and deployments, while
+database-backed game logs and fatigue scores remain current.
+
+## Implementation Summary
+
+- Added a database-backed `sync_runs` model/table for durable sync metadata.
+- Added `services/sync_metadata.py` to record sync start, completion, failure,
+  and data/fatigue coverage metadata.
+- Updated manual sync and scheduled sync paths to write durable metadata.
+- Updated the GitHub Actions sync body to identify its source as
+  `github_actions`.
+- Updated `/api/bullpen/sync/status` to prefer durable metadata while preserving
+  legacy fields.
+- Updated the dashboard sync pill to separately display sync timestamp and data
+  coverage.
+- Added backend and frontend regression tests for successful, failed, missing,
+  and no-data metadata states.
+
+## Persistence Design
+
+Migration:
+
+```text
+backend/migrations/versions/41f4f9a8d6c2_add_sync_runs.py
+```
+
+Table:
+
+```text
+sync_runs
+```
+
+Fields:
+
+| Field | Purpose |
+| --- | --- |
+| `id` | Primary key |
+| `started_at` | Sync attempt start timestamp |
+| `completed_at` | Sync attempt completion timestamp |
+| `status` | `running`, `success`, or `failed` |
+| `source` | Sync source such as `manual` or `scheduled` |
+| `latest_game_date` | Latest baseball game-log date after sync |
+| `latest_workload_date` | Latest workload date after sync |
+| `latest_fatigue_calculated_at` | Latest fatigue score calculation timestamp after sync |
+| `records_processed` | Records processed by the sync run |
+| `new_logs_added` | New game logs inserted |
+| `pitchers_updated` | Pitchers with recalculated fatigue scores |
+| `errors` | Error count for the run |
+| `error_message` | Failure or limitation text |
+| `created_at` | Row creation timestamp |
+
+Indexes:
+
+- `ix_sync_runs_started_at`
+- `ix_sync_runs_status_completed`
+
+## API Shape
+
+`GET /api/bullpen/sync/status` now returns durable metadata:
+
+```json
+{
+  "status": "success",
+  "last_sync": "2026-06-01T21:39:12",
+  "last_successful_sync": "2026-06-01T21:39:56",
+  "pitchers_updated": 428,
+  "new_logs_added": 120,
+  "errors": 0,
+  "message": "",
+  "finished_at": "2026-06-01T21:39:56",
+  "data": {
+    "game_logs": 35768,
+    "latest_game_date": "2026-05-31",
+    "latest_workload_date": "2026-05-31",
+    "latest_fatigue_calculated_at": "2026-06-01T21:39:55"
+  },
+  "freshness": {
+    "is_current": true,
+    "label": "Current baseball data through 2026-05-31.",
+    "limitations": []
+  },
+  "sync": {
+    "id": 1,
+    "status": "success",
+    "source": "github_actions"
+  }
+}
+```
+
+Backward-compatible fields retained:
+
+- `status`
+- `last_sync`
+- `pitchers_updated`
+- `new_logs_added`
+- `errors`
+- `message`
+- `finished_at`
+- `data.latest_game_date`
+- `data.game_logs`
+
+## UI Behavior
+
+When sync metadata and data coverage are both available, the dashboard shows:
+
+```text
+Synced: June 1, 2026
+Data Through: May 31, 2026
+```
+
+When game logs exist but sync metadata is unavailable:
+
+```text
+Sync metadata: Unavailable
+Data Through: May 31, 2026
+```
+
+When the latest sync attempt failed:
+
+```text
+Last sync failed: June 2, 2026
+Data Through: May 31, 2026
+```
+
+When no metadata or game logs exist:
+
+```text
+No data loaded
+```
+
+## Fallback Behavior
+
+- Durable `sync_runs` metadata is authoritative when available.
+- Legacy `backend/logs/sync_status.json` remains a fallback for existing local
+  deployments and backward-compatible fields.
+- If durable metadata is temporarily unavailable, `/sync/status` still reports
+  data coverage from game logs and adds a freshness limitation instead of
+  implying that baseball data is missing.
+
+## Tests Run
+
+- `python -m pytest tests\test_sync_status.py`
+- `python -m compileall api services models tests`
+- `python -m pytest`
+- `python -m compileall api services scripts models migrations tests`
+- `npm test`
+- `npm run build`
+- `git diff --check`
+
+Full backend and frontend validation were run before commit.
+
+## Remaining Limitations
+
+- Existing deployments will not have durable sync metadata until the migration
+  is applied and a new sync run completes.
+- Historical sync timestamps cannot be reconstructed perfectly from game logs;
+  if no durable run exists, the API reports sync metadata as unavailable.
+- `latest_workload_date` currently matches the latest MLB game-log date because
+  workload V1 derives from game logs.

--- a/backend/services/sync.py
+++ b/backend/services/sync.py
@@ -19,6 +19,7 @@ from sqlalchemy import desc
 from utils.db import db
 from models.pitcher import Pitcher
 from models.game_log import GameLog
+from services import sync_metadata
 from services.fatigue import calculate_fatigue
 from services.mlb_api import mlb_client
 
@@ -257,11 +258,12 @@ def run_daily_sync(app, days_back: int = 7):
     run_logger.setLevel(logging.INFO)
 
     started_at = datetime.now(timezone.utc)
+    sync_run_id = None
     run_logger.info('── Daily sync starting (days_back=%s) ──', days_back)
 
     status = {
         'last_sync':        started_at.isoformat(),
-        'status':           'ok',
+        'status':           sync_metadata.STATUS_SUCCESS,
         'pitchers_updated': 0,
         'new_logs_added':   0,
         'errors':           0,
@@ -270,6 +272,10 @@ def run_daily_sync(app, days_back: int = 7):
 
     try:
         with app.app_context():
+            sync_run_id = sync_metadata.start_sync_run(
+                source=sync_metadata.SOURCE_SCHEDULED,
+                started_at=started_at.replace(tzinfo=None),
+            )
             pull = sync_recent_logs(days_back=days_back)
             run_logger.info(
                 'Pulled %s new logs (touched %s pitchers, %s errors)',
@@ -285,18 +291,33 @@ def run_daily_sync(app, days_back: int = 7):
                     GameLog.game_date >= (date.today() - timedelta(days=days_back))
                 ).first()
                 if recent_any is None:
-                    status['status']  = 'no_games'
                     status['message'] = 'No games found — offseason skip.'
                     run_logger.info('No games found — offseason skip.')
 
             pitchers_updated = recalculate_all_fatigue(use_last_game_date=True)
             status['pitchers_updated'] = pitchers_updated
             run_logger.info('Recalculated fatigue for %s pitchers', pitchers_updated)
+            sync_metadata.finish_sync_run(
+                sync_run_id,
+                status=sync_metadata.STATUS_SUCCESS,
+                records_processed=pull['new_logs_added'],
+                new_logs_added=pull['new_logs_added'],
+                pitchers_updated=pitchers_updated,
+                errors=pull['errors'],
+                error_message=status['message'] or None,
+            )
 
     except Exception as e:
-        status['status']  = 'error'
+        status['status']  = sync_metadata.STATUS_FAILED
         status['message'] = str(e)
         run_logger.exception('Daily sync failed: %s', e)
+        with app.app_context():
+            sync_metadata.finish_sync_run(
+                sync_run_id,
+                status=sync_metadata.STATUS_FAILED,
+                errors=1,
+                error_message=str(e),
+            )
 
     status['finished_at'] = datetime.now(timezone.utc).isoformat()
 

--- a/backend/services/sync_metadata.py
+++ b/backend/services/sync_metadata.py
@@ -1,0 +1,260 @@
+from datetime import date, datetime, timedelta
+import logging
+
+from sqlalchemy.exc import SQLAlchemyError
+
+from models.fatigue_score import FatigueScore
+from models.game_log import GameLog
+from models.sync_run import SyncRun
+from services.availability import ACTIVE_WINDOW_DAYS
+from utils.db import db
+
+
+STATUS_RUNNING = 'running'
+STATUS_SUCCESS = 'success'
+STATUS_FAILED = 'failed'
+STATUS_NEVER = 'never'
+STATUS_METADATA_UNAVAILABLE = 'metadata_unavailable'
+
+SOURCE_MANUAL = 'manual'
+SOURCE_SCHEDULED = 'scheduled'
+SOURCE_GITHUB_ACTIONS = 'github_actions'
+
+logger = logging.getLogger(__name__)
+
+
+def _now():
+    return datetime.utcnow()
+
+
+def _iso(value):
+    return value.isoformat() if value else None
+
+
+def _normalize_legacy_status(status):
+    if status == 'ok':
+        return STATUS_SUCCESS
+    if status == 'error':
+        return STATUS_FAILED
+    if status in ('no_games', STATUS_SUCCESS, STATUS_FAILED, STATUS_RUNNING):
+        return status
+    return status or STATUS_NEVER
+
+
+def collect_data_metadata():
+    latest_game_date = db.session.query(db.func.max(GameLog.game_date)).scalar()
+    latest_fatigue = db.session.query(db.func.max(FatigueScore.calculated_at)).scalar()
+    game_logs = db.session.query(db.func.count(GameLog.id)).scalar() or 0
+    return {
+        'game_logs': int(game_logs),
+        'latest_game_date': latest_game_date,
+        # V1 workload coverage is based on MLB game logs, so this matches the
+        # latest game-log date while leaving a distinct API field for future
+        # workload sources.
+        'latest_workload_date': latest_game_date,
+        'latest_fatigue_calculated_at': latest_fatigue,
+    }
+
+
+def start_sync_run(source=SOURCE_MANUAL, started_at=None):
+    started_at = started_at or _now()
+    try:
+        run = SyncRun(
+            started_at=started_at,
+            status=STATUS_RUNNING,
+            source=source,
+            created_at=started_at,
+        )
+        db.session.add(run)
+        db.session.commit()
+        return run.id
+    except SQLAlchemyError as exc:
+        db.session.rollback()
+        logger.warning('Could not persist sync start metadata: %s', exc)
+        return None
+
+
+def finish_sync_run(
+    sync_run_id,
+    status,
+    completed_at=None,
+    records_processed=0,
+    new_logs_added=0,
+    pitchers_updated=0,
+    errors=0,
+    error_message=None,
+):
+    if not sync_run_id:
+        return None
+
+    completed_at = completed_at or _now()
+    try:
+        run = db.session.get(SyncRun, sync_run_id)
+        if run is None:
+            return None
+        metadata = collect_data_metadata()
+        run.completed_at = completed_at
+        run.status = status
+        run.latest_game_date = metadata['latest_game_date']
+        run.latest_workload_date = metadata['latest_workload_date']
+        run.latest_fatigue_calculated_at = metadata['latest_fatigue_calculated_at']
+        run.records_processed = records_processed or 0
+        run.new_logs_added = new_logs_added or 0
+        run.pitchers_updated = pitchers_updated or 0
+        run.errors = errors or 0
+        run.error_message = error_message
+        db.session.commit()
+        return run
+    except SQLAlchemyError as exc:
+        db.session.rollback()
+        logger.warning('Could not persist sync completion metadata: %s', exc)
+        return None
+
+
+def latest_sync_run():
+    return SyncRun.query.order_by(SyncRun.started_at.desc(), SyncRun.id.desc()).first()
+
+
+def latest_successful_sync_run():
+    return (
+        SyncRun.query
+        .filter_by(status=STATUS_SUCCESS)
+        .order_by(SyncRun.completed_at.desc(), SyncRun.started_at.desc(), SyncRun.id.desc())
+        .first()
+    )
+
+
+def _run_message(run):
+    if run is None:
+        return ''
+    if run.status == STATUS_FAILED:
+        return run.error_message or 'Last sync failed.'
+    return run.error_message or ''
+
+
+def _freshness_payload(metadata, status, last_successful_sync, reference_date=None):
+    ref = reference_date or date.today()
+    latest_game_date = metadata['latest_game_date']
+    latest_fatigue = metadata['latest_fatigue_calculated_at']
+    limitations = []
+
+    if not metadata['game_logs'] or latest_game_date is None:
+        return {
+            'is_current': False,
+            'label': 'No baseball workload data loaded.',
+            'limitations': ['No game logs are available.'],
+        }
+
+    cutoff = ref - timedelta(days=ACTIVE_WINDOW_DAYS)
+    is_current = latest_game_date >= cutoff
+    label = (
+        f"Current baseball data through {latest_game_date.isoformat()}."
+        if is_current
+        else f"Historical baseball data through {latest_game_date.isoformat()}."
+    )
+
+    if status == STATUS_METADATA_UNAVAILABLE:
+        limitations.append('Sync metadata unavailable; data coverage is based on game logs.')
+    if last_successful_sync is None:
+        limitations.append('No durable successful sync timestamp is available.')
+    if latest_fatigue is None:
+        limitations.append('No fatigue calculation timestamp is available.')
+    if not is_current:
+        limitations.append(f'Latest game date is outside the {ACTIVE_WINDOW_DAYS}-day freshness window.')
+    if status == STATUS_FAILED:
+        limitations.append('The latest sync attempt failed; data may reflect an earlier successful sync.')
+
+    return {
+        'is_current': is_current,
+        'label': label,
+        'limitations': limitations,
+    }
+
+
+def build_sync_status_payload(legacy_status=None, reference_date=None):
+    legacy_status = legacy_status or {}
+    metadata = collect_data_metadata()
+    try:
+        latest_run = latest_sync_run()
+        successful_run = latest_successful_sync_run()
+    except SQLAlchemyError as exc:
+        db.session.rollback()
+        logger.warning('Could not read durable sync metadata: %s', exc)
+        latest_run = None
+        successful_run = None
+
+    if latest_run:
+        status = latest_run.status
+        last_sync = _iso(latest_run.started_at)
+        finished_at = _iso(latest_run.completed_at)
+        pitchers_updated = latest_run.pitchers_updated or 0
+        new_logs_added = latest_run.new_logs_added or 0
+        errors = latest_run.errors or 0
+        message = _run_message(latest_run)
+        sync_block = latest_run.to_dict()
+    elif legacy_status.get('last_sync'):
+        status = _normalize_legacy_status(legacy_status.get('status'))
+        last_sync = legacy_status.get('last_sync')
+        finished_at = legacy_status.get('finished_at')
+        pitchers_updated = legacy_status.get('pitchers_updated', 0) or 0
+        new_logs_added = legacy_status.get('new_logs_added', 0) or 0
+        errors = legacy_status.get('errors', 0) or 0
+        message = legacy_status.get('message', '') or ''
+        sync_block = {
+            'id': None,
+            'source': 'legacy_status_file',
+            'started_at': last_sync,
+            'completed_at': finished_at,
+            'status': status,
+        }
+    else:
+        status = STATUS_METADATA_UNAVAILABLE if metadata['game_logs'] else STATUS_NEVER
+        last_sync = None
+        finished_at = None
+        pitchers_updated = legacy_status.get('pitchers_updated', 0) or 0
+        new_logs_added = legacy_status.get('new_logs_added', 0) or 0
+        errors = legacy_status.get('errors', 0) or 0
+        message = (
+            'Sync metadata unavailable.'
+            if status == STATUS_METADATA_UNAVAILABLE
+            else legacy_status.get('message', 'No sync has run yet.')
+        )
+        sync_block = None
+
+    if successful_run:
+        last_successful_sync = _iso(successful_run.completed_at or successful_run.started_at)
+        last_successful_sync_run = successful_run.to_dict()
+    elif status == STATUS_SUCCESS and finished_at:
+        last_successful_sync = finished_at
+        last_successful_sync_run = sync_block
+    elif status == STATUS_SUCCESS:
+        last_successful_sync = last_sync
+        last_successful_sync_run = sync_block
+    else:
+        last_successful_sync = None
+        last_successful_sync_run = None
+
+    return {
+        'status': status,
+        'last_sync': last_sync,
+        'last_successful_sync': last_successful_sync,
+        'pitchers_updated': pitchers_updated,
+        'new_logs_added': new_logs_added,
+        'errors': errors,
+        'message': message,
+        'finished_at': finished_at,
+        'data': {
+            'game_logs': metadata['game_logs'],
+            'latest_game_date': _iso(metadata['latest_game_date']),
+            'latest_workload_date': _iso(metadata['latest_workload_date']),
+            'latest_fatigue_calculated_at': _iso(metadata['latest_fatigue_calculated_at']),
+        },
+        'freshness': _freshness_payload(
+            metadata,
+            status=status,
+            last_successful_sync=last_successful_sync,
+            reference_date=reference_date,
+        ),
+        'sync': sync_block,
+        'last_successful_sync_run': last_successful_sync_run,
+    }

--- a/backend/tests/test_sync_status.py
+++ b/backend/tests/test_sync_status.py
@@ -2,25 +2,25 @@
 Tests for the enriched GET /api/bullpen/sync/status endpoint.
 
 The endpoint now reports the real data snapshot (latest game date + log count)
-alongside the file-based sync status, so the dashboard can tell a loaded
-historical snapshot apart from a genuinely empty / never-synced system.
+alongside durable sync metadata, so the dashboard can tell sync timestamps
+apart from data-through dates.
 
 Runs against in-memory SQLite (no Postgres / MLB / network). The sync status
-file is pointed at an empty temp path so read_status() returns the 'never'
-sentinel deterministically — i.e. we simulate "data loaded via seed, no sync".
+file is pointed at an empty temp path so durable metadata is the authority.
 """
 
-from datetime import date
-import json
+from datetime import date, datetime
 
 import pytest
 from flask import Flask
 
 import services.sync as sync_service
+from services import sync_metadata
 from utils.db import db
 from models.pitcher import Pitcher
 from models.game_log import GameLog
-import models.fatigue_score  # noqa: F401  (register on db.metadata)
+from models.fatigue_score import FatigueScore
+from models.sync_run import SyncRun
 import models.prospect        # noqa: F401  (register on db.metadata)
 from api.bullpen import bullpen_bp
 
@@ -60,45 +60,148 @@ class TestSyncStatusSnapshot:
 
         # No sync has run...
         assert body['last_sync'] is None
-        assert body['status'] == 'never'
+        assert body['status'] == 'metadata_unavailable'
         # ...but the data snapshot is reported honestly from the DB.
         assert body['data']['game_logs'] == 2
         assert body['data']['latest_game_date'] == '2025-09-10'
+        assert body['data']['latest_workload_date'] == '2025-09-10'
+        assert body['freshness']['limitations'] == [
+            'Sync metadata unavailable; data coverage is based on game logs.',
+            'No durable successful sync timestamp is available.',
+            'No fatigue calculation timestamp is available.',
+            'Latest game date is outside the 14-day freshness window.',
+        ]
 
     def test_reports_empty_when_no_data_and_no_sync(self, client):
         res = client.get('/api/bullpen/sync/status')
         assert res.status_code == 200
         body = res.get_json()
         assert body['last_sync'] is None
+        assert body['last_successful_sync'] is None
+        assert body['status'] == 'never'
         assert body['data']['game_logs'] == 0
         assert body['data']['latest_game_date'] is None
+        assert body['data']['latest_workload_date'] is None
+        assert body['data']['latest_fatigue_calculated_at'] is None
+        assert body['freshness']['label'] == 'No baseball workload data loaded.'
 
     def test_reports_sync_timestamp_and_snapshot_date_together(self, client):
-        sync_service.STATUS_FILE.write_text(
-            json.dumps({
-                'last_sync': '2026-06-01T21:39:12+00:00',
-                'status': 'ok',
-                'pitchers_updated': 428,
-                'new_logs_added': 120,
-                'errors': 0,
-                'message': '',
-                'finished_at': '2026-06-01T21:39:56+00:00',
-            }),
-            encoding='utf-8',
-        )
         with client.application.app_context():
             p = Pitcher(mlb_id=1, full_name='A', team_id=1, active=True)
             db.session.add(p)
             db.session.commit()
             db.session.add(GameLog(pitcher_id=p.id, mlb_game_pk=31, game_date=date(2026, 5, 31)))
+            db.session.add(FatigueScore(
+                pitcher_id=p.id,
+                raw_score=42.0,
+                calculated_at=datetime(2026, 6, 1, 21, 39, 55),
+            ))
+            db.session.add(SyncRun(
+                started_at=datetime(2026, 6, 1, 21, 39, 12),
+                completed_at=datetime(2026, 6, 1, 21, 39, 56),
+                status='success',
+                source='github_actions',
+                latest_game_date=date(2026, 5, 31),
+                latest_workload_date=date(2026, 5, 31),
+                latest_fatigue_calculated_at=datetime(2026, 6, 1, 21, 39, 55),
+                records_processed=120,
+                new_logs_added=120,
+                pitchers_updated=428,
+                errors=0,
+                created_at=datetime(2026, 6, 1, 21, 39, 12),
+            ))
             db.session.commit()
 
         res = client.get('/api/bullpen/sync/status')
         assert res.status_code == 200
         body = res.get_json()
 
-        assert body['last_sync'] == '2026-06-01T21:39:12+00:00'
-        assert body['status'] == 'ok'
+        assert body['status'] == 'success'
+        assert body['last_sync'] == '2026-06-01T21:39:12'
+        assert body['last_successful_sync'] == '2026-06-01T21:39:56'
         assert body['pitchers_updated'] == 428
+        assert body['new_logs_added'] == 120
         assert body['data']['game_logs'] == 1
         assert body['data']['latest_game_date'] == '2026-05-31'
+        assert body['data']['latest_workload_date'] == '2026-05-31'
+        assert body['data']['latest_fatigue_calculated_at'] == '2026-06-01T21:39:55'
+        assert body['freshness']['is_current'] is True
+        assert body['freshness']['limitations'] == []
+        assert body['sync']['source'] == 'github_actions'
+        assert body['last_successful_sync_run']['status'] == 'success'
+
+    def test_reports_failed_sync_without_hiding_last_successful_sync(self, client):
+        with client.application.app_context():
+            p = Pitcher(mlb_id=1, full_name='A', team_id=1, active=True)
+            db.session.add(p)
+            db.session.commit()
+            db.session.add(GameLog(pitcher_id=p.id, mlb_game_pk=31, game_date=date(2026, 5, 31)))
+            db.session.add(FatigueScore(
+                pitcher_id=p.id,
+                raw_score=42.0,
+                calculated_at=datetime(2026, 6, 1, 21, 39, 55),
+            ))
+            db.session.add(SyncRun(
+                started_at=datetime(2026, 6, 1, 21, 39, 12),
+                completed_at=datetime(2026, 6, 1, 21, 39, 56),
+                status='success',
+                source='github_actions',
+                created_at=datetime(2026, 6, 1, 21, 39, 12),
+            ))
+            db.session.add(SyncRun(
+                started_at=datetime(2026, 6, 2, 10, 0, 0),
+                completed_at=datetime(2026, 6, 2, 10, 0, 30),
+                status='failed',
+                source='github_actions',
+                errors=1,
+                error_message='MLB API unavailable',
+                created_at=datetime(2026, 6, 2, 10, 0, 0),
+            ))
+            db.session.commit()
+
+        res = client.get('/api/bullpen/sync/status')
+        assert res.status_code == 200
+        body = res.get_json()
+
+        assert body['status'] == 'failed'
+        assert body['last_sync'] == '2026-06-02T10:00:00'
+        assert body['last_successful_sync'] == '2026-06-01T21:39:56'
+        assert body['message'] == 'MLB API unavailable'
+        assert 'The latest sync attempt failed; data may reflect an earlier successful sync.' in body['freshness']['limitations']
+
+    def test_sync_metadata_service_persists_start_and_completion(self, client):
+        with client.application.app_context():
+            p = Pitcher(mlb_id=1, full_name='A', team_id=1, active=True)
+            db.session.add(p)
+            db.session.commit()
+            db.session.add(GameLog(pitcher_id=p.id, mlb_game_pk=31, game_date=date(2026, 5, 31)))
+            db.session.add(FatigueScore(
+                pitcher_id=p.id,
+                raw_score=42.0,
+                calculated_at=datetime(2026, 6, 1, 21, 39, 55),
+            ))
+            db.session.commit()
+
+            run_id = sync_metadata.start_sync_run(
+                source='test',
+                started_at=datetime(2026, 6, 1, 21, 39, 12),
+            )
+            run = db.session.get(SyncRun, run_id)
+            assert run.status == 'running'
+
+            sync_metadata.finish_sync_run(
+                run_id,
+                status='success',
+                completed_at=datetime(2026, 6, 1, 21, 39, 56),
+                records_processed=120,
+                new_logs_added=120,
+                pitchers_updated=428,
+            )
+            run = db.session.get(SyncRun, run_id)
+
+            assert run.status == 'success'
+            assert run.latest_game_date == date(2026, 5, 31)
+            assert run.latest_workload_date == date(2026, 5, 31)
+            assert run.latest_fatigue_calculated_at == datetime(2026, 6, 1, 21, 39, 55)
+            assert run.records_processed == 120
+            assert run.pitchers_updated == 428

--- a/frontend/src/components/dashboard/Dashboard.jsx
+++ b/frontend/src/components/dashboard/Dashboard.jsx
@@ -48,8 +48,9 @@ export default function Dashboard() {
   // latest game-date year from the database (not a hardcoded year).
   const seasonInfo = (() => {
     const s = sync.data
-    if (s && s.last_sync && s.status === 'ok') {
-      const d = new Date(s.last_sync)
+    const syncedAt = s?.last_successful_sync || (s?.status === 'success' || s?.status === 'ok' ? s?.last_sync : null)
+    if (syncedAt) {
+      const d = new Date(syncedAt)
       if (!Number.isNaN(d.getTime())) {
         return { season: String(d.getFullYear()), isLive: true }
       }
@@ -127,7 +128,7 @@ export default function Dashboard() {
                   </>
                 )}
                 {fmtThroughDate(sync.data?.data?.latest_game_date) && (
-                  <span> · through {fmtThroughDate(sync.data.data.latest_game_date)}</span>
+                  <span> · data through {fmtThroughDate(sync.data.data.latest_game_date)}</span>
                 )}
               </div>
             )}

--- a/frontend/src/components/dashboard/SyncStatus.jsx
+++ b/frontend/src/components/dashboard/SyncStatus.jsx
@@ -1,32 +1,10 @@
 import { useFetch } from '../../hooks/useFetch'
 import { getSyncStatus } from '../../utils/api'
-
-const STALE_HOURS = 36
-const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
-                'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
-
-// Format an ISO datetime (a real sync timestamp) as "Jun 3 at 2:05 PM".
-const fmtSyncTime = (iso) => {
-  if (!iso) return null
-  const d = new Date(iso)
-  if (Number.isNaN(d.getTime())) return null
-  const date = d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
-  const time = d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' })
-  return `${date} at ${time}`
-}
-
-// Format a 'YYYY-MM-DD' game date as "Sep 10, 2025" without timezone drift.
-const fmtSnapshotDate = (ymd) => {
-  if (!ymd) return null
-  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(ymd)
-  if (!m) return null
-  const [, y, mm, dd] = m
-  return `${MONTHS[Number(mm) - 1]} ${Number(dd)}, ${y}`
-}
+import { getSyncStatusView } from './syncStatusView'
 
 const Pill = ({ dot, style = {}, title, children }) => (
   <div
-    className="inline-flex items-center gap-2 px-3 py-1 rounded-md border text-[11px] font-mono"
+    className="inline-flex items-center gap-2 px-3 py-1 rounded-md border text-[11px] font-mono max-w-full"
     style={{ borderColor: '#242b35', backgroundColor: 'rgba(26,31,38,0.4)', ...style }}
     title={title}
   >
@@ -35,9 +13,7 @@ const Pill = ({ dot, style = {}, title, children }) => (
   </div>
 )
 
-export default function SyncStatus() {
-  const { data, loading, error } = useFetch(getSyncStatus)
-
+export function SyncStatusContent({ data, loading, error, now }) {
   if (loading) {
     return <Pill dot="#8899aa"><span className="animate-pulse">Checking sync…</span></Pill>
   }
@@ -45,51 +21,31 @@ export default function SyncStatus() {
     return <Pill dot="#4a5568">Sync status unavailable</Pill>
   }
 
-  const { last_sync, status, pitchers_updated } = data || {}
-  const snapshotDate = data?.data?.latest_game_date
-  const logCount     = data?.data?.game_logs
+  const view = getSyncStatusView(data, now ? { now } : undefined)
+  const title = [view.helper, ...view.limitations].filter(Boolean).join(' ')
 
-  // 1) A sync ran and failed.
-  if (status === 'error') {
-    return (
-      <Pill dot="#ef4444" style={{ borderColor: '#ef444455', backgroundColor: '#ef444412', color: '#fca5a5' }}
-            title={data?.message || undefined}>
-        <span>Last sync failed{last_sync ? `: ${fmtSyncTime(last_sync)}` : ''}</span>
-      </Pill>
-    )
-  }
-
-  // 2) A sync succeeded — show the real timestamp (amber if stale).
-  if (last_sync) {
-    const ageHours = (Date.now() - new Date(last_sync).getTime()) / 3_600_000
-    const stale = ageHours > STALE_HOURS
-    const dot = stale ? '#f5a623' : '#10b981'
-    return (
-      <Pill dot={dot}
-            title="Pitchers refreshed in the latest sync (those with games in the recent 14-day window)."
-            style={stale ? { borderColor: '#f5a62355', backgroundColor: '#f5a62312', color: '#f5a623' } : { color: '#d1dce8' }}>
+  return (
+    <Pill dot={view.dot} style={view.style} title={title || undefined}>
+      <span className="flex flex-wrap items-center gap-x-2 gap-y-0.5 min-w-0">
         <span>
-          Last synced: {fmtSyncTime(last_sync)}
-          {stale && <span className="ml-1 opacity-80">· stale</span>}
+          <span className="text-chalk600 normal-case">
+            {view.syncLabel}{view.syncValue ? ':' : ''}
+          </span>
+          {view.syncValue && <span className="ml-1">{view.syncValue}</span>}
         </span>
-        {pitchers_updated != null && pitchers_updated > 0 && (
-          <span className="text-chalk600 normal-case">· {pitchers_updated.toLocaleString()} refreshed</span>
+        {view.dataLabel && view.dataValue && (
+          <span>
+            <span className="text-chalk600 normal-case">{view.dataLabel}:</span>
+            <span className="ml-1">{view.dataValue}</span>
+          </span>
         )}
-      </Pill>
-    )
-  }
+        {view.refreshed && <span className="text-chalk600 normal-case">· {view.refreshed}</span>}
+      </span>
+    </Pill>
+  )
+}
 
-  // 3) No sync has run, but data is loaded → historical snapshot (not broken).
-  if (logCount > 0 && snapshotDate) {
-    return (
-      <Pill dot="#f5a623"
-            style={{ borderColor: '#f5a62355', backgroundColor: '#f5a62312', color: '#f5a623' }}
-            title="Historical snapshot loaded — no live sync has run.">
-        <span>Snapshot · through {fmtSnapshotDate(snapshotDate)}</span>
-      </Pill>
-    )
-  }
-
-  // 4) No sync and no data.
-  return <Pill dot="#4a5568">No data loaded</Pill>
+export default function SyncStatus() {
+  const { data, loading, error } = useFetch(getSyncStatus)
+  return <SyncStatusContent data={data} loading={loading} error={error} />
 }

--- a/frontend/src/components/dashboard/syncStatusView.js
+++ b/frontend/src/components/dashboard/syncStatusView.js
@@ -1,0 +1,91 @@
+const STALE_HOURS = 36
+const MONTHS_SHORT = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+                      'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+const MONTHS_LONG = ['January', 'February', 'March', 'April', 'May', 'June',
+                     'July', 'August', 'September', 'October', 'November', 'December']
+
+export const fmtSyncDate = (iso) => {
+  if (!iso) return null
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return null
+  return `${MONTHS_LONG[d.getMonth()]} ${d.getDate()}, ${d.getFullYear()}`
+}
+
+export const fmtDataDate = (ymd) => {
+  if (!ymd) return null
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(ymd)
+  if (!m) return null
+  const [, y, mm, dd] = m
+  return `${MONTHS_SHORT[Number(mm) - 1]} ${Number(dd)}, ${y}`
+}
+
+const failedStatuses = new Set(['failed', 'error'])
+const successfulStatuses = new Set(['success', 'ok'])
+
+export function getSyncStatusView(data, { now = Date.now() } = {}) {
+  const status = data?.status
+  const latestAttempt = data?.last_sync
+  const successfulSync = data?.last_successful_sync || (successfulStatuses.has(status) ? latestAttempt : null)
+  const dataThrough = fmtDataDate(data?.data?.latest_game_date)
+  const logCount = data?.data?.game_logs
+  const limitations = data?.freshness?.limitations || []
+
+  if (failedStatuses.has(status)) {
+    return {
+      variant: 'failed',
+      dot: '#ef4444',
+      style: { borderColor: '#ef444455', backgroundColor: '#ef444412', color: '#fca5a5' },
+      syncLabel: 'Last sync failed',
+      syncValue: fmtSyncDate(latestAttempt) || 'Latest attempt failed',
+      dataLabel: dataThrough ? 'Data Through' : null,
+      dataValue: dataThrough,
+      helper: data?.message || 'Latest sync attempt failed.',
+      limitations,
+    }
+  }
+
+  if (successfulSync) {
+    const ageHours = (now - new Date(successfulSync).getTime()) / 3_600_000
+    const stale = ageHours > STALE_HOURS
+    return {
+      variant: stale ? 'stale' : 'synced',
+      dot: stale ? '#f5a623' : '#10b981',
+      style: stale
+        ? { borderColor: '#f5a62355', backgroundColor: '#f5a62312', color: '#f5a623' }
+        : { color: '#d1dce8' },
+      syncLabel: 'Synced',
+      syncValue: fmtSyncDate(successfulSync),
+      dataLabel: dataThrough ? 'Data Through' : null,
+      dataValue: dataThrough,
+      refreshed: data?.pitchers_updated > 0 ? `${data.pitchers_updated.toLocaleString()} refreshed` : null,
+      helper: stale ? 'Sync metadata is older than the freshness target.' : data?.freshness?.label,
+      limitations,
+    }
+  }
+
+  if (logCount > 0 && dataThrough) {
+    return {
+      variant: 'metadata_unavailable',
+      dot: '#f5a623',
+      style: { borderColor: '#f5a62355', backgroundColor: '#f5a62312', color: '#f5a623' },
+      syncLabel: 'Sync metadata',
+      syncValue: 'Unavailable',
+      dataLabel: 'Data Through',
+      dataValue: dataThrough,
+      helper: 'Sync metadata unavailable; data coverage is based on game logs.',
+      limitations,
+    }
+  }
+
+  return {
+    variant: 'empty',
+    dot: '#4a5568',
+    style: {},
+    syncLabel: 'No data loaded',
+    syncValue: null,
+    dataLabel: null,
+    dataValue: null,
+    helper: 'No sync metadata or game logs are available.',
+    limitations,
+  }
+}

--- a/frontend/tests/syncStatus.test.mjs
+++ b/frontend/tests/syncStatus.test.mjs
@@ -1,0 +1,128 @@
+import assert from 'node:assert/strict'
+import test, { after } from 'node:test'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { createServer } from 'vite'
+
+const server = await createServer({
+  root: process.cwd(),
+  server: { middlewareMode: true },
+  appType: 'custom',
+  logLevel: 'silent',
+})
+
+after(async () => {
+  await server.close()
+})
+
+const {
+  getSyncStatusView,
+} = await server.ssrLoadModule('/src/components/dashboard/syncStatusView.js')
+const {
+  SyncStatusContent,
+} = await server.ssrLoadModule('/src/components/dashboard/SyncStatus.jsx')
+
+const htmlIncludes = (html, text) => html.includes(text)
+const now = Date.parse('2026-06-02T12:00:00Z')
+
+test('renders sync and data-through dates when both are available', () => {
+  const data = {
+    status: 'success',
+    last_sync: '2026-06-01T21:39:12',
+    last_successful_sync: '2026-06-01T21:39:56',
+    pitchers_updated: 428,
+    data: {
+      game_logs: 35768,
+      latest_game_date: '2026-05-31',
+      latest_workload_date: '2026-05-31',
+      latest_fatigue_calculated_at: '2026-06-01T21:39:55',
+    },
+    freshness: { is_current: true, label: 'Current baseball data through 2026-05-31.', limitations: [] },
+  }
+
+  const view = getSyncStatusView(data, { now })
+  const html = renderToStaticMarkup(
+    React.createElement(SyncStatusContent, { data, loading: false, error: null, now }),
+  )
+
+  assert.equal(view.syncLabel, 'Synced')
+  assert.equal(view.syncValue, 'June 1, 2026')
+  assert.equal(view.dataLabel, 'Data Through')
+  assert.equal(view.dataValue, 'May 31, 2026')
+  assert.ok(htmlIncludes(html, 'Synced:'))
+  assert.ok(htmlIncludes(html, 'June 1, 2026'))
+  assert.ok(htmlIncludes(html, 'Data Through:'))
+  assert.ok(htmlIncludes(html, 'May 31, 2026'))
+})
+
+test('renders sync metadata unavailable with data-through date', () => {
+  const data = {
+    status: 'metadata_unavailable',
+    last_sync: null,
+    last_successful_sync: null,
+    data: {
+      game_logs: 35768,
+      latest_game_date: '2026-05-31',
+    },
+    freshness: {
+      is_current: true,
+      label: 'Current baseball data through 2026-05-31.',
+      limitations: ['Sync metadata unavailable; data coverage is based on game logs.'],
+    },
+  }
+
+  const html = renderToStaticMarkup(
+    React.createElement(SyncStatusContent, { data, loading: false, error: null, now }),
+  )
+
+  assert.ok(htmlIncludes(html, 'Sync metadata:'))
+  assert.ok(htmlIncludes(html, 'Unavailable'))
+  assert.ok(htmlIncludes(html, 'Data Through:'))
+  assert.ok(htmlIncludes(html, 'May 31, 2026'))
+})
+
+test('renders failed sync while preserving data-through date', () => {
+  const data = {
+    status: 'failed',
+    last_sync: '2026-06-02T10:00:00',
+    last_successful_sync: '2026-06-01T21:39:56',
+    message: 'MLB API unavailable',
+    data: {
+      game_logs: 35768,
+      latest_game_date: '2026-05-31',
+    },
+    freshness: {
+      is_current: true,
+      label: 'Current baseball data through 2026-05-31.',
+      limitations: ['The latest sync attempt failed; data may reflect an earlier successful sync.'],
+    },
+  }
+
+  const html = renderToStaticMarkup(
+    React.createElement(SyncStatusContent, { data, loading: false, error: null, now }),
+  )
+
+  assert.ok(htmlIncludes(html, 'Last sync failed:'))
+  assert.ok(htmlIncludes(html, 'June 2, 2026'))
+  assert.ok(htmlIncludes(html, 'Data Through:'))
+  assert.ok(htmlIncludes(html, 'May 31, 2026'))
+})
+
+test('renders no data loaded when metadata and data are unavailable', () => {
+  const html = renderToStaticMarkup(
+    React.createElement(SyncStatusContent, {
+      data: {
+        status: 'never',
+        last_sync: null,
+        last_successful_sync: null,
+        data: { game_logs: 0, latest_game_date: null },
+        freshness: { is_current: false, label: 'No baseball workload data loaded.', limitations: [] },
+      },
+      loading: false,
+      error: null,
+      now,
+    }),
+  )
+
+  assert.ok(htmlIncludes(html, 'No data loaded'))
+})


### PR DESCRIPTION
Persist sync run metadata in the database, expose durable sync and data freshness fields in the sync status API, separate dashboard synced/data-through labels, and add regression coverage.