### PR TITLE
feat: add landscape team drilldown navigation

### DIFF
--- a/docs/LANDSCAPE_TEAM_DRILLDOWN_NAVIGATION.md
+++ b/docs/LANDSCAPE_TEAM_DRILLDOWN_NAVIGATION.md
@@ -1,0 +1,62 @@
+# Landscape Team Drilldown Navigation
+
+## Decision
+
+Make the team rows in **Tonight's Bullpen Landscape** (Most constrained / Most
+available bullpen situations, and Monitoring concentration) clickable, deep-
+linking into that team's bullpen board.
+
+## Reason
+
+The landscape cards naturally create curiosity — users immediately notice the
+teams surfaced and want to investigate them. Previously a team row was a dead
+end (Dashboard → landscape card → team listed → no action).
+
+## Outcome
+
+The dashboard becomes a **discovery workflow** rather than a static information
+view:
+
+```
+Dashboard → Landscape card → click team → Tonight's Bullpen Board, focused on that team
+```
+
+Example: clicking **SF** opens the bullpen board focused on San Francisco;
+clicking **LAD** opens it focused on the Dodgers — with no extra click.
+
+## Guardrail
+
+This is **navigation only**. It introduces no rankings, recommendations, matchup
+advice, or predictions, and changes no availability / fatigue / trust / freshness
+/ comparison / classification logic. The landscape's descriptive, deterministic
+sorting is unchanged; rows simply become links into existing bullpen intelligence.
+
+## How it works (reusing existing architecture)
+
+- Reuses the existing `/bullpen?view=` deep-link pattern already used by the
+  dashboard Quick Actions. Each landscape row links to
+  `/bullpen?view=board&team=<ABBR>&source=landscape` (built by
+  `buildLandscapeTeamHref`). `source=landscape` is passed for later UX analytics.
+- `Bullpen.jsx` reads the existing `?view=` plus a new `?team=` param and passes
+  `requestedTeam` to `TonightsBullpenBoard`.
+- `TonightsBullpenBoard.resolveTeamId` resolves the param against the loaded team
+  list by abbreviation (case-insensitive), numeric id, or name, and preselects
+  that team **once** — a later manual team click is never overridden, and the
+  default-to-first behavior is suppressed only while a resolvable deep link is
+  pending (no flash). No second routing system was introduced.
+
+## Visual affordance
+
+Rows gain a lightweight interactive affordance — cursor pointer, a subtle hover
+highlight, a hover underline on the team name, an arrow that appears on hover,
+and a keyboard focus ring. They render as accessible `<a>` links (keyboard
+reachable) and intentionally remain informational rows, not buttons.
+
+## Tests
+
+`frontend/tests/landscapeTeamDrilldown.test.mjs` — each callout team (constrained
+/ available / monitoring) links to its board; rows are accessible anchors with
+aria-labels; the affordance is present but not button-like; `buildLandscapeTeamHref`
+and `resolveTeamId` (abbreviation/id/name/miss) are unit-tested; and a guardrail
+check confirms no advisory/ranking language was introduced. Existing dashboard,
+landscape, and game-context tests remain green (no regression).

--- a/frontend/src/components/bullpen/Bullpen.jsx
+++ b/frontend/src/components/bullpen/Bullpen.jsx
@@ -30,9 +30,12 @@ const VALID_VIEWS = new Set(VIEW_MODES.map(m => m.id))
 
 export default function Bullpen() {
   const location = useLocation()
-  // Allow the dashboard's Quick Actions to deep-link to a specific tab,
-  // e.g. /bullpen?view=compare. Defaults to Tonight's Board.
-  const requestedView = new URLSearchParams(location.search).get('view')
+  // Allow deep-links to a specific tab and team, e.g. the dashboard Quick Actions
+  // (/bullpen?view=compare) and the landscape team drilldown
+  // (/bullpen?view=board&team=SF). Defaults to Tonight's Board.
+  const searchParams = new URLSearchParams(location.search)
+  const requestedView = searchParams.get('view')
+  const requestedTeam = searchParams.get('team')
   const [viewMode, setViewMode]           = useState(VALID_VIEWS.has(requestedView) ? requestedView : 'board')
   const [selectedTeam, setSelectedTeam]   = useState(null)
   const [riskFilter, setRiskFilter]       = useState('ALL')
@@ -104,7 +107,7 @@ export default function Bullpen() {
       />
 
       {viewMode === 'board' ? (
-        <TonightsBullpenBoard teams={teams} />
+        <TonightsBullpenBoard teams={teams} requestedTeam={requestedTeam} />
       ) : viewMode === 'compare' ? (
         <TeamBullpenComparison teams={teams} />
       ) : viewMode === 'teams' ? (

--- a/frontend/src/components/bullpen/board/TonightsBullpenBoard.jsx
+++ b/frontend/src/components/bullpen/board/TonightsBullpenBoard.jsx
@@ -6,10 +6,30 @@ import BullpenBoardView from './BullpenBoardView'
 import TeamGameContextCard from './TeamGameContextCard'
 import PitcherDetail from '../PitcherDetail'
 
+// Resolve a deep-link `team` param (abbreviation like "SF", a team id, or a name)
+// against the loaded team list. Returns the matching team_id, or null.
+export function resolveTeamId(teamList, requested) {
+  if (requested == null) return null
+  const raw = String(requested).trim()
+  if (!raw || !Array.isArray(teamList)) return null
+
+  const asNum = Number(raw)
+  if (Number.isInteger(asNum)) {
+    const byId = teamList.find(team => team.team_id === asNum)
+    if (byId) return byId.team_id
+  }
+  const lower = raw.toLowerCase()
+  const byAbbr = teamList.find(team => (team.team_abbreviation || '').toLowerCase() === lower)
+  if (byAbbr) return byAbbr.team_id
+  const byName = teamList.find(team => (team.team_name || '').toLowerCase() === lower)
+  return byName ? byName.team_id : null
+}
+
 // Tonight's Bullpen Board lives inside the Bullpen workflow. It receives the
 // shared teams fetch so it does not double-load the team list, manages its own
-// single-team selection, and renders the grouped board for that team.
-export default function TonightsBullpenBoard({ teams }) {
+// single-team selection, and renders the grouped board for that team. A
+// `requestedTeam` deep-link (e.g. from the landscape drilldown) preselects a team.
+export default function TonightsBullpenBoard({ teams, requestedTeam = null }) {
   const teamList = teams?.data || []
   const [selectedTeam, setSelectedTeam] = useState(null)
   const [includeStale, setIncludeStale] = useState(false)
@@ -17,18 +37,32 @@ export default function TonightsBullpenBoard({ teams }) {
   // board never duplicates that screen.
   const [detailPitcherId, setDetailPitcherId] = useState(null)
   const detailRef = useRef(null)
+  // Apply a given requestedTeam deep-link only once, so a later manual team
+  // click is never overridden by the URL.
+  const appliedRequestRef = useRef(null)
 
   useEffect(() => {
     if (detailPitcherId != null) detailRef.current?.focus()
   }, [detailPitcherId])
 
-  // Default to the first team once the list loads so the board shows a bullpen
-  // immediately instead of an empty prompt.
+  // Preselect the deep-linked team (landscape drilldown), once per requested value.
   useEffect(() => {
-    if (selectedTeam == null && teamList.length > 0) {
-      setSelectedTeam(teamList[0].team_id)
+    if (!requestedTeam || teamList.length === 0) return
+    if (appliedRequestRef.current === requestedTeam) return
+    const resolved = resolveTeamId(teamList, requestedTeam)
+    if (resolved != null) {
+      setSelectedTeam(resolved)
+      appliedRequestRef.current = requestedTeam
     }
-  }, [teamList, selectedTeam])
+  }, [requestedTeam, teamList])
+
+  // Default to the first team once the list loads so the board shows a bullpen
+  // immediately — unless a resolvable deep link is pending (avoids a flash).
+  useEffect(() => {
+    if (selectedTeam != null || teamList.length === 0) return
+    if (requestedTeam && resolveTeamId(teamList, requestedTeam) != null) return
+    setSelectedTeam(teamList[0].team_id)
+  }, [teamList, selectedTeam, requestedTeam])
 
   const board = useFetch(
     () => {

--- a/frontend/src/components/dashboard/BullpenLandscape.jsx
+++ b/frontend/src/components/dashboard/BullpenLandscape.jsx
@@ -1,4 +1,38 @@
+import { Link } from 'react-router-dom'
 import { getLandscapeView } from './bullpenLandscapeView'
+
+// One landscape team row. When a deep link is available it becomes a lightweight
+// clickable link into that team's bullpen board — informational, not a button.
+function EntryRow({ entry, column }) {
+  const content = (
+    <>
+      <span className="truncate font-medium text-chalk200 group-hover:text-amber group-hover:underline" title={entry.teamName || entry.label}>
+        {entry.label}
+      </span>
+      <span className="flex shrink-0 items-baseline gap-1 font-mono text-xs" style={{ color: column.tone.color }}>
+        {entry[column.metric]} <span className="text-chalk600">{column.suffix}</span>
+        {entry.teamHref && (
+          <span className="text-chalk600 opacity-0 transition-opacity group-hover:opacity-100" aria-hidden="true">→</span>
+        )}
+      </span>
+    </>
+  )
+
+  if (!entry.teamHref) {
+    return <li className="flex items-baseline justify-between gap-2">{content}</li>
+  }
+  return (
+    <li>
+      <Link
+        to={entry.teamHref}
+        className="group -mx-1 flex cursor-pointer items-baseline justify-between gap-2 rounded px-1 py-0.5 transition-colors hover:bg-amber/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber/60"
+        aria-label={`Open the bullpen board for ${entry.teamName || entry.label}`}
+      >
+        {content}
+      </Link>
+    </li>
+  )
+}
 
 // Tonight's Bullpen Landscape — league-wide orientation for first-time users.
 // Descriptive context only: it surfaces which bullpens are most constrained /
@@ -14,16 +48,9 @@ function Column({ column }) {
       {column.entries.length === 0 ? (
         <p className="mt-3 text-xs text-chalk600">None right now.</p>
       ) : (
-        <ol className="mt-3 space-y-2">
+        <ol className="mt-3 space-y-1">
           {column.entries.map(entry => (
-            <li key={entry.teamId ?? entry.label} className="flex items-baseline justify-between gap-2">
-              <span className="truncate font-medium text-chalk200" title={entry.teamName || entry.label}>
-                {entry.label}
-              </span>
-              <span className="shrink-0 font-mono text-xs" style={{ color: column.tone.color }}>
-                {entry[column.metric]} <span className="text-chalk600">{column.suffix}</span>
-              </span>
-            </li>
+            <EntryRow key={entry.teamId ?? entry.label} entry={entry} column={column} />
           ))}
         </ol>
       )}

--- a/frontend/src/components/dashboard/bullpenLandscapeView.js
+++ b/frontend/src/components/dashboard/bullpenLandscapeView.js
@@ -11,11 +11,22 @@ function entryLabel(entry) {
   return entry?.team_abbreviation || entry?.team_name || `Team ${entry?.team_id ?? ''}`.trim()
 }
 
+// Deep-link a landscape team row into its bullpen board, reusing the existing
+// /bullpen?view= deep-link pattern. Prefers the abbreviation (e.g. SF) and falls
+// back to the numeric team id; source=landscape is passed for later UX analytics.
+export function buildLandscapeTeamHref(entry) {
+  const param = entry?.team_abbreviation || (entry?.team_id != null ? String(entry.team_id) : null)
+  if (!param) return null
+  const query = new URLSearchParams({ view: 'board', team: param, source: 'landscape' })
+  return `/bullpen?${query.toString()}`
+}
+
 function mapEntries(list) {
   return (Array.isArray(list) ? list : []).map(entry => ({
     teamId: entry?.team_id,
     label: entryLabel(entry),
     teamName: entry?.team_name || null,
+    teamHref: buildLandscapeTeamHref(entry),
     available: Number(entry?.available) || 0,
     monitor: Number(entry?.monitor) || 0,
     restricted: Number(entry?.restricted) || 0,

--- a/frontend/tests/landscapeTeamDrilldown.test.mjs
+++ b/frontend/tests/landscapeTeamDrilldown.test.mjs
@@ -1,0 +1,104 @@
+import assert from 'node:assert/strict'
+import test, { after } from 'node:test'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import { createServer } from 'vite'
+
+const server = await createServer({
+  root: process.cwd(),
+  server: { middlewareMode: true },
+  appType: 'custom',
+  logLevel: 'silent',
+})
+
+after(async () => {
+  await server.close()
+})
+
+const { default: BullpenLandscape } = await server.ssrLoadModule('/src/components/dashboard/BullpenLandscape.jsx')
+const { buildLandscapeTeamHref } = await server.ssrLoadModule('/src/components/dashboard/bullpenLandscapeView.js')
+const { resolveTeamId } = await server.ssrLoadModule('/src/components/bullpen/board/TonightsBullpenBoard.jsx')
+
+const escapeRegExp = (value) => String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+const htmlIncludes = (html, text) => new RegExp(escapeRegExp(text)).test(html)
+const render = (el) => renderToStaticMarkup(React.createElement(MemoryRouter, null, el))
+
+const landscape = {
+  capability: 'tonights_bullpen_landscape',
+  reference_date: '2026-06-06',
+  teams_evaluated: 3,
+  games: { available: true, data_state: 'historical', today_count: 0, as_of_date: '2026-06-04', as_of_count: 5, is_today: false },
+  constrained_bullpens: [{ team_id: 1, team_name: 'Aces', team_abbreviation: 'ACE', total_relievers: 8, available: 2, monitor: 2, restricted: 4, pct_available: 25, pct_restricted: 50, health_label: 'Availability is constrained tonight.' }],
+  available_bullpens: [{ team_id: 2, team_name: 'Bears', team_abbreviation: 'BEA', total_relievers: 8, available: 6, monitor: 1, restricted: 1, pct_available: 75, pct_restricted: 12, health_label: 'Bullpen workload appears manageable.' }],
+  monitoring_concentration: [{ team_id: 3, team_name: 'Cubs', team_abbreviation: 'CHC', total_relievers: 8, available: 3, monitor: 4, restricted: 1, pct_available: 37, pct_restricted: 12, health_label: 'Several relievers require monitoring.' }],
+  notes: [],
+}
+
+const html = render(React.createElement(BullpenLandscape, { landscape }))
+
+// ── Routing correctness: each callout team deep-links into its bullpen board ─
+
+test('clicking a constrained team links to its bullpen board', () => {
+  assert.ok(htmlIncludes(html, 'view=board'))
+  assert.ok(htmlIncludes(html, 'team=ACE'))
+  assert.ok(htmlIncludes(html, 'source=landscape'))
+})
+
+test('clicking an available team links to its bullpen board', () => {
+  assert.ok(htmlIncludes(html, 'team=BEA'))
+})
+
+test('clicking a monitoring team links to its bullpen board', () => {
+  assert.ok(htmlIncludes(html, 'team=CHC'))
+})
+
+test('rows render as accessible links (anchor + aria-label), keyboard reachable', () => {
+  assert.ok(htmlIncludes(html, '<a'))
+  assert.ok(htmlIncludes(html, 'Open the bullpen board for Aces'))
+  assert.ok(htmlIncludes(html, 'Open the bullpen board for Bears'))
+  assert.ok(htmlIncludes(html, 'Open the bullpen board for Cubs'))
+})
+
+test('rows carry an interactive affordance but are not buttons', () => {
+  assert.ok(htmlIncludes(html, 'cursor-pointer'))
+  assert.ok(htmlIncludes(html, 'hover:bg-amber/5'))
+  // Informational rows: no role="button" / <button> styling.
+  assert.ok(!htmlIncludes(html, 'role="button"'))
+  assert.ok(!htmlIncludes(html, '<button'))
+})
+
+// ── buildLandscapeTeamHref ─────────────────────────────────────────────────
+
+test('buildLandscapeTeamHref prefers abbreviation, falls back to id, else null', () => {
+  assert.equal(buildLandscapeTeamHref({ team_abbreviation: 'SF', team_id: 1 }),
+    '/bullpen?view=board&team=SF&source=landscape')
+  assert.equal(buildLandscapeTeamHref({ team_id: 5 }),
+    '/bullpen?view=board&team=5&source=landscape')
+  assert.equal(buildLandscapeTeamHref({}), null)
+})
+
+// ── resolveTeamId (the deep-link target the bullpen board reads) ────────────
+
+test('resolveTeamId matches abbreviation (case-insensitive), id, and name', () => {
+  const teamList = [
+    { team_id: 1, team_abbreviation: 'SF', team_name: 'San Francisco' },
+    { team_id: 2, team_abbreviation: 'NYY', team_name: 'New York' },
+  ]
+  assert.equal(resolveTeamId(teamList, 'SF'), 1)
+  assert.equal(resolveTeamId(teamList, 'sf'), 1)        // case-insensitive
+  assert.equal(resolveTeamId(teamList, '2'), 2)         // numeric id
+  assert.equal(resolveTeamId(teamList, 'New York'), 2)  // name
+  assert.equal(resolveTeamId(teamList, 'ZZZ'), null)    // miss
+  assert.equal(resolveTeamId(teamList, null), null)
+  assert.equal(resolveTeamId([], 'SF'), null)
+})
+
+// ── Guardrail: navigation only, no advisory/ranking language ───────────────
+
+test('drilldown adds no advisory or ranking language to the rows', () => {
+  const low = html.toLowerCase()
+  for (const term of ['best bullpen', 'worst bullpen', 'recommended', 'should use', 'advantage', 'rank #', 'ranked']) {
+    assert.ok(!low.includes(term), `leaked term: ${term}`)
+  }
+})


### PR DESCRIPTION
Make the team rows in Tonight's Bullpen Landscape (Most constrained / Most available bullpen situations, and Monitoring concentration) clickable, deep- linking into that team's bullpen board. The dashboard becomes a discovery workflow: landscape card -> click team -> Tonight's Bullpen Board focused on that team, with no extra click.

Navigation only — no analytics, ranking, recommendation, matchup, or prediction logic is added or changed; availability/fatigue/trust/freshness/comparison/ classification logic is untouched.

- Reuses the existing /bullpen?view= deep-link pattern. Each row links to /bullpen?view=board&team=<ABBR>&source=landscape (buildLandscapeTeamHref); source=landscape is passed for later UX analytics.
- Bullpen.jsx reads the new ?team= param and passes requestedTeam to the board.
- TonightsBullpenBoard.resolveTeamId resolves the param by abbreviation (case-insensitive), id, or name and preselects that team once — a later manual click is never overridden, and default-to-first is suppressed only while a resolvable deep link is pending (no flash). No second routing system added.
- Rows gain a lightweight affordance (cursor pointer, hover highlight + underline, hover arrow, focus ring) and render as accessible <a> links; they stay informational rows, not buttons.

Tests: frontend/tests/landscapeTeamDrilldown.test.mjs (constrained/available/ monitoring drilldown hrefs, accessible anchors + aria-labels, affordance present but not button-like, buildLandscapeTeamHref and resolveTeamId units, guardrail language). Frontend 219 pass, build clean, backend 488 unchanged.

Docs: docs/LANDSCAPE_TEAM_DRILLDOWN_NAVIGATION.md.