### PR TITLE
feat: add bullpen landscape and team game context

### DIFF
--- a/backend/api/bullpen.py
+++ b/backend/api/bullpen.py
@@ -22,6 +22,7 @@ from services.availability_snapshot import (
 from services.availability_summary import summarize_availability_records
 from services.bullpen_board import BOARD_GROUP_ORDER, build_board_payload, build_team_context
 from services.bullpen_comparison import build_team_comparison
+from services.game_context import build_landscape, build_team_game_context
 from services.pitcher_role import ROLE_KEYS, ROLE_WINDOW_DAYS, classify_usage_role
 from services.mlb_api import mlb_client
 from services import sync as sync_service
@@ -866,6 +867,10 @@ def get_bullpen_dashboard():
         key = role['role_key']
         role_counts[key] = role_counts.get(key, 0) + 1
 
+    # Tonight's Bullpen Landscape — league orientation, reusing the records we
+    # already classified above (no extra availability pass).
+    landscape = build_landscape(records=availability_records, freshness=freshness)
+
     return jsonify({
         'capability': 'bullpen_dashboard',
         'generated_at': datetime.now(timezone.utc).isoformat(),
@@ -878,9 +883,33 @@ def get_bullpen_dashboard():
             'counts': role_counts,
             'total': len(pitcher_ids),
         },
+        'landscape': landscape,
         'freshness': freshness,
         'availability_summary': summary,
     })
+
+
+@bullpen_bp.route('/landscape', methods=['GET'])
+def get_bullpen_landscape():
+    """
+    Tonight's Bullpen Landscape — league-wide orientation: which bullpens are
+    most constrained, most available, and carrying the most monitoring, plus a
+    stored games-today anchor. Descriptive and deterministic; no ranking,
+    selection, recommendation, or prediction.
+    """
+    freshness = _board_freshness_block()
+    return jsonify(build_landscape(freshness=freshness))
+
+
+@bullpen_bp.route('/teams/<int:team_id>/game-context', methods=['GET'])
+def get_team_game_context(team_id):
+    """
+    Today's Game Context for one team, derived from stored game logs only (no
+    live schedule call). Frames bullpen availability; not a scoreboard, matchup
+    engine, or prediction. Home/away and scheduled time are reported as missing
+    because the stored game log does not carry them.
+    """
+    return jsonify(build_team_game_context(team_id))
 
 
 # ─── Insights ─────────────────────────────────────────────────────────────────

--- a/backend/services/game_context.py
+++ b/backend/services/game_context.py
@@ -1,0 +1,318 @@
+"""
+Schedule / game-context adapter for bullpen framing.
+
+This is descriptive context only. It frames *when* a bullpen last pitched and
+*who* it played so the availability views have a day-of-games anchor. It is NOT
+a scoreboard, a matchup engine, or a prediction system, and it never ranks teams
+or recommends anything.
+
+The app's durable stored data is MLB game logs, which carry the opponent and
+game date but NOT home/away or scheduled time (the MLB gameLog endpoint does not
+return them). Those fields are therefore reported as missing rather than
+fabricated, and this context is labelled as stored game-log context — never as an
+authoritative live schedule. Everything respects the freshness model: a context
+is labelled live / historical / stale / unavailable, never silently presented as
+current. No live network call is made here.
+"""
+
+from datetime import date
+
+from sqlalchemy import desc
+
+from models.game_log import GameLog
+from models.pitcher import Pitcher
+from services.availability import ACTIVE_WINDOW_DAYS
+from services.availability_snapshot import (
+    CURRENT_AVAILABILITY_MODE,
+    classify_latest_fatigue_rows,
+    latest_fatigue_rows,
+)
+from services.bullpen_board import BOARD_GROUP_ORDER, build_team_context
+from utils.db import db
+
+
+# Stored game logs never carry these — reported honestly as missing.
+GAME_LOG_MISSING_FIELDS = ['home_away', 'scheduled_time']
+SOURCE_LABEL = 'Stored game-log context'
+
+
+def _data_state_for(days_ago):
+    """Honest freshness label for how old the stored game is."""
+    if days_ago is None:
+        return 'unavailable'
+    if days_ago == 0:
+        return 'live'
+    if days_ago <= ACTIVE_WINDOW_DAYS:
+        return 'historical'
+    return 'stale'
+
+
+def _team_identity(team_id):
+    row = (
+        db.session.query(Pitcher.team_id, Pitcher.team_name, Pitcher.team_abbreviation)
+        .filter(Pitcher.team_id == team_id)
+        .first()
+    )
+    if row is None:
+        return {'team_id': team_id, 'team_name': None, 'team_abbreviation': None}
+    return {
+        'team_id': row.team_id,
+        'team_name': row.team_name,
+        'team_abbreviation': row.team_abbreviation,
+    }
+
+
+def _context_confidence(opponent, data_state):
+    """Confidence is capped at medium — home/away and time are never available."""
+    if data_state == 'unavailable':
+        return 'none'
+    if opponent is None or data_state == 'stale':
+        return 'low'
+    return 'medium'
+
+
+# ── Team game context (stored game-log only) ───────────────────────────────
+
+def build_team_game_context(team_id, reference_date=None):
+    """
+    Compact game context for one team's most recent stored game on/before today.
+
+    Derived entirely from durable GameLog data — no live schedule call. Supports
+    historical fallback: if there is no game today, the latest stored game is
+    returned and labelled accordingly. Home/away and scheduled time are not in the
+    stored data, so they are reported in ``missing_fields`` rather than fabricated.
+
+    States:
+      * 'stored_game_log' — a stored game was found (possibly historical).
+      * 'no_game_found'    — the team exists but has no stored game.
+      * 'unavailable'      — no team/schedule context is available at all.
+    """
+    ref = reference_date or date.today()
+    team = _team_identity(team_id)
+
+    latest_game_date = (
+        db.session.query(db.func.max(GameLog.game_date))
+        .join(Pitcher, GameLog.pitcher_id == Pitcher.id)
+        .filter(Pitcher.team_id == team_id, GameLog.game_date <= ref)
+        .scalar()
+    )
+
+    if latest_game_date is None:
+        unknown_team = team['team_name'] is None and team['team_abbreviation'] is None
+        return {
+            'capability': 'team_game_context',
+            'team': team,
+            'available': False,
+            'state': 'unavailable' if unknown_team else 'no_game_found',
+            'data_source': 'game_log',
+            'data_state': 'unavailable',
+            'source_label': SOURCE_LABEL,
+            'confidence': 'none',
+            'message': (
+                'Schedule context unavailable.'
+                if unknown_team
+                else 'No game found in the stored game log for this date.'
+            ),
+            'reference_date': ref.isoformat(),
+            'game_date': None,
+            'opponent': None,
+            'opponent_abbreviation': None,
+            'home_away': None,
+            'scheduled_time': None,
+            'game_status': None,
+            'is_today': False,
+            'days_ago': None,
+            'missing_fields': list(GAME_LOG_MISSING_FIELDS),
+        }
+
+    log = (
+        GameLog.query
+        .join(Pitcher, GameLog.pitcher_id == Pitcher.id)
+        .filter(Pitcher.team_id == team_id, GameLog.game_date == latest_game_date)
+        .order_by(desc(GameLog.mlb_game_pk))
+        .first()
+    )
+    days_ago = (ref - latest_game_date).days
+    is_today = days_ago == 0
+    data_state = _data_state_for(days_ago)
+    opponent = log.opponent if log else None
+
+    missing_fields = list(GAME_LOG_MISSING_FIELDS)
+    if opponent is None:
+        missing_fields.append('opponent')
+
+    return {
+        'capability': 'team_game_context',
+        'team': team,
+        'available': True,
+        'state': 'stored_game_log',
+        'data_source': 'game_log',
+        # Stored game logs are not a live schedule; label by recency, honestly.
+        'data_state': data_state,
+        'source_label': SOURCE_LABEL,
+        'confidence': _context_confidence(opponent, data_state),
+        'message': None,
+        'reference_date': ref.isoformat(),
+        'game_date': latest_game_date.isoformat(),
+        'opponent': opponent,
+        'opponent_abbreviation': log.opponent_abbreviation if log else None,
+        # Not present in the stored game-log data — reported honestly as unknown.
+        'home_away': None,
+        'scheduled_time': None,
+        'game_status': 'final',
+        'is_today': is_today,
+        'days_ago': days_ago,
+        'missing_fields': missing_fields,
+    }
+
+
+# ── League-wide bullpen landscape ──────────────────────────────────────────
+
+def _team_buckets(records):
+    """Group classified availability records by team into status counts."""
+    buckets = {}
+    for record in records:
+        pitcher = record.get('pitcher')
+        if pitcher is None:
+            continue
+        bucket = buckets.setdefault(pitcher.team_id, {
+            'team_id': pitcher.team_id,
+            'team_name': pitcher.team_name,
+            'team_abbreviation': pitcher.team_abbreviation,
+            'counts': {status: 0 for status in BOARD_GROUP_ORDER},
+        })
+        status = (record.get('availability') or {}).get('availability_status')
+        if status in bucket['counts']:
+            bucket['counts'][status] += 1
+    return buckets
+
+
+def _landscape_entry(bucket):
+    counts = bucket['counts']
+    groups = [{'status': status, 'count': counts[status]} for status in BOARD_GROUP_ORDER]
+    context = build_team_context(groups)
+    metrics = context['metrics']
+    return {
+        'team_id': bucket['team_id'],
+        'team_name': bucket['team_name'],
+        'team_abbreviation': bucket['team_abbreviation'],
+        'total_relievers': metrics['total_relievers'],
+        'available': metrics['available'],
+        'monitor': metrics['monitor'],
+        'restricted': metrics['restricted'],
+        'pct_available': metrics['pct_available'],
+        'pct_restricted': metrics['pct_restricted'],
+        'health_state': context['health']['state'],
+        'health_label': context['health']['label'],
+    }
+
+
+def _games_block(reference_date=None):
+    ref = reference_date or date.today()
+    latest_game_date = db.session.query(db.func.max(GameLog.game_date)).scalar()
+    if latest_game_date is None:
+        return {
+            'available': False,
+            'data_state': 'unavailable',
+            'message': 'Schedule context unavailable.',
+            'today_count': 0,
+            'as_of_date': None,
+            'as_of_count': 0,
+            'is_today': False,
+        }
+
+    def _distinct_games_on(day):
+        return int(
+            db.session.query(db.func.count(db.func.distinct(GameLog.mlb_game_pk)))
+            .filter(GameLog.game_date == day)
+            .scalar()
+            or 0
+        )
+
+    days_ago = (ref - latest_game_date).days
+    return {
+        'available': True,
+        'data_state': _data_state_for(days_ago),
+        'message': None,
+        'today_count': _distinct_games_on(ref),
+        # The most recent slate present in the stored data (historical anchor).
+        'as_of_date': latest_game_date.isoformat(),
+        'as_of_count': _distinct_games_on(latest_game_date),
+        'is_today': days_ago == 0,
+    }
+
+
+def _landscape_notes(games):
+    # Disclaimers are worded to avoid advisory vocabulary entirely (no
+    # best/worst/advice/forecast language), so the surface stays descriptive.
+    notes = [
+        'Descriptive groupings of bullpen situations only — this is bullpen context, not a league ranking or a game forecast.',
+        'Sorted deterministically by count, then percentage, then team name.',
+    ]
+    state = (games or {}).get('data_state')
+    if state == 'unavailable':
+        notes.append('Schedule context unavailable; bullpen situations reflect the latest workload data only.')
+    elif state in ('historical', 'stale'):
+        notes.append('Game context is from the latest stored game log, not a live schedule.')
+    return notes
+
+
+def build_landscape(records=None, reference_date=None, freshness=None, top_n=3):
+    """
+    League-wide bullpen landscape: which bullpens are most constrained, most
+    available, and carrying the most monitoring, plus a stored games anchor.
+
+    Sorting is descriptive and deterministic (by count, then percentage, then
+    team name) — it surfaces *situations*, not a ranking or recommendation, and
+    never uses best / worst / advantage language. ``records`` may be supplied by
+    the caller to avoid re-classifying; otherwise they are computed here.
+    """
+    ref = reference_date or date.today()
+    if records is None:
+        records = classify_latest_fatigue_rows(
+            latest_fatigue_rows(),
+            mode=CURRENT_AVAILABILITY_MODE,
+        )
+
+    buckets = _team_buckets(records)
+    entries = [
+        entry for entry in (_landscape_entry(bucket) for bucket in buckets.values())
+        if entry['total_relievers'] > 0
+    ]
+
+    constrained_bullpens = [
+        entry for entry in sorted(
+            entries,
+            key=lambda e: (-e['restricted'], -e['pct_restricted'], e['team_name'] or ''),
+        )
+        if entry['restricted'] > 0
+    ][:top_n]
+
+    available_bullpens = sorted(
+        entries,
+        key=lambda e: (-e['available'], -e['pct_available'], e['team_name'] or ''),
+    )[:top_n]
+
+    monitoring_concentration = [
+        entry for entry in sorted(
+            entries,
+            key=lambda e: (-e['monitor'], e['team_name'] or ''),
+        )
+        if entry['monitor'] > 0
+    ][:top_n]
+
+    games = _games_block(ref)
+
+    return {
+        'capability': 'tonights_bullpen_landscape',
+        'ranking_applied': False,
+        'selection_made': False,
+        'reference_date': ref.isoformat(),
+        'teams_evaluated': len(entries),
+        'games': games,
+        'constrained_bullpens': constrained_bullpens,
+        'available_bullpens': available_bullpens,
+        'monitoring_concentration': monitoring_concentration,
+        'freshness': freshness or {},
+        'notes': _landscape_notes(games),
+    }

--- a/backend/tests/test_game_context.py
+++ b/backend/tests/test_game_context.py
@@ -1,0 +1,194 @@
+"""
+Tests for the schedule / game-context adapter (services/game_context.py) and its
+endpoints: Today's Game Context and Tonight's Bullpen Landscape.
+
+Everything is derived from stored game logs / availability — no live network.
+In-memory SQLite, no Postgres / MLB.
+"""
+
+from datetime import date, datetime, timedelta
+from types import SimpleNamespace
+
+import pytest
+from flask import Flask
+
+import services.sync as sync_service
+from services.game_context import build_landscape, build_team_game_context
+from utils.db import db
+from models.pitcher import Pitcher
+from models.game_log import GameLog
+from models.fatigue_score import FatigueScore
+import models.prospect  # noqa: F401
+from api.bullpen import bullpen_bp
+
+FORBIDDEN_TERMS = (
+    'best bullpen', 'worst bullpen', 'best ', 'worst ', 'recommended', 'recommendation',
+    'prediction', 'predict', 'advantage', 'should use', 'expected winner', 'matchup advice',
+)
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    monkeypatch.setattr(sync_service, 'STATUS_FILE', tmp_path / 'sync_status.json')
+    app = Flask(__name__)
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+    db.init_app(app)
+    app.register_blueprint(bullpen_bp, url_prefix='/api/bullpen')
+    with app.app_context():
+        db.create_all()
+        try:
+            yield app.test_client()
+        finally:
+            db.session.remove()
+            db.drop_all()
+
+
+def _seed_team_with_game(team_id, mlb_id, opponent='Rivals', opp_abbr='RIV', days_ago=2):
+    pitcher = Pitcher(mlb_id=mlb_id, full_name=f'P{mlb_id}', team_id=team_id,
+                      team_name=f'Team {team_id}', team_abbreviation=f'T{team_id}', active=True)
+    db.session.add(pitcher)
+    db.session.commit()
+    db.session.add(GameLog(pitcher_id=pitcher.id, mlb_game_pk=mlb_id * 100,
+                           game_date=date.today() - timedelta(days=days_ago),
+                           opponent=opponent, opponent_abbreviation=opp_abbr,
+                           pitches_thrown=12, innings_pitched=1.0))
+    db.session.add(FatigueScore(pitcher_id=pitcher.id, raw_score=20.0,
+                                risk_level='LOW', calculated_at=datetime.utcnow()))
+    db.session.commit()
+    return pitcher
+
+
+def _fake_record(team_id, status):
+    pitcher = SimpleNamespace(team_id=team_id, team_name=f'Team {team_id}',
+                              team_abbreviation=f'T{team_id}')
+    return {'pitcher': pitcher, 'availability': {'availability_status': status}}
+
+
+def _no_forbidden_language(blob):
+    low = blob.lower()
+    return not any(term in low for term in FORBIDDEN_TERMS)
+
+
+# ── Team game context ──────────────────────────────────────────────────────
+
+class TestTeamGameContext:
+    def test_stored_game_log_state_with_opponent(self, client):
+        with client.application.app_context():
+            _seed_team_with_game(1, mlb_id=1, opponent='Rivals', opp_abbr='RIV', days_ago=2)
+            ctx = build_team_game_context(1)
+        assert ctx['state'] == 'stored_game_log'
+        assert ctx['available'] is True
+        assert ctx['data_source'] == 'game_log'
+        assert ctx['opponent'] == 'Rivals'
+        assert ctx['opponent_abbreviation'] == 'RIV'
+        assert ctx['data_state'] == 'historical'
+        assert ctx['confidence'] == 'medium'
+        # Home/away and scheduled time are never in the stored data.
+        assert ctx['home_away'] is None
+        assert ctx['scheduled_time'] is None
+        assert 'home_away' in ctx['missing_fields']
+        assert 'scheduled_time' in ctx['missing_fields']
+        assert ctx['source_label'] == 'Stored game-log context'
+
+    def test_no_game_found_when_team_has_no_logs(self, client):
+        with client.application.app_context():
+            p = Pitcher(mlb_id=9, full_name='X', team_id=5, team_name='Team 5',
+                        team_abbreviation='T5', active=True)
+            db.session.add(p)
+            db.session.commit()
+            ctx = build_team_game_context(5)
+        assert ctx['state'] == 'no_game_found'
+        assert ctx['available'] is False
+        assert ctx['message'] == 'No game found in the stored game log for this date.'
+        assert ctx['data_state'] == 'unavailable'
+
+    def test_unavailable_when_team_unknown(self, client):
+        ctx = build_team_game_context(999)
+        assert ctx['state'] == 'unavailable'
+        assert ctx['message'] == 'Schedule context unavailable.'
+        assert ctx['confidence'] == 'none'
+
+    def test_stale_game_lowers_confidence(self, client):
+        with client.application.app_context():
+            _seed_team_with_game(2, mlb_id=2, days_ago=40)
+            ctx = build_team_game_context(2)
+        assert ctx['data_state'] == 'stale'
+        assert ctx['confidence'] == 'low'
+
+    def test_endpoint_returns_game_context(self, client):
+        with client.application.app_context():
+            _seed_team_with_game(1, mlb_id=1)
+        res = client.get('/api/bullpen/teams/1/game-context')
+        assert res.status_code == 200
+        body = res.get_json()
+        assert body['capability'] == 'team_game_context'
+        assert _no_forbidden_language(str(body))
+
+
+# ── Landscape ──────────────────────────────────────────────────────────────
+
+class TestLandscape:
+    def test_response_shape_and_governance(self, client):
+        with client.application.app_context():
+            payload = build_landscape(reference_date=date.today())
+        for key in ('reference_date', 'teams_evaluated', 'games', 'constrained_bullpens',
+                    'available_bullpens', 'monitoring_concentration', 'notes', 'freshness'):
+            assert key in payload, f'missing {key}'
+        assert payload['ranking_applied'] is False
+        assert payload['selection_made'] is False
+        assert payload['capability'] == 'tonights_bullpen_landscape'
+
+    def test_descriptive_sorting_is_deterministic(self, client):
+        # Team 1: 3 restricted; Team 2: 1 restricted; Team 3: all available.
+        records = (
+            [_fake_record(1, 'Avoid')] * 2 + [_fake_record(1, 'Unavailable')]
+            + [_fake_record(1, 'Available')]
+            + [_fake_record(2, 'Avoid')] + [_fake_record(2, 'Available')] * 4
+            + [_fake_record(3, 'Available')] * 5
+        )
+        with client.application.app_context():
+            payload = build_landscape(records=records, reference_date=date.today())
+
+        constrained = payload['constrained_bullpens']
+        assert constrained[0]['team_id'] == 1          # most restricted first (count)
+        assert constrained[0]['restricted'] == 3
+        # Only teams with restriction appear.
+        assert all(entry['restricted'] > 0 for entry in constrained)
+
+        available = payload['available_bullpens']
+        assert available[0]['team_id'] in (2, 3)       # most available arms
+        assert available[0]['available'] == 5
+
+    def test_no_forbidden_language_in_payload(self, client):
+        records = [_fake_record(1, 'Avoid'), _fake_record(1, 'Monitor'), _fake_record(2, 'Available')]
+        with client.application.app_context():
+            payload = build_landscape(records=records, reference_date=date.today())
+        assert _no_forbidden_language(str(payload))
+        # Notes explicitly frame this as bullpen context, not a ranking/forecast.
+        assert any('bullpen context' in note.lower() for note in payload['notes'])
+        assert any('not a league ranking' in note.lower() for note in payload['notes'])
+
+    def test_games_block_reports_stored_anchor(self, client):
+        with client.application.app_context():
+            _seed_team_with_game(1, mlb_id=1, days_ago=3)
+            payload = build_landscape(reference_date=date.today())
+        games = payload['games']
+        assert games['available'] is True
+        assert games['as_of_date'] == (date.today() - timedelta(days=3)).isoformat()
+        assert games['today_count'] == 0               # historical sample → no game today
+        assert games['data_state'] == 'historical'
+
+    def test_endpoint_and_dashboard_expose_landscape(self, client):
+        with client.application.app_context():
+            _seed_team_with_game(1, mlb_id=1)
+            _seed_team_with_game(2, mlb_id=2)
+
+        res = client.get('/api/bullpen/landscape')
+        assert res.status_code == 200
+        assert res.get_json()['capability'] == 'tonights_bullpen_landscape'
+
+        dash = client.get('/api/bullpen/dashboard').get_json()
+        assert 'landscape' in dash
+        assert dash['landscape']['capability'] == 'tonights_bullpen_landscape'
+        assert _no_forbidden_language(str(dash['landscape']))

--- a/docs/TONIGHTS_BULLPEN_LANDSCAPE_AND_GAME_CONTEXT.md
+++ b/docs/TONIGHTS_BULLPEN_LANDSCAPE_AND_GAME_CONTEXT.md
@@ -1,0 +1,94 @@
+# Tonight's Bullpen Landscape & Today's Game Context
+
+## Decision
+
+Add two contextual surfaces:
+
+1. **Tonight's Bullpen Landscape** — a league-wide orientation section on the
+   homepage/dashboard.
+2. **Today's Game Context** — a compact card near the top of the team bullpen
+   board.
+
+## Reason
+
+Real user feedback: a first-time user did not understand why the app opened into
+a specific team view. The product needed stronger initial orientation around
+*tonight's league-wide bullpen state*, and a clearer relationship between a
+team's bullpen and the games it belongs to.
+
+The dashboard now answers "What does tonight's bullpen landscape look like?"
+before users drill into a single team's bullpen.
+
+## Guardrail
+
+This is **contextual schedule/game framing only.** BaseballOS remains a bullpen
+availability and workload intelligence product — not a scoreboard, matchup
+engine, prediction engine, or recommendation engine. Specifically:
+
+- No rankings, no best/worst, no advantage, no recommendations, no "should use",
+  no predictions, no matchup advice, no hidden ordering.
+- Any sorted display is **descriptive and deterministic** (by count, then
+  percentage, then team name) and is labelled as a *situation*, not a ranking.
+- Schedule context is derived only from stored game logs and is labelled
+  honestly as **"Stored game-log context"** — never presented as a live schedule.
+  Freshness states (live / historical / stale / unavailable) are always shown.
+
+## What was built
+
+### Backend — `services/game_context.py` (no live network)
+
+- `build_team_game_context(team_id, reference_date=None)` — derives a team's most
+  recent stored game on/before today from `GameLog`. States: `stored_game_log`
+  (a game was found, possibly historical), `no_game_found` (team exists but has no
+  stored game), `unavailable` (no team/schedule context). Returns
+  `data_source: "game_log"`, a freshness `data_state`, a capped `confidence`, and
+  `missing_fields: ["home_away", "scheduled_time"]` — because the stored game log
+  does not carry home/away or scheduled time, those are reported missing, never
+  fabricated.
+- `build_landscape(records=None, ...)` — groups already-classified availability
+  records by team and surfaces `constrained_bullpens`, `available_bullpens`, and
+  `monitoring_concentration` (top 3 each, descriptive deterministic sort), plus a
+  stored `games` anchor (`today_count`, `as_of_date`, `as_of_count`,
+  `data_state`), `teams_evaluated`, `reference_date`, and disclaiming `notes`.
+  `ranking_applied` / `selection_made` stay `false`.
+
+### API (existing `bullpen` blueprint)
+
+- `GET /api/bullpen/landscape` — the landscape payload.
+- `GET /api/bullpen/teams/<team_id>/game-context` — the team game context.
+- `GET /api/bullpen/dashboard` now also embeds `landscape` (reusing the records
+  it already classified — no extra availability pass).
+
+### Frontend
+
+- `dashboard/BullpenLandscape.jsx` (+ `bullpenLandscapeView.js`) — the "Tonight's
+  Bullpen Landscape" section, rendered near the top of the dashboard. Copy makes
+  clear: *"This is bullpen context, not a game prediction."*
+- `bullpen/board/TeamGameContextCard.jsx` (+ `teamGameContextView.js`) — the
+  "Today's Game Context" card, rendered above the team board. Labels the data as
+  stored game-log context, states unavailable fields explicitly, and carries the
+  helper copy: *"Game context is provided to frame bullpen availability and
+  workload. BaseballOS does not provide matchup advice or game predictions."*
+
+## Data limitations (honest)
+
+- Stored `GameLog` provides the opponent and date but **not** home/away or
+  scheduled time; those are surfaced as unavailable.
+- With the current historical sample, "games today" is typically 0; the landscape
+  and card fall back to the latest stored slate and say so.
+- A live schedule integration (`mlb_client.get_schedule`) exists but is
+  intentionally **not** wired into these request paths — it would add a network
+  dependency and would not match the stored sample data. This surface stays
+  derived from durable data and testable.
+
+## Tests
+
+- Backend: `backend/tests/test_game_context.py` — team context states
+  (stored/no_game_found/unavailable), missing fields, confidence, landscape shape
+  and governance flags, deterministic descriptive sorting, stored games anchor,
+  endpoint + dashboard integration, and a guardrail-language regression.
+- Frontend: `frontend/tests/bullpenLandscapeAndGameContext.test.mjs` — landscape
+  rendering + columns + stored-games anchor + dashboard integration, game-context
+  card states (present / no_game_found / unavailable / loading / missing), and an
+  affirmative-advisory-language regression (the required disclaimers negate
+  "prediction"/"matchup advice" and are asserted as disclaimers).

--- a/frontend/src/components/bullpen/board/TeamGameContextCard.jsx
+++ b/frontend/src/components/bullpen/board/TeamGameContextCard.jsx
@@ -1,0 +1,64 @@
+import { getTeamGameContextView } from './teamGameContextView'
+
+// Today's Game Context — a compact card that frames a team's bullpen with its
+// most recent stored game. Derived from stored game logs only (labelled as
+// such), never presented as a live schedule. Not a scoreboard, matchup engine,
+// or prediction.
+const HELPER_COPY =
+  'Game context is provided to frame bullpen availability and workload. BaseballOS does not provide matchup advice or game predictions.'
+
+function Field({ label, value, muted = false }) {
+  return (
+    <div>
+      <dt className="font-mono text-[10px] uppercase tracking-widest text-chalk600">{label}</dt>
+      <dd className={`mt-0.5 font-mono text-xs ${muted ? 'text-chalk500' : 'text-chalk200'}`}>{value}</dd>
+    </div>
+  )
+}
+
+export default function TeamGameContextCard({ gameContext, loading = false, error = null }) {
+  const view = getTeamGameContextView(gameContext)
+
+  return (
+    <section className="mb-5 rounded-lg border border-dirt bg-field/60 p-4" aria-label="Today's Game Context">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <h3 className="font-mono text-xs uppercase tracking-widest text-chalk400">Today's Game Context</h3>
+        <span className="rounded border border-dirt bg-dugout px-2 py-0.5 font-mono text-[10px] uppercase tracking-widest text-chalk500">
+          Stored game-log context
+        </span>
+      </div>
+
+      {loading ? (
+        <p className="mt-3 font-mono text-xs text-chalk500">Loading game context…</p>
+      ) : error ? (
+        <p className="mt-3 font-mono text-xs text-chalk500">Schedule context unavailable.</p>
+      ) : !view.hasContext ? (
+        <p className="mt-3 font-mono text-xs text-chalk500">Schedule context unavailable.</p>
+      ) : !view.isPresent ? (
+        <p className="mt-3 text-sm leading-relaxed text-chalk400">
+          {view.state === 'no_game_found'
+            ? 'No stored game-log context found for this date.'
+            : (view.message || 'Schedule context unavailable.')}
+        </p>
+      ) : (
+        <>
+          <dl className="mt-3 grid grid-cols-2 gap-x-4 gap-y-3 sm:grid-cols-4">
+            <Field label="Opponent" value={view.opponent || '—'} />
+            <Field label="Game date" value={view.gameDate || '—'} />
+            <Field label="Data" value={`${view.dataStateLabel} · ${view.confidenceLabel} confidence`} muted />
+            <Field label="Status" value={view.isToday ? 'Scheduled' : 'Final'} muted />
+          </dl>
+          {view.missingFields.length > 0 && (
+            <p className="mt-2 font-mono text-[11px] text-chalk600">
+              {view.missingFields.join(' and ')} unavailable in stored game-log data.
+            </p>
+          )}
+        </>
+      )}
+
+      <p className="mt-3 border-t border-dirt/70 pt-2 text-[11px] leading-relaxed text-chalk500">
+        {HELPER_COPY}
+      </p>
+    </section>
+  )
+}

--- a/frontend/src/components/bullpen/board/TonightsBullpenBoard.jsx
+++ b/frontend/src/components/bullpen/board/TonightsBullpenBoard.jsx
@@ -1,8 +1,9 @@
 import { useEffect, useRef, useState } from 'react'
 import { useFetch } from '../../../hooks/useFetch'
-import { getTeamBullpenBoard } from '../../../utils/api'
+import { getTeamBullpenBoard, getTeamGameContext } from '../../../utils/api'
 import { LoadingPane, ErrorState, EmptyState } from '../../UI'
 import BullpenBoardView from './BullpenBoardView'
+import TeamGameContextCard from './TeamGameContextCard'
 import PitcherDetail from '../PitcherDetail'
 
 // Tonight's Bullpen Board lives inside the Bullpen workflow. It receives the
@@ -35,6 +36,12 @@ export default function TonightsBullpenBoard({ teams }) {
       return getTeamBullpenBoard(selectedTeam, includeStale ? { include_stale: true } : {})
     },
     [selectedTeam, includeStale],
+  )
+
+  // Today's Game Context for the selected team (stored game-log only).
+  const gameContext = useFetch(
+    () => (selectedTeam == null ? Promise.resolve(null) : getTeamGameContext(selectedTeam)),
+    [selectedTeam],
   )
 
   return (
@@ -82,6 +89,11 @@ export default function TonightsBullpenBoard({ teams }) {
       ) : (
         <div className="flex flex-col gap-6 2xl:flex-row 2xl:items-start">
           <div className="min-w-0 flex-1">
+            <TeamGameContextCard
+              gameContext={gameContext.data}
+              loading={gameContext.loading}
+              error={gameContext.error}
+            />
             <BullpenBoardView board={board.data} onSelectPitcher={setDetailPitcherId} />
           </div>
           {detailPitcherId != null && (

--- a/frontend/src/components/bullpen/board/teamGameContextView.js
+++ b/frontend/src/components/bullpen/board/teamGameContextView.js
@@ -1,0 +1,40 @@
+import { formatConfidence } from '../availabilityView'
+import { fmtDataDate } from '../../dashboard/syncStatusView'
+
+const DATA_STATE_LABEL = {
+  live: 'Live',
+  historical: 'Historical',
+  stale: 'Stale',
+  unavailable: 'Unavailable',
+}
+
+const MISSING_FIELD_LABEL = {
+  home_away: 'Home/away',
+  scheduled_time: 'Scheduled time',
+  opponent: 'Opponent',
+}
+
+export function getTeamGameContextView(ctx) {
+  if (!ctx) return { hasContext: false }
+  const state = ctx.state || 'unavailable'
+  const dataState = ctx.data_state || 'unavailable'
+  const missing = (Array.isArray(ctx.missing_fields) ? ctx.missing_fields : [])
+    .map(field => MISSING_FIELD_LABEL[field] || field)
+
+  return {
+    hasContext: true,
+    state,
+    // Only a real stored game is "present"; no_game_found / unavailable are not.
+    isPresent: ctx.available === true && state === 'stored_game_log',
+    sourceLabel: ctx.source_label || 'Stored game-log context',
+    dataState,
+    dataStateLabel: DATA_STATE_LABEL[dataState] || 'Unknown',
+    message: ctx.message || null,
+    opponent: ctx.opponent || null,
+    opponentAbbr: ctx.opponent_abbreviation || null,
+    gameDate: fmtDataDate(ctx.game_date),
+    confidenceLabel: formatConfidence(ctx.confidence),
+    missingFields: missing,
+    isToday: !!ctx.is_today,
+  }
+}

--- a/frontend/src/components/dashboard/BullpenLandscape.jsx
+++ b/frontend/src/components/dashboard/BullpenLandscape.jsx
@@ -1,0 +1,69 @@
+import { getLandscapeView } from './bullpenLandscapeView'
+
+// Tonight's Bullpen Landscape — league-wide orientation for first-time users.
+// Descriptive context only: it surfaces which bullpens are most constrained /
+// most available / carrying the most monitoring. It is NOT a ranking, a
+// scoreboard, or a game forecast.
+function Column({ column }) {
+  return (
+    <div className="card p-4">
+      <div className="flex items-center gap-2">
+        <span className="h-2 w-2 rounded-full" style={{ backgroundColor: column.tone.dot }} aria-hidden="true" />
+        <h4 className="font-mono text-xs uppercase tracking-widest text-chalk400">{column.title}</h4>
+      </div>
+      {column.entries.length === 0 ? (
+        <p className="mt-3 text-xs text-chalk600">None right now.</p>
+      ) : (
+        <ol className="mt-3 space-y-2">
+          {column.entries.map(entry => (
+            <li key={entry.teamId ?? entry.label} className="flex items-baseline justify-between gap-2">
+              <span className="truncate font-medium text-chalk200" title={entry.teamName || entry.label}>
+                {entry.label}
+              </span>
+              <span className="shrink-0 font-mono text-xs" style={{ color: column.tone.color }}>
+                {entry[column.metric]} <span className="text-chalk600">{column.suffix}</span>
+              </span>
+            </li>
+          ))}
+        </ol>
+      )}
+    </div>
+  )
+}
+
+export default function BullpenLandscape({ landscape }) {
+  const view = getLandscapeView(landscape)
+  if (!view.hasLandscape) return null
+
+  return (
+    <section className="mb-6" aria-label="Tonight's Bullpen Landscape">
+      <div className="mb-3">
+        <h2 className="font-mono text-xs uppercase tracking-widest text-chalk400">Tonight's Bullpen Landscape</h2>
+        <p className="mt-1 text-xs leading-relaxed text-chalk600">
+          League-wide bullpen state across {view.teamsEvaluated} tracked team{view.teamsEvaluated === 1 ? '' : 's'}.
+          This is bullpen context, not a game prediction.
+        </p>
+      </div>
+
+      {/* Stored games anchor */}
+      <div className="mb-4 rounded-lg border border-dirt bg-field/50 px-4 py-2">
+        <span className="font-mono text-[11px] uppercase tracking-widest text-chalk500">Games</span>
+        <span className="ml-2 font-mono text-xs text-chalk300">{view.games.label}</span>
+      </div>
+
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+        {view.columns.map(column => (
+          <Column key={column.key} column={column} />
+        ))}
+      </div>
+
+      {view.notes.length > 0 && (
+        <ul className="mt-3 space-y-1">
+          {view.notes.map((note, index) => (
+            <li key={index} className="text-[11px] leading-relaxed text-chalk600">• {note}</li>
+          ))}
+        </ul>
+      )}
+    </section>
+  )
+}

--- a/frontend/src/components/dashboard/Dashboard.jsx
+++ b/frontend/src/components/dashboard/Dashboard.jsx
@@ -3,6 +3,7 @@ import { useFetch } from '../../hooks/useFetch'
 import { getBullpenDashboard } from '../../utils/api'
 import { LoadingPane, ErrorState } from '../UI'
 import SeasonBanner from './SeasonBanner'
+import BullpenLandscape from './BullpenLandscape'
 import { fmtSyncDate } from './syncStatusView'
 import {
   getBoardContextView,
@@ -81,6 +82,9 @@ export function DashboardView({ data, loading = false, error = null, onRetry }) 
         <ErrorState message={error} onRetry={onRetry} />
       ) : !data ? null : (
         <>
+          {/* Tonight's Bullpen Landscape — first-time league orientation */}
+          <BullpenLandscape landscape={data.landscape} />
+
           {/* Section 2 — Bullpen Snapshot */}
           <Section title="League-Wide Bullpen Snapshot" subtitle={`${context.metrics.total} relievers across all tracked MLB bullpens`}>
             <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">

--- a/frontend/src/components/dashboard/bullpenLandscapeView.js
+++ b/frontend/src/components/dashboard/bullpenLandscapeView.js
@@ -1,0 +1,66 @@
+import { fmtDataDate } from './syncStatusView'
+
+// Neutral tones per callout column — describing situations, never "good/bad".
+const COLUMN_TONE = {
+  constrained: { color: '#fca5a5', dot: '#ef4444' },
+  available: { color: '#6ee7b7', dot: '#10b981' },
+  monitoring: { color: '#fde047', dot: '#eab308' },
+}
+
+function entryLabel(entry) {
+  return entry?.team_abbreviation || entry?.team_name || `Team ${entry?.team_id ?? ''}`.trim()
+}
+
+function mapEntries(list) {
+  return (Array.isArray(list) ? list : []).map(entry => ({
+    teamId: entry?.team_id,
+    label: entryLabel(entry),
+    teamName: entry?.team_name || null,
+    available: Number(entry?.available) || 0,
+    monitor: Number(entry?.monitor) || 0,
+    restricted: Number(entry?.restricted) || 0,
+    total: Number(entry?.total_relievers) || 0,
+    pctAvailable: Number(entry?.pct_available) || 0,
+    pctRestricted: Number(entry?.pct_restricted) || 0,
+    healthLabel: entry?.health_label || null,
+  }))
+}
+
+export function getLandscapeView(landscape) {
+  if (!landscape) return { hasLandscape: false }
+  const games = landscape.games || {}
+  const dataState = games.data_state || 'unavailable'
+  const asOfDate = fmtDataDate(games.as_of_date)
+
+  let gamesLabel
+  if (games.available === false || dataState === 'unavailable') {
+    gamesLabel = games.message || 'Schedule context unavailable'
+  } else if (games.is_today && games.today_count > 0) {
+    gamesLabel = `${games.today_count} game${games.today_count === 1 ? '' : 's'} in today's stored data`
+  } else {
+    const count = games.as_of_count || 0
+    gamesLabel = `No games in today's stored data · latest stored slate ${asOfDate || 'unavailable'} (${count} game${count === 1 ? '' : 's'})`
+  }
+
+  return {
+    hasLandscape: true,
+    referenceDate: fmtDataDate(landscape.reference_date),
+    teamsEvaluated: Number(landscape.teams_evaluated) || 0,
+    games: {
+      available: games.available !== false,
+      isToday: !!games.is_today,
+      dataState,
+      label: gamesLabel,
+      asOfDate,
+    },
+    columns: [
+      { key: 'constrained', title: 'Most constrained bullpen situations', metric: 'restricted',
+        suffix: 'Avoid / Unavailable', tone: COLUMN_TONE.constrained, entries: mapEntries(landscape.constrained_bullpens) },
+      { key: 'available', title: 'Most available bullpen situations', metric: 'available',
+        suffix: 'Available Tonight', tone: COLUMN_TONE.available, entries: mapEntries(landscape.available_bullpens) },
+      { key: 'monitoring', title: 'Monitoring concentration', metric: 'monitor',
+        suffix: 'in Monitor', tone: COLUMN_TONE.monitoring, entries: mapEntries(landscape.monitoring_concentration) },
+    ],
+    notes: Array.isArray(landscape.notes) ? landscape.notes : [],
+  }
+}

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -623,6 +623,10 @@ export const getBullpenOverview = () => request('/bullpen/stats/overview')
 // League-wide bullpen landing summary: availability snapshot, Team Context
 // health, and usage-role composition. Context only (no ranking/selection).
 export const getBullpenDashboard = () => request('/bullpen/dashboard')
+// Tonight's Bullpen Landscape — league-wide bullpen context (descriptive only).
+export const getBullpenLandscape = () => request('/bullpen/landscape')
+// Today's Game Context for one team, derived from stored game logs only.
+export const getTeamGameContext = (teamId) => request(`/bullpen/teams/${teamId}/game-context`)
 export const getSyncStatus     = () => request('/bullpen/sync/status')
 export const getFatigueEraInsight = () => request('/bullpen/insights/fatigue-era')
 // No public helper for /bullpen/fatigue/snapshot: latest-workload snapshot mode

--- a/frontend/tests/bullpenLandscapeAndGameContext.test.mjs
+++ b/frontend/tests/bullpenLandscapeAndGameContext.test.mjs
@@ -1,0 +1,140 @@
+import assert from 'node:assert/strict'
+import test, { after } from 'node:test'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import { createServer } from 'vite'
+
+import { makeBoard } from './fixtures/bullpenBoardFixtures.mjs'
+
+const server = await createServer({
+  root: process.cwd(),
+  server: { middlewareMode: true },
+  appType: 'custom',
+  logLevel: 'silent',
+})
+
+after(async () => {
+  await server.close()
+})
+
+const { default: BullpenLandscape } = await server.ssrLoadModule('/src/components/dashboard/BullpenLandscape.jsx')
+const { default: TeamGameContextCard } = await server.ssrLoadModule('/src/components/bullpen/board/TeamGameContextCard.jsx')
+const { DashboardView } = await server.ssrLoadModule('/src/components/dashboard/Dashboard.jsx')
+
+const escapeRegExp = (value) => String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+const htmlIncludes = (html, text) => new RegExp(escapeRegExp(text)).test(html)
+const render = (el) => renderToStaticMarkup(React.createElement(MemoryRouter, null, el))
+
+// Affirmative advisory phrasing that must never appear. (The required
+// disclaimers legitimately negate "prediction"/"matchup advice", so those bare
+// words are checked separately as disclaimers, not as advisory language.)
+const FORBIDDEN_AFFIRMATIVE = [
+  'best bullpen', 'worst bullpen', 'best arm', 'recommended', 'recommendation',
+  'should use', 'expected winner', 'has the advantage', 'we recommend',
+]
+const noAffirmativeAdvisory = (html) => {
+  const low = html.toLowerCase()
+  return FORBIDDEN_AFFIRMATIVE.every(term => !low.includes(term))
+}
+
+const landscape = {
+  capability: 'tonights_bullpen_landscape',
+  ranking_applied: false,
+  selection_made: false,
+  reference_date: '2026-06-06',
+  teams_evaluated: 3,
+  games: { available: true, data_state: 'historical', today_count: 0, as_of_date: '2026-06-04', as_of_count: 5, is_today: false, message: null },
+  constrained_bullpens: [{ team_id: 1, team_name: 'Aces', team_abbreviation: 'ACE', total_relievers: 8, available: 2, monitor: 2, restricted: 4, pct_available: 25, pct_restricted: 50, health_state: 'constrained', health_label: 'Availability is constrained tonight.' }],
+  available_bullpens: [{ team_id: 2, team_name: 'Bears', team_abbreviation: 'BEA', total_relievers: 8, available: 6, monitor: 1, restricted: 1, pct_available: 75, pct_restricted: 12, health_state: 'manageable', health_label: 'Bullpen workload appears manageable.' }],
+  monitoring_concentration: [{ team_id: 3, team_name: 'Cubs', team_abbreviation: 'CHC', total_relievers: 8, available: 3, monitor: 4, restricted: 1, pct_available: 37, pct_restricted: 12, health_state: 'monitoring', health_label: 'Several relievers require monitoring.' }],
+  notes: ['Descriptive groupings of bullpen situations only — this is bullpen context, not a league ranking or a game forecast.', 'Game context is from the latest stored game log, not a live schedule.'],
+}
+
+// ── Tonight's Bullpen Landscape ────────────────────────────────────────────
+
+test('landscape renders title and the three descriptive callout columns', () => {
+  const html = render(React.createElement(BullpenLandscape, { landscape }))
+  assert.ok(htmlIncludes(html, 'Bullpen Landscape'))
+  assert.ok(htmlIncludes(html, 'Most constrained bullpen situations'))
+  assert.ok(htmlIncludes(html, 'Most available bullpen situations'))
+  assert.ok(htmlIncludes(html, 'Monitoring concentration'))
+  assert.ok(htmlIncludes(html, 'ACE'))
+  assert.ok(htmlIncludes(html, 'BEA'))
+  assert.ok(htmlIncludes(html, 'CHC'))
+})
+
+test('landscape shows the stored-games anchor honestly (not a live schedule)', () => {
+  const html = render(React.createElement(BullpenLandscape, { landscape }))
+  assert.ok(htmlIncludes(html, 'latest stored slate'))
+  assert.ok(htmlIncludes(html, 'not a game prediction'))   // required disclaimer
+})
+
+test('landscape renders nothing without data', () => {
+  const html = render(React.createElement(BullpenLandscape, { landscape: null }))
+  assert.equal(html, '')
+})
+
+test('landscape contains no affirmative advisory language', () => {
+  const html = render(React.createElement(BullpenLandscape, { landscape }))
+  assert.ok(noAffirmativeAdvisory(html), 'affirmative advisory language leaked')
+})
+
+test('dashboard surfaces the landscape section near the top', () => {
+  const data = {
+    capability: 'bullpen_dashboard',
+    context: makeBoard({ cardsByStatus: { Available: [{ pitcher_id: 1, name: 'A', availability_status: 'Available' }] } }).context,
+    roles: { order: [], counts: {}, total: 1 },
+    freshness: { is_current: false, sync_status: 'metadata_unavailable', data_through: '2026-06-04' },
+    landscape,
+  }
+  const html = render(React.createElement(DashboardView, { data }))
+  assert.ok(htmlIncludes(html, 'Bullpen Landscape'))
+  assert.ok(htmlIncludes(html, 'Most constrained bullpen situations'))
+})
+
+// ── Today's Game Context card ──────────────────────────────────────────────
+
+const presentContext = {
+  capability: 'team_game_context', available: true, state: 'stored_game_log', data_source: 'game_log',
+  data_state: 'historical', source_label: 'Stored game-log context', confidence: 'medium',
+  opponent: 'Rivals', opponent_abbreviation: 'RIV', game_date: '2026-06-04', home_away: null,
+  scheduled_time: null, game_status: 'final', is_today: false, missing_fields: ['home_away', 'scheduled_time'],
+}
+
+test('game-context card shows opponent, date, and stored-context labelling', () => {
+  const html = render(React.createElement(TeamGameContextCard, { gameContext: presentContext }))
+  assert.ok(htmlIncludes(html, 'Game Context'))
+  assert.ok(htmlIncludes(html, 'Stored game-log context'))
+  assert.ok(htmlIncludes(html, 'Rivals'))
+  assert.ok(htmlIncludes(html, 'Jun 4, 2026'))
+  // Unavailable fields are stated, not fabricated.
+  assert.ok(htmlIncludes(html, 'Home/away and Scheduled time unavailable in stored game-log data.'))
+  assert.ok(htmlIncludes(html, 'does not provide matchup advice or game predictions'))
+})
+
+test('game-context card handles no stored game found', () => {
+  const html = render(React.createElement(TeamGameContextCard, {
+    gameContext: { capability: 'team_game_context', available: false, state: 'no_game_found',
+      message: 'No game found in the stored game log for this date.', data_state: 'unavailable', confidence: 'none', missing_fields: [] },
+  }))
+  assert.ok(htmlIncludes(html, 'No stored game-log context found for this date.'))
+})
+
+test('game-context card handles unavailable context', () => {
+  const html = render(React.createElement(TeamGameContextCard, {
+    gameContext: { capability: 'team_game_context', available: false, state: 'unavailable',
+      message: 'Schedule context unavailable.', data_state: 'unavailable', confidence: 'none', missing_fields: [] },
+  }))
+  assert.ok(htmlIncludes(html, 'Schedule context unavailable.'))
+})
+
+test('game-context card handles loading and missing context', () => {
+  assert.ok(htmlIncludes(render(React.createElement(TeamGameContextCard, { loading: true })), 'Loading game context'))
+  assert.ok(htmlIncludes(render(React.createElement(TeamGameContextCard, { gameContext: null })), 'Schedule context unavailable.'))
+})
+
+test('game-context card contains no affirmative advisory language', () => {
+  const html = render(React.createElement(TeamGameContextCard, { gameContext: presentContext }))
+  assert.ok(noAffirmativeAdvisory(html), 'affirmative advisory language leaked')
+})


### PR DESCRIPTION
Improve first-time orientation. The dashboard now opens with a league-wide "Tonight's Bullpen Landscape" before users drill into a single team, and the team bullpen board carries a compact "Today's Game Context" card.

Backend (services/game_context.py — derived from stored data only, no live network call):
- build_team_game_context: a team's most recent stored game on/before today from GameLog. States stored_game_log / no_game_found / unavailable, with data_source=game_log, a freshness data_state, a capped confidence, and missing_fields (home_away, scheduled_time) because the stored game log does not carry them — reported honestly, never fabricated, and never presented as a live schedule.
- build_landscape: groups already-classified availability records by team and surfaces constrained_bullpens, available_bullpens, and monitoring_concentration (top 3 each, descriptive deterministic sort by count then percentage then team name), plus a stored games anchor, teams_evaluated, reference_date, and disclaiming notes. ranking_applied / selection_made stay false.
- Routes on the existing bullpen blueprint: GET /api/bullpen/landscape and GET /api/bullpen/teams/<id>/game-context; the dashboard payload also embeds the landscape (reusing records already classified — no extra availability pass).

Frontend:
- dashboard/BullpenLandscape + bullpenLandscapeView: the landscape section near the top of the dashboard ("This is bullpen context, not a game prediction").
- bullpen/board/TeamGameContextCard + teamGameContextView: the game-context card above the team board, labelled as stored game-log context, stating unavailable fields explicitly, with the helper copy that BaseballOS does not provide matchup advice or game predictions.

Guardrails preserved: descriptive only — no rankings, recommendations, best/worst, advantage, predictions, matchup advice, or hidden ordering. Sorted displays are labelled descriptive/deterministic.

Tests: backend test_game_context.py (states, missing fields, confidence, landscape shape/governance, deterministic sorting, stored games anchor, endpoint + dashboard integration, guardrail language) and frontend bullpenLandscapeAndGameContext.test .mjs (rendering, states, dashboard integration, affirmative-advisory regression). Backend 488 pass, frontend 211 pass, build clean.

Docs: docs/TONIGHTS_BULLPEN_LANDSCAPE_AND_GAME_CONTEXT.md.