### PR TITLE
feat: polish dashboard trust strip

### DIFF
--- a/frontend/docs/dashboard_trust_strip_polish.md
+++ b/frontend/docs/dashboard_trust_strip_polish.md
@@ -1,0 +1,108 @@
+# Dashboard Trust Strip Polish
+
+## Scope
+
+This polish changes only dashboard trust and freshness presentation. It does not
+change sync logic, fatigue scoring, availability classification,
+recommendations, APIs, or database schema.
+
+## Before
+
+The dashboard hero displayed the season badge and sync metadata in the same
+compact row:
+
+```text
+LIVE - 2026 SEASON
+Synced: June 1, 2026
+Data Through: May 31, 2026
+428 refreshed
+```
+
+The information was correct, but the trust signals were visually compressed and
+easy to scan past.
+
+## After
+
+The hero now keeps the season badge focused on platform context, while a
+dedicated trust strip sits directly below the hero:
+
+```text
+DATA STATUS: HEALTHY
+
+Synced:
+June 1, 2026
+
+Data Through:
+May 31, 2026
+
+Refresh Coverage:
+428 Pitchers Refreshed
+```
+
+The strip also supports lower-trust states without hiding data:
+
+```text
+DATA STATUS: LIMITED
+Sync metadata: Unavailable
+Data Through: May 31, 2026
+Refresh Coverage: Not reported
+```
+
+```text
+DATA STATUS: STALE
+Synced: May 30, 2026
+Data Through: May 31, 2026
+Refresh Coverage: 429 Pitchers Refreshed
+```
+
+## Layout Rationale
+
+- The trust strip is full-width within the dashboard content column so it reads
+  as operational context for the entire dashboard, not as a small badge.
+- It uses the existing BaseballOS palette: dugout/chalk surfaces, dirt borders,
+  pine for healthy, amber for limited or stale, and red for failed sync states.
+- It stays compact and information-dense: one status marker, three short
+  metrics, and an optional helper line.
+- It remains visually subordinate to the hero and avoids large-card treatment,
+  motion, or high-saturation styling.
+
+## Trust Messaging Rationale
+
+The strip separates four trust questions:
+
+| Question | Strip Field |
+| --- | --- |
+| Is the platform data state healthy, limited, or stale? | `DATA STATUS` |
+| When was the system last synced? | `Synced` or sync-state label |
+| What baseball data date does the dashboard represent? | `Data Through` |
+| How much workload data was refreshed? | `Refresh Coverage` |
+
+The health label is derived only from existing sync status, freshness metadata,
+and limitation fields:
+
+- `Healthy`: successful, current sync metadata with no freshness limitation.
+- `Limited`: failed, unavailable, missing, or freshness-limited metadata.
+- `Stale`: successful sync metadata older than the existing freshness target.
+
+No new business logic or backend data source is introduced.
+
+## Responsive Behavior
+
+- Desktop: status marker and three trust metrics render in one compact row.
+- Tablet: the strip keeps the same hierarchy while allowing the metric row to
+  wrap within the available width.
+- Mobile: the strip stacks the status and metrics vertically, preserving label
+  and value pairing without horizontal scrolling.
+
+## Validation Notes
+
+Frontend tests cover:
+
+- healthy trust strip rendering
+- stale trust strip rendering
+- metadata-unavailable fallback rendering
+- failed sync with preserved data-through date
+- successful sync without a data-through date
+- no metadata and no data
+
+Local browser validation covered desktop, tablet, and mobile widths.

--- a/frontend/src/components/dashboard/Dashboard.jsx
+++ b/frontend/src/components/dashboard/Dashboard.jsx
@@ -80,12 +80,14 @@ export default function Dashboard() {
             </p>
             <div className="mt-4 flex flex-wrap items-center gap-3">
               <SeasonBanner season={seasonInfo.season} isLive={seasonInfo.isLive} />
-              <SyncStatus />
             </div>
           </div>
           <div className="hidden sm:block absolute right-8 top-1/2 -translate-y-1/2 opacity-5">
             <div className="font-display text-[120px] tracking-widest text-white leading-none select-none">⚾</div>
           </div>
+        </div>
+        <div className="mt-3">
+          <SyncStatus />
         </div>
       </div>
 

--- a/frontend/src/components/dashboard/SyncStatus.jsx
+++ b/frontend/src/components/dashboard/SyncStatus.jsx
@@ -2,46 +2,101 @@ import { useFetch } from '../../hooks/useFetch'
 import { getSyncStatus } from '../../utils/api'
 import { getSyncStatusView } from './syncStatusView'
 
-const Pill = ({ dot, style = {}, title, children }) => (
-  <div
-    className="inline-flex items-center gap-2 px-3 py-1 rounded-md border text-[11px] font-mono max-w-full"
-    style={{ borderColor: '#242b35', backgroundColor: 'rgba(26,31,38,0.4)', ...style }}
-    title={title}
-  >
-    <span className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: dot }} />
-    {children}
+const Metric = ({ label, value, muted = false }) => (
+  <div className="min-w-0">
+    <div className="text-[10px] uppercase tracking-widest text-chalk600">{label}:</div>
+    <div className={`mt-1 break-words text-sm leading-snug ${muted ? 'text-chalk600' : 'text-chalk200'}`}>
+      {value}
+    </div>
   </div>
 )
 
+const TrustStrip = ({ dot, style = {}, title, status, metrics, helper }) => {
+  const stripStyle = {
+    borderColor: style.borderColor || '#242b35',
+    backgroundColor: style.backgroundColor || 'rgba(26,31,38,0.44)',
+    color: style.color || '#d1dce8',
+  }
+
+  return (
+    <section
+      className="w-full rounded-lg border px-4 py-3 sm:px-5 font-mono"
+      style={stripStyle}
+      title={title}
+      aria-label="Dashboard data trust status"
+    >
+      <div className="grid gap-4 lg:grid-cols-[minmax(180px,0.75fr)_2.25fr] lg:items-center">
+        <div className="flex min-w-0 items-center gap-2">
+          <span className="h-2 w-2 rounded-full flex-none" style={{ backgroundColor: dot }} />
+          <div className="min-w-0 text-xs uppercase tracking-widest">
+            <span className="text-chalk600">Data Status:</span>{' '}
+            <span className="font-semibold">{status}</span>
+          </div>
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-3">
+          {metrics.map((metric) => (
+            <Metric key={metric.label} {...metric} />
+          ))}
+        </div>
+      </div>
+      {helper && (
+        <div className="mt-3 border-t border-dirt/70 pt-2 text-[11px] leading-relaxed text-chalk400">
+          {helper}
+        </div>
+      )}
+    </section>
+  )
+}
+
 export function SyncStatusContent({ data, loading, error, now }) {
   if (loading) {
-    return <Pill dot="#8899aa"><span className="animate-pulse">Checking sync…</span></Pill>
+    return (
+      <TrustStrip
+        dot="#8899aa"
+        status="Checking"
+        metrics={[
+          { label: 'Synced', value: 'Checking sync status', muted: true },
+          { label: 'Data Through', value: 'Checking data coverage', muted: true },
+          { label: 'Refresh Coverage', value: 'Checking refresh count', muted: true },
+        ]}
+      />
+    )
   }
   if (error) {
-    return <Pill dot="#4a5568">Sync status unavailable</Pill>
+    return (
+      <TrustStrip
+        dot="#4a5568"
+        status="Limited"
+        helper="Sync status unavailable."
+        metrics={[
+          { label: 'Synced', value: 'Unavailable', muted: true },
+          { label: 'Data Through', value: 'Unavailable', muted: true },
+          { label: 'Refresh Coverage', value: 'Unavailable', muted: true },
+        ]}
+      />
+    )
   }
 
   const view = getSyncStatusView(data, now ? { now } : undefined)
   const title = [view.helper, ...view.limitations].filter(Boolean).join(' ')
+  const syncValue = view.syncValue || (view.syncLabel === 'No data loaded' ? 'No data loaded' : 'Unavailable')
+  const dataValue = view.dataValue || 'Unavailable'
+  const coverageValue = view.coverageValue || 'Not reported'
 
   return (
-    <Pill dot={view.dot} style={view.style} title={title || undefined}>
-      <span className="flex flex-wrap items-center gap-x-2 gap-y-0.5 min-w-0">
-        <span>
-          <span className="text-chalk600 normal-case">
-            {view.syncLabel}{view.syncValue ? ':' : ''}
-          </span>
-          {view.syncValue && <span className="ml-1">{view.syncValue}</span>}
-        </span>
-        {view.dataLabel && view.dataValue && (
-          <span>
-            <span className="text-chalk600 normal-case">{view.dataLabel}:</span>
-            <span className="ml-1">{view.dataValue}</span>
-          </span>
-        )}
-        {view.refreshed && <span className="text-chalk600 normal-case">· {view.refreshed}</span>}
-      </span>
-    </Pill>
+    <TrustStrip
+      dot={view.dot}
+      style={view.style}
+      title={title || undefined}
+      status={view.healthLabel}
+      helper={view.helper}
+      metrics={[
+        { label: view.syncLabel === 'No data loaded' ? 'Synced' : view.syncLabel, value: syncValue, muted: !view.syncValue },
+        { label: view.dataLabel || 'Data Through', value: dataValue, muted: !view.dataValue },
+        { label: 'Refresh Coverage', value: coverageValue, muted: !view.coverageValue },
+      ]}
+    />
   )
 }
 

--- a/frontend/src/components/dashboard/syncStatusView.js
+++ b/frontend/src/components/dashboard/syncStatusView.js
@@ -29,16 +29,21 @@ export function getSyncStatusView(data, { now = Date.now() } = {}) {
   const dataThrough = fmtDataDate(data?.data?.latest_game_date)
   const logCount = data?.data?.game_logs
   const limitations = data?.freshness?.limitations || []
+  const coverageValue = data?.pitchers_updated > 0
+    ? `${data.pitchers_updated.toLocaleString()} Pitchers Refreshed`
+    : null
 
   if (failedStatuses.has(status)) {
     return {
       variant: 'failed',
+      healthLabel: 'Limited',
       dot: '#ef4444',
       style: { borderColor: '#ef444455', backgroundColor: '#ef444412', color: '#fca5a5' },
       syncLabel: 'Last sync failed',
       syncValue: fmtSyncDate(latestAttempt) || 'Latest attempt failed',
       dataLabel: dataThrough ? 'Data Through' : null,
       dataValue: dataThrough,
+      coverageValue,
       helper: data?.message || 'Latest sync attempt failed.',
       limitations,
     }
@@ -47,17 +52,22 @@ export function getSyncStatusView(data, { now = Date.now() } = {}) {
   if (successfulSync) {
     const ageHours = (now - new Date(successfulSync).getTime()) / 3_600_000
     const stale = ageHours > STALE_HOURS
+    const limited = data?.freshness?.is_current === false || limitations.length > 0
     return {
-      variant: stale ? 'stale' : 'synced',
-      dot: stale ? '#f5a623' : '#10b981',
+      variant: stale ? 'stale' : (limited ? 'limited' : 'synced'),
+      healthLabel: stale ? 'Stale' : (limited ? 'Limited' : 'Healthy'),
+      dot: stale || limited ? '#f5a623' : '#10b981',
       style: stale
         ? { borderColor: '#f5a62355', backgroundColor: '#f5a62312', color: '#f5a623' }
+        : limited
+          ? { borderColor: '#f5a62355', backgroundColor: '#f5a62312', color: '#f5a623' }
         : { color: '#d1dce8' },
       syncLabel: 'Synced',
       syncValue: fmtSyncDate(successfulSync),
       dataLabel: dataThrough ? 'Data Through' : null,
       dataValue: dataThrough,
-      refreshed: data?.pitchers_updated > 0 ? `${data.pitchers_updated.toLocaleString()} refreshed` : null,
+      coverageValue,
+      refreshed: coverageValue,
       helper: stale ? 'Sync metadata is older than the freshness target.' : data?.freshness?.label,
       limitations,
     }
@@ -66,12 +76,14 @@ export function getSyncStatusView(data, { now = Date.now() } = {}) {
   if (logCount > 0 && dataThrough) {
     return {
       variant: 'metadata_unavailable',
+      healthLabel: 'Limited',
       dot: '#f5a623',
       style: { borderColor: '#f5a62355', backgroundColor: '#f5a62312', color: '#f5a623' },
       syncLabel: 'Sync metadata',
       syncValue: 'Unavailable',
       dataLabel: 'Data Through',
       dataValue: dataThrough,
+      coverageValue,
       helper: 'Sync metadata unavailable; data coverage is based on game logs.',
       limitations,
     }
@@ -79,12 +91,14 @@ export function getSyncStatusView(data, { now = Date.now() } = {}) {
 
   return {
     variant: 'empty',
+    healthLabel: 'Limited',
     dot: '#4a5568',
     style: {},
     syncLabel: 'No data loaded',
     syncValue: null,
     dataLabel: null,
     dataValue: null,
+    coverageValue,
     helper: 'No sync metadata or game logs are available.',
     limitations,
   }

--- a/frontend/tests/syncStatus.test.mjs
+++ b/frontend/tests/syncStatus.test.mjs
@@ -49,10 +49,16 @@ test('renders sync and data-through dates when both are available', () => {
   assert.equal(view.syncValue, 'June 1, 2026')
   assert.equal(view.dataLabel, 'Data Through')
   assert.equal(view.dataValue, 'May 31, 2026')
+  assert.equal(view.healthLabel, 'Healthy')
+  assert.equal(view.coverageValue, '428 Pitchers Refreshed')
+  assert.ok(htmlIncludes(html, 'Data Status:'))
+  assert.ok(htmlIncludes(html, 'Healthy'))
   assert.ok(htmlIncludes(html, 'Synced:'))
   assert.ok(htmlIncludes(html, 'June 1, 2026'))
   assert.ok(htmlIncludes(html, 'Data Through:'))
   assert.ok(htmlIncludes(html, 'May 31, 2026'))
+  assert.ok(htmlIncludes(html, 'Refresh Coverage:'))
+  assert.ok(htmlIncludes(html, '428 Pitchers Refreshed'))
 })
 
 test('renders sync metadata unavailable with data-through date', () => {
@@ -75,10 +81,38 @@ test('renders sync metadata unavailable with data-through date', () => {
     React.createElement(SyncStatusContent, { data, loading: false, error: null, now }),
   )
 
+  const view = getSyncStatusView(data, { now })
+  assert.equal(view.healthLabel, 'Limited')
   assert.ok(htmlIncludes(html, 'Sync metadata:'))
   assert.ok(htmlIncludes(html, 'Unavailable'))
   assert.ok(htmlIncludes(html, 'Data Through:'))
   assert.ok(htmlIncludes(html, 'May 31, 2026'))
+})
+
+test('labels old sync metadata as stale without changing freshness logic', () => {
+  const data = {
+    status: 'success',
+    last_sync: '2026-05-30T05:00:00',
+    last_successful_sync: '2026-05-30T05:00:00',
+    pitchers_updated: 429,
+    data: {
+      game_logs: 35768,
+      latest_game_date: '2026-05-31',
+      latest_workload_date: '2026-05-31',
+      latest_fatigue_calculated_at: '2026-05-30T05:00:00',
+    },
+    freshness: { is_current: true, label: 'Current baseball data through 2026-05-31.', limitations: [] },
+  }
+
+  const view = getSyncStatusView(data, { now })
+  const html = renderToStaticMarkup(
+    React.createElement(SyncStatusContent, { data, loading: false, error: null, now }),
+  )
+
+  assert.equal(view.healthLabel, 'Stale')
+  assert.ok(htmlIncludes(html, 'Data Status:'))
+  assert.ok(htmlIncludes(html, 'Stale'))
+  assert.ok(htmlIncludes(html, '429 Pitchers Refreshed'))
 })
 
 test('renders successful sync without a data-through date', () => {
@@ -106,7 +140,8 @@ test('renders successful sync without a data-through date', () => {
 
   assert.ok(htmlIncludes(html, 'Synced:'))
   assert.ok(htmlIncludes(html, 'June 1, 2026'))
-  assert.equal(htmlIncludes(html, 'Data Through:'), false)
+  assert.ok(htmlIncludes(html, 'Data Through:'))
+  assert.ok(htmlIncludes(html, 'Unavailable'))
 })
 
 test('renders failed sync while preserving data-through date', () => {


### PR DESCRIPTION
Adds a dedicated dashboard trust strip for data status, sync date, data-through date, and refresh coverage.

Documents the layout rationale and expands frontend coverage for healthy, stale, and fallback trust states.