### PR TITLE
docs: update availability and trust foundation state

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,27 +35,55 @@ Everything here is implemented and runs against real MLB Stats API data:
 - **Fatigue scoring engine** — a deterministic 0–100 workload heuristic from four factors the
   MLB Stats API exposes reliably: pitch-count load (35%), rest days (30%), appearance
   frequency (20%), innings load (15%). Continuous and monotonic across thresholds.
+- **Availability Engine V1** — deterministic bullpen availability statuses
+  (`Available`, `Monitor`, `Limited`, `Avoid`, `Unavailable`) derived from existing
+  workload, fatigue, rest, and freshness data.
+- **Availability explainability** — every non-Available status carries ordered reasons,
+  confidence, data state, limitations, and deterministic inputs; labels are not black boxes.
+- **Dashboard availability summary** — current-mode availability distributions, confidence
+  counts, and stale/missing-data notes are visible from the dashboard.
 - **MLB Stats API ingestion** — pulls rosters and game-by-game pitching logs; idempotent
   (skips duplicates, enforced at the database level).
 - **Pitcher detail workflow** — per-pitcher view with score, risk tier, weighted component
-  breakdown, component radar, fatigue trend, and recent appearances — on desktop **and**
-  mobile.
+  breakdown, component radar, fatigue trend, recent appearances, availability status,
+  confidence, reasons, and limitations — on desktop **and** mobile.
 - **Team bullpen views** — per-team bullpen overview and team-vs-team workload rankings.
-- **Sync freshness visibility** — the dashboard pill shows the real state: last synced,
-  failed, historical snapshot, or no data.
+- **Trust strip and sync freshness visibility** — the dashboard separates platform data
+  status, last successful sync, baseball data-through date, and refresh coverage.
+- **Durable sync metadata** — sync attempts persist in the `sync_runs` table so successful,
+  failed, and missing metadata states survive restarts and deployments.
 - **Current-season coverage transparency** — the dashboard distinguishes total tracked
   pitchers, pitchers with computed workload data, and pitchers refreshed in the latest sync,
   so coverage gaps are visible rather than hidden.
+- **Freshness-aware bullpen visibility** — active/current data is the default; stale or
+  inactive pitchers remain inspectable without being presented as current availability.
 - **External scheduled sync** — a GitHub Actions workflow refreshes data daily via the
   protected backend endpoint.
 - **Protected operational endpoints** — sync and fatigue-recalculation are admin-token
   gated; all read endpoints stay public.
 - **Methodology page** — public, in-app documentation of the model, weights, and limitations.
+- **Availability governance framework** — threshold audits, snapshot validation, boundary
+  review, and adoption reports document how status thresholds are changed.
 - **Backend test coverage** — unit + integration tests for the scoring engine, the
-  admin-token guard, the game-log uniqueness constraint, and the sync-status endpoint.
+  availability engine, admin-token guard, game-log uniqueness constraint, sync-status
+  endpoint, and threshold audit tools.
 - **Data integrity** — a database unique constraint makes duplicate game logs impossible.
 - **Production config hardening** — environment-driven config with fail-fast checks before a
   hosted launch.
+
+## Platform Status
+
+| Capability | Status |
+|------------|--------|
+| Bullpen Intelligence | ✓ Complete |
+| Fatigue Engine | ✓ Complete |
+| Availability Engine | ✓ Complete |
+| Explainability | ✓ Complete |
+| Trust Layer | ✓ Complete |
+| Freshness Transparency | ✓ Complete |
+| Governance Framework | ✓ Complete |
+| Recommendation Engine | Planned |
+| Prospect Pipeline | Prototype |
 
 ## Trust & Transparency
 
@@ -68,6 +96,12 @@ BaseballOS is built to earn a reviewer's trust rather than ask for it:
   limitations, never as causation or validation.
 - **Freshness is always visible** — you can see when data was last synced (or that it's a
   historical snapshot) instead of guessing.
+- **Synced and Data Through are distinct** — sync timestamps come from durable sync metadata;
+  baseball coverage dates come from workload/game-log data.
+- **Availability labels are explainable** — status badges are paired with confidence, data
+  state, reasons, and limitations.
+- **Threshold changes are governed** — the first adopted change raised the Unavailable
+  three-day pitch threshold from 80 to 90 after audit, experiment, and boundary review.
 - **Coverage is explicit** — tracked vs. workload-data vs. refreshed counts are labeled
   distinctly so gaps aren't mistaken for bugs.
 - **Write operations are protected** — only an admin token can trigger sync/recalculation.
@@ -104,11 +138,11 @@ a sync — only the scheduled workflow (or a manual admin call) does. See
 Direction, not promises — these are where the platform is headed, not features that exist
 today:
 
-- Bullpen **availability engine** (who is usable today, and at what workload cost)
+- **Recommendation Engine V1 Policy** — the next major milestone. The goal is to move
+  BaseballOS from availability intelligence to decision-support intelligence while keeping
+  recommendation wording bounded by public workload data and explicit limitations.
 - Usage **simulator** and bullpen **planning dashboard**
 - **Role-aware** fatigue (separating starters from relievers)
-- A **recommendation** layer for staff decisions
-- Trust infrastructure (a DB-backed sync ledger for durable freshness history)
 - **Reports / exports** and a documented **API platform**
 - Real minor-league prospect ingestion with a defensible grade/ETA source
 
@@ -126,12 +160,13 @@ bullpen-intel-engine/
 │   ├── seed.py                  # Seeds pitchers, game logs, fatigue scores (+ sample prospects)
 │   ├── recalculate_fatigue.py   # Recompute fatigue from historical reference dates
 │   ├── api/                     # Route blueprints (bullpen, prospects, methodology)
-│   ├── models/                  # SQLAlchemy models (pitcher, game_log, fatigue_score, prospect)
-│   ├── services/                # mlb_api · fatigue (scoring engine) · sync
+│   ├── models/                  # SQLAlchemy models (incl. sync_run metadata)
+│   ├── services/                # mlb_api · fatigue · availability · sync metadata
 │   ├── utils/                   # db.py · auth.py (admin-token guard)
 │   ├── analysis/                # Out-of-band retrospective fatigue→ERA analysis
 │   ├── migrations/              # Alembic migrations (incl. game-log uniqueness)
-│   └── tests/                   # pytest: fatigue, auth, game-log constraint, sync status
+│   ├── reports/                 # Audit, threshold, freshness, and readiness reports
+│   └── tests/                   # pytest coverage for fatigue, availability, sync, audits
 ├── frontend/                    # React + Vite app
 │   ├── .env.example             # Frontend env template
 │   └── src/
@@ -139,6 +174,9 @@ bullpen-intel-engine/
 │       ├── hooks/
 │       └── utils/               # API client, formatters, shared fatigue-model definitions
 └── docs/
+    ├── PROJECT_STATE_2026_06.md # Current product state and next milestone
+    ├── BULLPEN_AVAILABILITY_ENGINE_V1.md
+    ├── AVAILABILITY_THRESHOLD_TUNING_PLAN.md
     └── SETUP.md                 # Full setup, env reference, and deployment notes
 ```
 
@@ -221,16 +259,27 @@ BaseballOS is an independent project and is not affiliated with or endorsed by M
 
 ## Documentation
 
+- [`docs/PROJECT_STATE_2026_06.md`](docs/PROJECT_STATE_2026_06.md) — current
+  product state after the Availability Engine trust foundation.
+- [`docs/BULLPEN_AVAILABILITY_ENGINE_V1.md`](docs/BULLPEN_AVAILABILITY_ENGINE_V1.md)
+  — status definitions, implemented classifier contract, UI presentation, trust
+  rules, and non-goals.
+- [`docs/AVAILABILITY_THRESHOLD_TUNING_PLAN.md`](docs/AVAILABILITY_THRESHOLD_TUNING_PLAN.md)
+  — governance process and current threshold baseline.
 - [`docs/SETUP.md`](docs/SETUP.md) — local setup, environment variables, troubleshooting,
   deployment notes, and the automated-sync guide.
+- [`frontend/docs/dashboard_trust_strip_polish.md`](frontend/docs/dashboard_trust_strip_polish.md)
+  — dashboard trust strip layout and messaging rationale.
 - **In-app Methodology page** — how the fatigue model works, its weights, and its limitations.
 
 ## Roadmap
 
-Near-term focus is depth on the bullpen engine and hardening for a public hosted demo. Beyond
-that, see **Product Direction** above — availability/usage intelligence, role-aware fatigue,
-decision support, durable freshness history, and exports/API — pursued in honest order, with
-prototype features labeled as such until they're real.
+The next major milestone is **Recommendation Engine V1 Policy**: defining how BaseballOS
+should move from availability intelligence to decision-support intelligence without
+pretending to know private clubhouse, medical, travel, or manager-intent information.
+Beyond that, see **Product Direction** above — usage simulation, role-aware fatigue,
+exports/API, and real prospect ingestion — pursued in honest order, with prototype features
+labeled as such until they're real.
 
 ## Author
 

--- a/docs/BULLPEN_AVAILABILITY_ENGINE_V1.md
+++ b/docs/BULLPEN_AVAILABILITY_ENGINE_V1.md
@@ -21,6 +21,29 @@ This is not a private clubhouse availability feed and not a medical model. V1
 is a public-data workload framework built from BaseballOS data: MLB Stats API
 game logs, existing fatigue scores, rest context, and data freshness state.
 
+## Current State: June 2026
+
+Availability Engine V1 is implemented as a completed trust foundation:
+
+- Backend classification service is live and reusable outside route handlers.
+- Fatigue, team bullpen, pitcher detail, and dashboard overview APIs expose
+  additive availability output.
+- Bullpen rows, filters, pitcher detail views, and dashboard summary surfaces
+  present availability without reclassifying in the frontend.
+- Explanations, confidence, data state, limitations, and deterministic inputs
+  are part of the contract.
+- Fixture coverage verifies all five statuses even when live local data does
+  not naturally contain every status.
+- Threshold audit, snapshot validation, boundary review, and tuning governance
+  are documented and tested.
+- The first governed threshold adoption raised the Unavailable three-day pitch
+  threshold from 80 to 90 after audit and boundary review.
+
+The next product milestone is not another threshold change. It is
+Recommendation Engine V1 Policy: defining how BaseballOS should move from
+availability intelligence to decision-support intelligence without implying
+private team, medical, travel, or manager-intent knowledge.
+
 ## Availability Statuses
 
 Availability labels are workload guidance, not commands. They should be shown
@@ -558,9 +581,10 @@ V1 deliberately defers:
 - Warm-up tracking or bullpen phone activity.
 - Travel, weather, and personal availability context.
 
-## Implementation Roadmap
+## V1 Foundation Sequence And Future Compatibility
 
-Future work should be split into small reviewable branches:
+The V1 foundation was built in small reviewable branches. Completed foundation
+work:
 
 1. **Backend status classification helper**
    - Add a pure deterministic helper that accepts fatigue score, game-log
@@ -591,21 +615,30 @@ Future work should be split into small reviewable branches:
    - Update setup/product docs with the status definitions and trust framing.
    - Link to methodology once the engine is implemented.
 
+Future compatibility work remains:
+
 7. **Future simulator compatibility**
    - Keep the classifier input shape compatible with hypothetical usage
      scenarios, such as "if used for 20 pitches tonight."
    - Do not build the simulator in V1.
 
-## Acceptance Criteria For This Design Branch
+## Current V1 Foundation Completion Criteria
 
-This branch is complete when:
+The V1 trust foundation is complete when:
 
-- This design document exists under `docs/`.
 - The five workload statuses are defined.
 - Initial deterministic inputs are listed.
-- The explainability contract is documented.
+- The backend classifier returns status, confidence, data state, reasons,
+  limitations, and inputs.
+- API availability output is additive and backward-compatible.
+- Bullpen and pitcher detail UI display status, confidence, data state,
+  reasons, and limitations.
+- Dashboard availability summary makes stale/missing-data dominance visible.
+- Explanation quality standards are documented and audited.
 - Trust rules are documented.
 - Edge cases are documented.
 - V1 non-goals are explicit.
-- Future implementation branches are clearly sequenced.
-- No engine logic or production endpoint behavior is changed.
+- Threshold governance and baseline artifacts exist.
+- The first governed threshold adoption is documented.
+- Durable sync metadata and dashboard trust-strip documentation distinguish
+  `Synced` from `Data Through`.

--- a/docs/PROJECT_STATE_2026_06.md
+++ b/docs/PROJECT_STATE_2026_06.md
@@ -1,0 +1,248 @@
+# Project State: June 2026
+
+## Executive Summary
+
+BaseballOS has completed the Availability Engine trust foundation. The platform
+now moves beyond a fatigue dashboard into explainable bullpen availability
+intelligence while preserving clear limits around what public workload data can
+and cannot prove.
+
+The current product identity is:
+
+```text
+BaseballOS: trust-first bullpen intelligence for workload, availability, and
+freshness-aware decision support.
+```
+
+The repository remains `bullpen-intel-engine`. Repository structures, package
+names, imports, and deployment configuration should not be renamed solely for
+branding.
+
+## Completed Foundations
+
+### Bullpen Intelligence
+
+BaseballOS ingests MLB Stats API rosters and pitching game logs, computes
+fatigue scores, and exposes team, pitcher, and dashboard workload views.
+
+### Fatigue Engine
+
+The Fatigue Engine remains the deterministic workload base. It produces a
+transparent 0-100 workload score from pitch-count load, rest days, appearance
+frequency, and innings load.
+
+### Availability Engine V1
+
+Availability Engine V1 is implemented. It translates fatigue, rest, recent
+workload, appearance compression, and data state into:
+
+- `Available`
+- `Monitor`
+- `Limited`
+- `Avoid`
+- `Unavailable`
+
+The classifier is centralized in the backend availability service and is not
+embedded directly in routes. API responses remain backward-compatible by adding
+availability objects rather than replacing fatigue fields.
+
+### Explainability
+
+Availability output includes:
+
+- status
+- confidence
+- data state
+- reasons
+- limitations
+- deterministic inputs
+
+Every non-Available classification must expose reasons. Missing, stale, or
+incomplete data must lower confidence, alter display, or make limitations
+visible.
+
+### Dashboard Integration
+
+The dashboard now includes:
+
+- current-mode availability summary
+- status distribution
+- confidence distribution
+- data-state distribution
+- stale/missing-data trust notes
+- dashboard trust strip for data status, sync date, data-through date, and
+  refresh coverage
+
+### Status Reachability
+
+Frontend fixture coverage verifies that all five availability statuses render
+correctly even when the current local dataset does not naturally contain all
+statuses at once. Fixture validation is for UI correctness only, not threshold
+validation.
+
+### Governance Framework
+
+Availability threshold governance is implemented through:
+
+- repeatable threshold audit tooling
+- latest-workload snapshot validation mode
+- explanation quality audit
+- threshold tuning plan
+- boundary review process
+- adoption records
+- readiness certification reports
+
+Threshold changes must be evidence-based, single-variable where possible, and
+reviewed before adoption.
+
+## Current Capabilities
+
+| Capability | Status |
+| --- | --- |
+| Bullpen Intelligence | ✓ Complete |
+| Fatigue Engine | ✓ Complete |
+| Availability Engine | ✓ Complete |
+| Explainability | ✓ Complete |
+| Trust Layer | ✓ Complete |
+| Freshness Transparency | ✓ Complete |
+| Governance Framework | ✓ Complete |
+| Recommendation Engine | Planned |
+| Prospect Pipeline | Prototype |
+
+## Trust & Governance Status
+
+Trust-first rules currently in force:
+
+- No black-box availability labels.
+- Every status must expose reasons when workload or data-state constraints are
+  present.
+- Stale data must not be presented as current availability.
+- Missing data must reduce confidence or alter display.
+- `Unavailable` means workload-unavailable from public data, not injured,
+  medically unavailable, or team-reported unavailable.
+- Recommendation wording must not imply private clubhouse, medical, travel, or
+  manager-intent knowledge.
+- Threshold changes require audit evidence and before/after comparison.
+
+The first governed threshold adoption is complete:
+
+```text
+Unavailable 3-day pitch threshold: 80 -> 90
+```
+
+This adoption allows 80-89 pitches in three days to classify as `Avoid` unless
+another Unavailable rule fires. 90+ pitches in three days remains
+`Unavailable`.
+
+Reference artifacts:
+
+- `docs/AVAILABILITY_THRESHOLD_TUNING_PLAN.md`
+- `backend/reports/availability_threshold_adoption_candidate_c.md`
+- `backend/reports/availability_unavailable_boundary_review.md`
+- `backend/reports/availability_post_adoption_readiness_certification.md`
+
+## Freshness & Sync Status
+
+Durable sync metadata is implemented through the `sync_runs` persistence model.
+The backend can separately expose:
+
+- last sync attempt
+- last successful sync
+- latest baseball game-log date
+- latest workload date
+- latest fatigue calculation timestamp
+- sync status
+- freshness limitations
+
+The dashboard distinguishes:
+
+```text
+Synced:
+June 1, 2026
+
+Data Through:
+May 31, 2026
+```
+
+This distinction matters because a sync timestamp is operational metadata, while
+data-through date is baseball data coverage. BaseballOS should never substitute
+one for the other.
+
+If sync metadata is unavailable but data exists, the dashboard should say so and
+still show the data-through date. If the latest sync fails, the dashboard should
+preserve the latest known data-through date and disclose the failed sync state.
+
+Reference artifacts:
+
+- `backend/reports/durable_sync_metadata_implementation.md`
+- `backend/reports/durable_sync_metadata_deployment_certification.md`
+- `frontend/docs/dashboard_trust_strip_polish.md`
+
+## Availability Engine Status
+
+Availability Engine V1 is complete as a deterministic, explainable
+classification framework. Current public UI surfaces consume backend output
+instead of recreating classification logic in the browser.
+
+Implemented public-facing surfaces:
+
+- bullpen row availability badges
+- availability filter
+- pitcher detail availability summary
+- dashboard availability summary
+- dashboard data trust strip
+
+Implemented validation/governance surfaces:
+
+- frontend fixtures for all five statuses
+- backend status tests
+- stale and missing data tests
+- threshold audit
+- snapshot validation
+- explanation audit
+- boundary review tooling
+- adoption reports
+
+The Availability Engine remains bounded by public workload data. It does not
+claim team-reported availability, injury status, warm-up activity, travel
+status, or manager intent.
+
+## Known Limitations
+
+- No injury, transaction/news, or team-reported availability feed is integrated.
+- No private clubhouse, medical, travel, or manager-intent data is available.
+- No Statcast, Hawk-Eye biomechanics, Stuff+, or pitch-quality modeling is used.
+- Role-aware starter/reliever handling remains limited.
+- Warm-up workload and bullpen phone activity are not modeled.
+- Prospect Pipeline remains a prototype with sample data, not a live
+  minor-league data product.
+- Recommendation Engine V1 is not implemented yet.
+- Latest-workload snapshot mode is validation/admin only and must not be treated
+  as current availability.
+
+## Next Major Milestone
+
+The next major initiative is:
+
+```text
+Recommendation Engine V1 Policy
+```
+
+Goal:
+
+```text
+Move BaseballOS from availability intelligence to decision-support intelligence.
+```
+
+This milestone should define policy before implementation:
+
+- what a recommendation is allowed to say
+- what it must not imply
+- how confidence and limitations are carried into recommendations
+- how workload-unavailable differs from unknown availability
+- how stale/missing data changes recommendation wording
+- how future simulator work can consume availability classifications without
+  bypassing trust rules
+
+No Recommendation Engine implementation details are authorized by this project
+state document.

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -130,21 +130,38 @@ match the freshness filter. Use **Show inactive pitchers** to inspect all
 tracked pitchers from the local snapshot. If the dashboard itself shows no game
 logs, the database is empty and needs to be seeded or synced.
 
+The dashboard trust strip separates sync metadata from baseball data coverage:
+
+- **Data Status** describes whether the visible data state is healthy, limited,
+  or stale.
+- **Synced** is based on explicit sync metadata from durable `sync_runs`
+  records when available.
+- **Data Through** is based on the latest game-log/workload date represented in
+  the database.
+- **Refresh Coverage** reports how many pitchers were refreshed by the latest
+  sync when that count is available.
+
+Seeded local snapshots may have game logs and fatigue rows without a durable
+sync run. In that case BaseballOS should show the data-through date and clearly
+state that sync metadata is unavailable rather than implying the database is
+empty.
+
 ---
 
 ## Step 5 — Run the tests
 
-The backend has a focused test suite for the fatigue scoring engine.
+The backend test suite covers fatigue scoring, availability classification,
+freshness behavior, sync metadata, admin protections, audit tooling, and data
+integrity checks.
 
 ```bash
 cd backend
 python -m pytest
-# Expected: 43 passed
+# Expected: all tests pass
 ```
 
-These tests are pure unit/integration tests of the scoring logic. They do **not**
-require a database, a running Flask server, or any MLB Stats API access — they
-use small in-memory stand-ins and run in well under a second.
+These tests do **not** require MLB Stats API access. Database-facing tests use
+test-local setup and small fixtures rather than production data.
 
 ---
 
@@ -321,12 +338,29 @@ custom headers it *could* call `/api/bullpen/sync` directly, but the Actions
 workflow is cleaner and easier to audit.)
 
 **Expected dashboard behavior after a successful run:** the sync writes
-`sync_status.json`, so the dashboard pill switches from **"Snapshot · through
-…"** (seeded historical data, no sync yet) to **"Last synced: …"**. If a run
-fails, the pill shows **"Last sync failed"**. (Note: the status file is currently
-on the instance's ephemeral disk, so a Render restart can revert the pill to the
-snapshot state until the next sync — persisting status in the DB is a sensible
-future enhancement.)
+durable metadata to the `sync_runs` table, while keeping the legacy status file
+as a fallback. The dashboard trust strip should show separate sync and data
+coverage fields:
+
+```text
+Data Status: Healthy
+Synced: <last successful sync date>
+Data Through: <latest baseball data date>
+Refresh Coverage: <pitchers refreshed>
+```
+
+If game logs exist but durable sync metadata is unavailable, the dashboard
+should show that limitation explicitly instead of presenting the database as
+empty:
+
+```text
+Data Status: Limited
+Sync metadata: Unavailable
+Data Through: <latest baseball data date>
+```
+
+If the latest run fails, the dashboard should preserve the data-through date and
+show the failed sync state separately.
 
 The protected endpoint stays protected throughout — the scheduler authenticates
 with `X-Admin-Token`; there is no anonymous sync and no public sync button.


### PR DESCRIPTION
Documents the completed Availability Engine trust foundation, governed threshold adoption, durable sync metadata, dashboard trust strip, current platform capabilities, and next Recommendation Engine policy milestone.