### PR TITLE
Fix durable sync write: self-heal sync_runs so every sync persists a row

### DIFF
--- a/backend/api/bullpen.py
+++ b/backend/api/bullpen.py
@@ -398,13 +398,19 @@ def sync_recent_logs():
         pull = sync_service.sync_recent_logs(days_back=days_back)
     except Exception as e:
         db.session.rollback()
-        sync_metadata.finish_sync_run(
+        # Durable first, and self-healing: writes a failed row even if the start
+        # row never persisted, so the failure is recorded in sync_runs (not only
+        # the cache file).
+        failed_run = sync_metadata.finish_sync_run(
             sync_run_id,
             status=sync_metadata.STATUS_FAILED,
             errors=1,
             error_message=str(e),
+            source=source,
+            started_at=started.replace(tzinfo=None),
         )
-        # Persist failure status so the dashboard reflects the bad state.
+        # Persist failure status so the dashboard reflects the bad state. The
+        # file write is best-effort and never gates the durable row above.
         sync_service.write_status({
             'last_sync':       started.isoformat(),
             'status':          sync_metadata.STATUS_FAILED,
@@ -419,7 +425,9 @@ def sync_recent_logs():
     # Live mode: score against today — same behavior as before.
     fatigue_updated = sync_service.recalculate_all_fatigue(use_last_game_date=False)
     finished        = datetime.now(timezone.utc)
-    sync_metadata.finish_sync_run(
+    # Durable first (self-healing if the start row never persisted), then the
+    # best-effort cache file. The durable row is the source of truth.
+    completed_run = sync_metadata.finish_sync_run(
         sync_run_id,
         status=sync_metadata.STATUS_SUCCESS,
         completed_at=finished.replace(tzinfo=None),
@@ -427,7 +435,10 @@ def sync_recent_logs():
         new_logs_added=pull['new_logs_added'],
         pitchers_updated=fatigue_updated,
         errors=pull['errors'],
+        source=source,
+        started_at=started.replace(tzinfo=None),
     )
+    persisted_run_id = completed_run.id if completed_run is not None else sync_run_id
 
     # Mirror what the daily APScheduler job writes so /sync/status stays accurate.
     sync_service.write_status({
@@ -446,7 +457,8 @@ def sync_recent_logs():
         'fatigue_recalculated': fatigue_updated,
         'errors':               pull['errors'],
         'synced_at':            finished.isoformat(),
-        'sync_run_id':          sync_run_id,
+        'sync_run_id':          persisted_run_id,
+        'sync_run_persisted':   persisted_run_id is not None,
         'days_back':            days_back,
     })
 

--- a/backend/services/sync.py
+++ b/backend/services/sync.py
@@ -305,6 +305,8 @@ def run_daily_sync(app, days_back: int = 7):
                 pitchers_updated=pitchers_updated,
                 errors=pull['errors'],
                 error_message=status['message'] or None,
+                source=sync_metadata.SOURCE_SCHEDULED,
+                started_at=started_at.replace(tzinfo=None),
             )
 
     except Exception as e:
@@ -315,6 +317,8 @@ def run_daily_sync(app, days_back: int = 7):
             sync_metadata.finish_sync_run(
                 sync_run_id,
                 status=sync_metadata.STATUS_FAILED,
+                source=sync_metadata.SOURCE_SCHEDULED,
+                started_at=started_at.replace(tzinfo=None),
                 errors=1,
                 error_message=str(e),
             )
@@ -336,12 +340,15 @@ def write_status(status: dict) -> None:
     can serve it. Used by both the daily APScheduler job and manual POSTs
     so both code paths produce a consistent dashboard pill.
     """
-    _ensure_logs_dir()
+    # Best-effort cache only. This file must NEVER gate the durable sync_runs
+    # write — a read-only filesystem (mkdir/open failure) here is non-fatal and
+    # is swallowed so it can never break or precede the durable record.
     try:
+        _ensure_logs_dir()
         with open(STATUS_FILE, 'w', encoding='utf-8') as fh:
             json.dump(status, fh, indent=2)
     except OSError as e:
-        # Non-fatal — sync itself succeeded, we just couldn't persist.
+        # Non-fatal — sync itself succeeded, we just couldn't persist the cache.
         logging.getLogger('baseballos.sync').warning(
             'Could not write status file: %s', e
         )

--- a/backend/services/sync_metadata.py
+++ b/backend/services/sync_metadata.py
@@ -59,6 +59,14 @@ def collect_data_metadata():
 
 def start_sync_run(source=SOURCE_MANUAL, started_at=None):
     started_at = started_at or _now()
+    # Start from a clean transaction. If an earlier statement in this request
+    # left the session in an aborted/poisoned state (a classic Postgres
+    # "current transaction is aborted" trap), the insert below would otherwise
+    # fail silently and we would never write a durable row.
+    try:
+        db.session.rollback()
+    except SQLAlchemyError:
+        pass
     try:
         run = SyncRun(
             started_at=started_at,
@@ -71,7 +79,8 @@ def start_sync_run(source=SOURCE_MANUAL, started_at=None):
         return run.id
     except SQLAlchemyError as exc:
         db.session.rollback()
-        logger.warning('Could not persist sync start metadata: %s', exc)
+        # Loud: a failed durable write must not hide behind the legacy file.
+        logger.error('Could not persist sync start metadata: %s', exc)
         return None
 
 
@@ -84,15 +93,36 @@ def finish_sync_run(
     pitchers_updated=0,
     errors=0,
     error_message=None,
+    source=SOURCE_MANUAL,
+    started_at=None,
 ):
-    if not sync_run_id:
-        return None
+    """
+    Record the outcome of a sync as a durable sync_runs row.
 
+    Self-healing: if ``sync_run_id`` is missing or the row cannot be found
+    (e.g. ``start_sync_run`` failed to persist), a brand-new row is created with
+    the final status. This guarantees that every completed or failed sync leaves
+    at least one durable row, so the freshness chain never has to fall back to the
+    legacy status file simply because the start write hiccuped.
+    """
     completed_at = completed_at or _now()
     try:
-        run = db.session.get(SyncRun, sync_run_id)
+        db.session.rollback()
+    except SQLAlchemyError:
+        pass
+    try:
+        run = db.session.get(SyncRun, sync_run_id) if sync_run_id else None
         if run is None:
-            return None
+            # Self-heal: start never persisted (or the id was lost). Create the
+            # durable row now so the sync is never recorded only in the file.
+            run = SyncRun(
+                started_at=started_at or completed_at,
+                status=status,
+                source=source,
+                created_at=started_at or completed_at,
+            )
+            db.session.add(run)
+
         metadata = collect_data_metadata()
         run.completed_at = completed_at
         run.status = status
@@ -108,7 +138,7 @@ def finish_sync_run(
         return run
     except SQLAlchemyError as exc:
         db.session.rollback()
-        logger.warning('Could not persist sync completion metadata: %s', exc)
+        logger.error('Could not persist sync completion metadata: %s', exc)
         return None
 
 
@@ -193,6 +223,7 @@ def build_sync_status_payload(legacy_status=None, reference_date=None):
         errors = latest_run.errors or 0
         message = _run_message(latest_run)
         sync_block = latest_run.to_dict()
+        metadata_source = 'sync_runs'
     elif legacy_status.get('last_sync'):
         status = _normalize_legacy_status(legacy_status.get('status'))
         last_sync = legacy_status.get('last_sync')
@@ -208,6 +239,7 @@ def build_sync_status_payload(legacy_status=None, reference_date=None):
             'completed_at': finished_at,
             'status': status,
         }
+        metadata_source = 'legacy_status_file'
     else:
         status = STATUS_METADATA_UNAVAILABLE if metadata['game_logs'] else STATUS_NEVER
         last_sync = None
@@ -221,6 +253,7 @@ def build_sync_status_payload(legacy_status=None, reference_date=None):
             else legacy_status.get('message', 'No sync has run yet.')
         )
         sync_block = None
+        metadata_source = 'none'
 
     if successful_run:
         last_successful_sync = _iso(successful_run.completed_at or successful_run.started_at)
@@ -237,6 +270,9 @@ def build_sync_status_payload(legacy_status=None, reference_date=None):
 
     return {
         'status': status,
+        # Which store actually answered: durable 'sync_runs', the cache
+        # 'legacy_status_file', or 'none'. Durable always wins when present.
+        'metadata_source': metadata_source,
         'last_sync': last_sync,
         'last_successful_sync': last_successful_sync,
         'pitchers_updated': pitchers_updated,

--- a/backend/tests/test_durable_sync_write_integration.py
+++ b/backend/tests/test_durable_sync_write_integration.py
@@ -1,0 +1,179 @@
+"""
+Durable sync-write integration tests.
+
+These pin the production-correctness rule: every successful OR failed sync must
+leave a durable row in sync_runs, and /api/bullpen/sync/status must then prefer
+that durable row over the legacy cache file. The MLB pull and fatigue recompute
+are mocked so the tests exercise the real endpoint wiring without network.
+
+In-memory SQLite, no Postgres / MLB / network.
+"""
+
+from datetime import date, datetime, timedelta
+
+import pytest
+from flask import Flask
+
+import services.sync as sync_service
+from services import sync_metadata
+from utils.db import db
+from models.pitcher import Pitcher
+from models.game_log import GameLog
+from models.fatigue_score import FatigueScore
+from models.sync_run import SyncRun
+import models.prospect  # noqa: F401
+from api.bullpen import bullpen_bp
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    monkeypatch.setattr(sync_service, 'STATUS_FILE', tmp_path / 'sync_status.json')
+    # Mock the network/heavy work so the endpoint's durable wiring is what's tested.
+    monkeypatch.setattr(sync_service, 'sync_recent_logs',
+                        lambda days_back=7: {'new_logs_added': 3, 'pitchers_touched': 2, 'errors': 0})
+    monkeypatch.setattr(sync_service, 'recalculate_all_fatigue', lambda use_last_game_date=False: 5)
+
+    app = Flask(__name__)
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+    db.init_app(app)
+    app.register_blueprint(bullpen_bp, url_prefix='/api/bullpen')
+    with app.app_context():
+        db.create_all()
+        # Recent data so collect_data_metadata() has something current to record.
+        pitcher = Pitcher(mlb_id=1, full_name='A', team_id=1, active=True)
+        db.session.add(pitcher)
+        db.session.commit()
+        db.session.add(GameLog(pitcher_id=pitcher.id, mlb_game_pk=10,
+                               game_date=date.today() - timedelta(days=3), pitches_thrown=12))
+        db.session.add(FatigueScore(pitcher_id=pitcher.id, raw_score=20.0,
+                                    risk_level='LOW', calculated_at=datetime.utcnow()))
+        db.session.commit()
+        try:
+            yield app.test_client()
+        finally:
+            db.session.remove()
+            db.drop_all()
+
+
+def _count_runs(client):
+    with client.application.app_context():
+        return db.session.query(db.func.count(SyncRun.id)).scalar()
+
+
+def _latest_run(client):
+    with client.application.app_context():
+        return SyncRun.query.order_by(SyncRun.id.desc()).first()
+
+
+# ── 1 & 2: successful manual sync writes and fully populates a durable row ──
+
+class TestSuccessfulSync:
+    def test_manual_sync_writes_a_sync_runs_row(self, client):
+        res = client.post('/api/bullpen/sync', json={'days_back': 7})
+        assert res.status_code == 200
+        body = res.get_json()
+        assert body['sync_run_persisted'] is True
+        assert body['sync_run_id'] is not None
+        assert _count_runs(client) >= 1
+
+    def test_successful_sync_updates_all_fields(self, client):
+        client.post('/api/bullpen/sync', json={'days_back': 7})
+        run = _latest_run(client)
+        assert run.status == 'success'
+        assert run.started_at is not None
+        assert run.completed_at is not None
+        assert run.latest_game_date == date.today() - timedelta(days=3)
+        assert run.latest_workload_date == date.today() - timedelta(days=3)
+        assert run.latest_fatigue_calculated_at is not None
+        assert run.records_processed == 3
+        assert run.new_logs_added == 3
+        assert run.pitchers_updated == 5
+        assert run.errors == 0
+
+
+# ── 3: a failed sync still writes/updates a durable row ────────────────────
+
+class TestFailedSync:
+    def test_failed_sync_writes_durable_failed_row(self, client, monkeypatch):
+        def boom(days_back=7):
+            raise RuntimeError('MLB API unavailable')
+        monkeypatch.setattr(sync_service, 'sync_recent_logs', boom)
+
+        res = client.post('/api/bullpen/sync', json={'days_back': 7})
+        assert res.status_code == 500
+        run = _latest_run(client)
+        assert run is not None
+        assert run.status == 'failed'
+        assert run.error_message == 'MLB API unavailable'
+        assert run.completed_at is not None
+        assert _count_runs(client) >= 1
+
+
+# ── 4: self-heal when the start row never persisted ────────────────────────
+
+class TestSelfHeal:
+    def test_durable_row_written_even_if_start_returns_none(self, client, monkeypatch):
+        # Simulate start_sync_run silently failing in prod (the exact symptom:
+        # source=legacy_status_file, id=null, count=0).
+        monkeypatch.setattr(sync_metadata, 'start_sync_run', lambda **kwargs: None)
+
+        res = client.post('/api/bullpen/sync', json={'days_back': 7})
+        assert res.status_code == 200
+        assert res.get_json()['sync_run_persisted'] is True
+        # finish_sync_run self-healed a durable row despite the missing start.
+        assert _count_runs(client) >= 1
+
+        status = client.get('/api/bullpen/sync/status').get_json()
+        assert status['metadata_source'] == 'sync_runs'
+        assert status['sync']['id'] is not None
+
+
+# ── 5: cache-file failure must not block the durable write ─────────────────
+
+class TestCacheFileIsNotTheGate:
+    def test_status_file_failure_does_not_prevent_durable_row(self, client, monkeypatch):
+        def explode(_status):
+            raise RuntimeError('read-only filesystem')
+        monkeypatch.setattr(sync_service, 'write_status', explode)
+
+        # The durable write happens before the (now-failing) cache write, so the
+        # row persists regardless of the file outcome.
+        try:
+            client.post('/api/bullpen/sync', json={'days_back': 7})
+        except RuntimeError:
+            pass
+        run = _latest_run(client)
+        assert run is not None
+        assert run.status == 'success'
+        assert _count_runs(client) >= 1
+
+
+# ── 6: /sync/status prefers sync_runs over the legacy file ─────────────────
+
+class TestStatusPrefersDurable:
+    def test_status_reports_sync_runs_source_after_sync(self, client):
+        # Pre-seed a conflicting legacy cache file to make sure durable wins.
+        with client.application.app_context():
+            sync_service.write_status({'last_sync': '2020-01-01T00:00:00', 'status': 'never',
+                                       'pitchers_updated': 0, 'new_logs_added': 0, 'errors': 0,
+                                       'message': 'stale'})
+        client.post('/api/bullpen/sync', json={'days_back': 7})
+
+        status = client.get('/api/bullpen/sync/status').get_json()
+        assert status['metadata_source'] == 'sync_runs'
+        assert status['sync'] is not None
+        assert status['sync']['id'] is not None
+        assert status['sync']['source'] != 'legacy_status_file'
+        assert status['status'] == 'success'
+
+
+# ── 7: no regression to dashboard freshness ────────────────────────────────
+
+class TestNoFreshnessRegression:
+    def test_dashboard_reports_current_after_sync(self, client):
+        client.post('/api/bullpen/sync', json={'days_back': 7})
+        dash = client.get('/api/bullpen/dashboard').get_json()
+        assert dash['freshness']['is_current'] is True
+        assert dash['freshness']['sync_status'] == 'success'
+        assert dash['freshness']['last_successful_sync'] is not None

--- a/docs/DURABLE_SYNC_WRITE_INTEGRATION_FIX.md
+++ b/docs/DURABLE_SYNC_WRITE_INTEGRATION_FIX.md
@@ -1,0 +1,139 @@
+# Durable Sync Write Integration Fix
+
+## Symptom
+
+Production had the `sync_runs` table created, Alembic at `41f4f9a8d6c2`, and a
+successful manual sync — yet:
+
+```json
+"source": "legacy_status_file",
+"id": null
+```
+
+```sql
+SELECT COUNT(*) FROM sync_runs;  -- 0
+```
+
+The sync wrote the legacy cache file but **no durable row**.
+
+## Root cause
+
+Both real sync paths (`POST /api/bullpen/sync` and the APScheduler
+`run_daily_sync`) already call `start_sync_run()` then `finish_sync_run()`. The
+defect was in how failures were handled, not whether the calls existed:
+
+1. **`start_sync_run()` swallowed errors and returned `None`.** Any failure of
+   the start insert (e.g. a poisoned/aborted transaction earlier in the request —
+   the classic Postgres *"current transaction is aborted, commands ignored until
+   end of transaction block"*) was caught, logged only at `warning`, and turned
+   into `None`.
+2. **`finish_sync_run(None, …)` was a no-op.** When the start id was `None`, the
+   finish call returned immediately and wrote nothing — so the sync produced
+   **zero** durable rows.
+3. The failure was **invisible**: the sync still wrote `sync_status.json` and
+   otherwise "succeeded," so `/api/bullpen/sync/status` permanently fell back to
+   the legacy file (`source: legacy_status_file`, `id: null`).
+
+In short: a single hiccup on the start insert meant the durable table was never
+written, and nothing surfaced the problem.
+
+## Fix
+
+Durable writes are now robust, self-healing, observable, and never gated by the
+cache file. No routes, UX, recommendation logic, or bullpen calculations changed.
+
+- **`start_sync_run()`** (`services/sync_metadata.py`): rolls back any poisoned
+  transaction *before* the insert (fixes the aborted-transaction trap), and logs
+  a failure at `error` instead of `warning`.
+- **`finish_sync_run()`** is now **self-healing**: if the start id is missing or
+  the row can't be found, it **creates** the durable row with the final status
+  (it also accepts `source` / `started_at` for that case). This guarantees that
+  every completed or failed sync leaves at least one durable row, even if the
+  start insert hiccuped.
+- **`POST /api/bullpen/sync`** (`api/bullpen.py`): passes `source`/`started_at`
+  into both finish calls and returns the **persisted** row id plus
+  `sync_run_persisted: bool`. The durable write happens before the best-effort
+  cache write.
+- **`run_daily_sync`** (`services/sync.py`): passes `source`/`started_at` into
+  both finish calls (self-heal context).
+- **`write_status()`** (`services/sync.py`): the directory create + file write
+  are both inside the guard, so a read-only filesystem can never raise into — or
+  precede — the durable write. The cache file is never the only write path.
+- **`build_sync_status_payload()`**: adds an explicit, unambiguous
+  `metadata_source` field — `"sync_runs"` (durable), `"legacy_status_file"`
+  (cache), or `"none"` — so the active source is observable directly.
+
+### Fallback order (unchanged, now guaranteed to be reachable)
+
+1. Durable `sync_runs` (authoritative).
+2. `sync_status.json` cache (only when no durable row exists).
+3. Generated `never` / `metadata_unavailable` fallback.
+
+## Tests
+
+`backend/tests/test_durable_sync_write_integration.py` (MLB pull + fatigue
+recompute mocked; in-memory SQLite):
+
+1. Manual sync endpoint writes a `sync_runs` row (`sync_run_persisted: true`,
+   non-null id).
+2. Successful sync populates status, started_at, completed_at, latest_game_date,
+   latest_workload_date, latest_fatigue_calculated_at, records_processed,
+   new_logs_added, pitchers_updated, errors.
+3. Failed sync still writes a durable failed row (status + error_message +
+   completed_at).
+4. **Self-heal:** with `start_sync_run` forced to return `None` (the exact prod
+   symptom), a durable row is still written and `/sync/status` reports
+   `metadata_source: "sync_runs"`, non-null `sync.id`.
+5. Cache-file write failure does not prevent the durable row.
+6. `/sync/status` prefers `sync_runs` over a conflicting legacy file.
+7. No regression to dashboard freshness after a sync.
+
+Backend: 478 passed. Frontend: 191 passed (unchanged — backend-only fix).
+
+## Production verification plan
+
+After deploying and running one sync (manual `POST /api/bullpen/sync`, or the
+GitHub Actions "Daily Bullpen Sync" workflow):
+
+```sql
+SELECT COUNT(*) FROM sync_runs;            -- expect >= 1
+
+SELECT id, status, started_at, completed_at, source,
+       latest_game_date, latest_workload_date, error_message
+FROM sync_runs
+ORDER BY started_at DESC
+LIMIT 5;                                   -- expect the latest sync as a row
+```
+
+Endpoint:
+
+```text
+GET /api/bullpen/sync/status
+```
+
+Expect:
+
+```json
+"metadata_source": "sync_runs",
+"sync": { "id": <non-null>, "source": "github_actions" | "manual" | "scheduled" }
+```
+
+(`metadata_source: "sync_runs"` with a non-null `sync.id` is the post-fix signal
+— it replaces the previous `source: "legacy_status_file"`, `id: null`.)
+
+The `POST /api/bullpen/sync` response also now returns `sync_run_persisted: true`
+and a non-null `sync_run_id` on success.
+
+## Remaining risks / operational notes
+
+- The fix guarantees a durable row whenever a sync **reaches** `finish_sync_run`.
+  A hard process crash between start and finish (when start also failed to
+  persist) could still leave no row — an extreme edge, not the observed symptom.
+- If durable writes still fail in production after this, the cause is now **loud**
+  (`logger.error('Could not persist sync … metadata: …')`) — check the backend
+  logs; it indicates a real DB/connection problem (permissions, search_path, or
+  connectivity), not a silent code fallback.
+- The database must remain persistent across deploys; an ephemeral/reset DB would
+  wipe `sync_runs` regardless of this fix.
+- The legacy `sync_status.json` is intentionally retained as a cache and was not
+  removed.


### PR DESCRIPTION
Production had the sync_runs table and a successful manual sync, yet /api/bullpen/sync/status reported source=legacy_status_file, id=null and SELECT COUNT(*) FROM sync_runs returned 0 — the durable row was never written.

Root cause: both real sync paths (POST /api/bullpen/sync and the APScheduler run_daily_sync) already call start_sync_run/finish_sync_run, but start_sync_run swallowed errors and returned None (e.g. on a poisoned/aborted transaction — the classic Postgres "current transaction is aborted" trap), and finish_sync_run(None, ...) was a no-op. So a single start-insert hiccup produced zero durable rows, invisibly, and the system fell back to the cache file forever.

Fix (no routes/UX/recommendation/bullpen-calculation changes):
- start_sync_run: rolls back any poisoned transaction before the insert; logs failures at error, not warning.
- finish_sync_run: self-healing — if the start id is missing or the row is not found, it creates the durable row with the final status (accepts source/ started_at for that case). Guarantees a durable row for every completed or failed sync.
- POST /api/bullpen/sync and run_daily_sync: pass source/started_at into finish; the endpoint returns the persisted row id and sync_run_persisted. Durable write precedes the best-effort cache write.
- write_status: directory-create + file-write both guarded, so a read-only filesystem can never raise into or precede the durable write. The cache file is never the only write path.
- build_sync_status_payload: adds an explicit metadata_source field ("sync_runs" | "legacy_status_file" | "none") so the active source is observable directly.

Tests: backend/tests/test_durable_sync_write_integration.py (7) — manual sync writes a row, successful sync populates all fields, failed sync writes a durable failed row, self-heal when start returns None, cache-file failure does not block the durable row, /sync/status prefers sync_runs over the legacy file, and no dashboard freshness regression. Backend 478 pass, frontend 191 unchanged.

Docs: docs/DURABLE_SYNC_WRITE_INTEGRATION_FIX.md with the post-deploy SQL and endpoint verification steps.