### PR TITLE
feat: improve game context visual hierarchy

### DIFF
--- a/docs/GAME_CONTEXT_VISUAL_HIERARCHY.md
+++ b/docs/GAME_CONTEXT_VISUAL_HIERARCHY.md
@@ -1,0 +1,62 @@
+# Today's Game Context — Visual Hierarchy
+
+## Decision
+
+Improve the visual hierarchy of the **Today's Game Context** card so the
+opponent/matchup is the first thing a user notices, while keeping all trust
+metadata visible.
+
+## Reason
+
+The card was technically correct but too data-oriented — the opponent sat in a
+small grid field competing with Date / Historical / Status. Users understand the
+bullpen faster when the game relationship is immediately obvious: a person should
+read *"this bullpen belongs to a game against the Dodgers"* before scanning any
+metadata.
+
+## What changed (refinement, not rewrite)
+
+- **Matchup is the hero.** The card now leads with `Team` **vs** `Opponent`,
+  with the opponent rendered at display size in the amber gradient — the
+  dominant element. The game date sits just under it.
+- **Metadata is subordinate.** Data state ("Historical Game Log"), confidence
+  ("Medium Confidence"), and status ("Final") moved into a single quiet,
+  monospaced line beneath the matchup. Unavailable fields (home/away, scheduled
+  time) remain stated. Nothing was hidden — only de-emphasized.
+- **Elevated context banner.** The disclaimer is now a subtle left-accent banner:
+  *"Game context helps explain bullpen workload and availability. BaseballOS does
+  not provide matchup advice or game predictions."*
+- **Polished empty states.** `no_game_found` → "No stored game-log context found
+  for this date."; `unavailable` / error / null → "Schedule context unavailable.";
+  opponent-missing degrades to "Opponent unavailable." No technical/debug wording.
+- The view helper now exposes the team name (from the existing payload's `team`),
+  a long data-state label, and the status label. No backend, availability,
+  fatigue, trust, freshness, or classification logic changed.
+
+## Guardrail
+
+This is **contextual framing only.** The card does not become a scoreboard,
+schedule product, matchup engine, or prediction surface. It adds no scores,
+standings, records, win probability, betting/odds, projections, expected
+outcomes, or matchup recommendations. The data remains stored game-log context,
+labelled honestly, with trust transparency intact.
+
+## Tests
+
+- `frontend/tests/gameContextVisualHierarchy.test.mjs` — matchup rendered
+  prominently (opponent is the hero element and reads before the metadata), trust
+  metadata still visible (data state / confidence / status / missing fields /
+  date), context banner + disclaimer present, `no_game_found` / `unavailable` /
+  loading / null states, opponent-missing graceful degradation, and a
+  scoreboard/advisory/prediction language regression.
+- Existing `bullpenLandscapeAndGameContext.test.mjs` remains green (no regression).
+- `npm run build` passes; `git diff --check` clean.
+
+## Observations / limitations
+
+- Home/away is not in the stored game log, so the connector is a neutral "vs"
+  and the missing-fields note states home/away + scheduled time are unavailable.
+- When the payload lacks a team name (older/edge payloads), the hero shows
+  "vs Opponent" without the team prefix — still reads as the game relationship.
+- Desktop and mobile both lead with the matchup; the metadata line wraps and
+  stays readable on narrow widths.

--- a/frontend/src/components/bullpen/board/TeamGameContextCard.jsx
+++ b/frontend/src/components/bullpen/board/TeamGameContextCard.jsx
@@ -1,23 +1,78 @@
 import { getTeamGameContextView } from './teamGameContextView'
 
-// Today's Game Context — a compact card that frames a team's bullpen with its
-// most recent stored game. Derived from stored game logs only (labelled as
-// such), never presented as a live schedule. Not a scoreboard, matchup engine,
-// or prediction.
-const HELPER_COPY =
-  'Game context is provided to frame bullpen availability and workload. BaseballOS does not provide matchup advice or game predictions.'
+// Today's Game Context — frames a team's bullpen with its most recent stored
+// game. The opponent/matchup is the hero so a user instantly understands who the
+// bullpen is connected to; trust metadata stays visible but subordinate. Derived
+// from stored game logs only (labelled as such), never a live schedule. Not a
+// scoreboard, matchup engine, or prediction.
+const CONTEXT_BANNER =
+  'Game context helps explain bullpen workload and availability. BaseballOS does not provide matchup advice or game predictions.'
 
-function Field({ label, value, muted = false }) {
+function ContextBanner() {
   return (
-    <div>
-      <dt className="font-mono text-[10px] uppercase tracking-widest text-chalk600">{label}</dt>
-      <dd className={`mt-0.5 font-mono text-xs ${muted ? 'text-chalk500' : 'text-chalk200'}`}>{value}</dd>
+    <p className="mt-4 rounded border-l-2 border-amber/40 bg-amber/5 px-3 py-2 text-[11px] leading-relaxed text-chalk400">
+      {CONTEXT_BANNER}
+    </p>
+  )
+}
+
+function Matchup({ view }) {
+  return (
+    <div className="mt-3">
+      {/* Hero: the opponent the bullpen is connected to is the dominant element. */}
+      <div className="flex flex-col items-start gap-x-3 gap-y-0.5 sm:flex-row sm:flex-wrap sm:items-baseline">
+        {view.teamName && (
+          <span className="font-display text-xl tracking-wide text-chalk100">{view.teamName}</span>
+        )}
+        <span className="font-mono text-[11px] uppercase tracking-widest text-chalk500">vs</span>
+        <span className="font-display text-2xl tracking-wide text-gradient-amber">
+          {view.opponent || 'Opponent unavailable'}
+        </span>
+      </div>
+      {view.gameDate && (
+        <div className="mt-1 font-mono text-sm text-chalk300">{view.gameDate}</div>
+      )}
+
+      {/* Subordinate trust metadata — present but visually quiet. */}
+      <div className="mt-3 flex flex-wrap items-center gap-x-2 gap-y-1 font-mono text-[11px] uppercase tracking-widest text-chalk500">
+        <span>{view.dataStateLongLabel}</span>
+        <span className="text-chalk700" aria-hidden="true">·</span>
+        <span>{view.confidenceLabel} Confidence</span>
+        <span className="text-chalk700" aria-hidden="true">·</span>
+        <span>{view.statusLabel}</span>
+      </div>
+      {view.missingFields.length > 0 && (
+        <p className="mt-2 font-mono text-[11px] text-chalk600">
+          {view.missingFields.join(' and ')} unavailable in stored game-log data.
+        </p>
+      )}
     </div>
   )
 }
 
+function EmptyState({ message }) {
+  return <p className="mt-3 text-sm leading-relaxed text-chalk400">{message}</p>
+}
+
 export default function TeamGameContextCard({ gameContext, loading = false, error = null }) {
   const view = getTeamGameContextView(gameContext)
+
+  let body
+  if (loading) {
+    body = <p className="mt-3 font-mono text-xs text-chalk500">Loading game context…</p>
+  } else if (error || !view.hasContext) {
+    body = <EmptyState message="Schedule context unavailable." />
+  } else if (!view.isPresent) {
+    body = (
+      <EmptyState
+        message={view.state === 'no_game_found'
+          ? 'No stored game-log context found for this date.'
+          : (view.message || 'Schedule context unavailable.')}
+      />
+    )
+  } else {
+    body = <Matchup view={view} />
+  }
 
   return (
     <section className="mb-5 rounded-lg border border-dirt bg-field/60 p-4" aria-label="Today's Game Context">
@@ -28,37 +83,9 @@ export default function TeamGameContextCard({ gameContext, loading = false, erro
         </span>
       </div>
 
-      {loading ? (
-        <p className="mt-3 font-mono text-xs text-chalk500">Loading game context…</p>
-      ) : error ? (
-        <p className="mt-3 font-mono text-xs text-chalk500">Schedule context unavailable.</p>
-      ) : !view.hasContext ? (
-        <p className="mt-3 font-mono text-xs text-chalk500">Schedule context unavailable.</p>
-      ) : !view.isPresent ? (
-        <p className="mt-3 text-sm leading-relaxed text-chalk400">
-          {view.state === 'no_game_found'
-            ? 'No stored game-log context found for this date.'
-            : (view.message || 'Schedule context unavailable.')}
-        </p>
-      ) : (
-        <>
-          <dl className="mt-3 grid grid-cols-2 gap-x-4 gap-y-3 sm:grid-cols-4">
-            <Field label="Opponent" value={view.opponent || '—'} />
-            <Field label="Game date" value={view.gameDate || '—'} />
-            <Field label="Data" value={`${view.dataStateLabel} · ${view.confidenceLabel} confidence`} muted />
-            <Field label="Status" value={view.isToday ? 'Scheduled' : 'Final'} muted />
-          </dl>
-          {view.missingFields.length > 0 && (
-            <p className="mt-2 font-mono text-[11px] text-chalk600">
-              {view.missingFields.join(' and ')} unavailable in stored game-log data.
-            </p>
-          )}
-        </>
-      )}
+      {body}
 
-      <p className="mt-3 border-t border-dirt/70 pt-2 text-[11px] leading-relaxed text-chalk500">
-        {HELPER_COPY}
-      </p>
+      <ContextBanner />
     </section>
   )
 }

--- a/frontend/src/components/bullpen/board/teamGameContextView.js
+++ b/frontend/src/components/bullpen/board/teamGameContextView.js
@@ -8,6 +8,14 @@ const DATA_STATE_LABEL = {
   unavailable: 'Unavailable',
 }
 
+// Longer, plain labels for the subordinate metadata row.
+const DATA_STATE_LONG_LABEL = {
+  live: 'Current Game Log',
+  historical: 'Historical Game Log',
+  stale: 'Stale Game Log',
+  unavailable: 'Unavailable',
+}
+
 const MISSING_FIELD_LABEL = {
   home_away: 'Home/away',
   scheduled_time: 'Scheduled time',
@@ -21,6 +29,7 @@ export function getTeamGameContextView(ctx) {
   const missing = (Array.isArray(ctx.missing_fields) ? ctx.missing_fields : [])
     .map(field => MISSING_FIELD_LABEL[field] || field)
 
+  const team = ctx.team || {}
   return {
     hasContext: true,
     state,
@@ -29,11 +38,14 @@ export function getTeamGameContextView(ctx) {
     sourceLabel: ctx.source_label || 'Stored game-log context',
     dataState,
     dataStateLabel: DATA_STATE_LABEL[dataState] || 'Unknown',
+    dataStateLongLabel: DATA_STATE_LONG_LABEL[dataState] || 'Unknown',
     message: ctx.message || null,
+    teamName: team.team_name || team.team_abbreviation || null,
     opponent: ctx.opponent || null,
     opponentAbbr: ctx.opponent_abbreviation || null,
     gameDate: fmtDataDate(ctx.game_date),
     confidenceLabel: formatConfidence(ctx.confidence),
+    statusLabel: ctx.is_today ? 'Scheduled' : 'Final',
     missingFields: missing,
     isToday: !!ctx.is_today,
   }

--- a/frontend/tests/gameContextVisualHierarchy.test.mjs
+++ b/frontend/tests/gameContextVisualHierarchy.test.mjs
@@ -1,0 +1,99 @@
+import assert from 'node:assert/strict'
+import test, { after } from 'node:test'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { createServer } from 'vite'
+
+const server = await createServer({
+  root: process.cwd(),
+  server: { middlewareMode: true },
+  appType: 'custom',
+  logLevel: 'silent',
+})
+
+after(async () => {
+  await server.close()
+})
+
+const { default: TeamGameContextCard } = await server.ssrLoadModule('/src/components/bullpen/board/TeamGameContextCard.jsx')
+
+const escapeRegExp = (value) => String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+const htmlIncludes = (html, text) => new RegExp(escapeRegExp(text)).test(html)
+const render = (props) => renderToStaticMarkup(React.createElement(TeamGameContextCard, props))
+
+const present = {
+  capability: 'team_game_context', available: true, state: 'stored_game_log', data_source: 'game_log',
+  data_state: 'historical', source_label: 'Stored game-log context', confidence: 'medium',
+  team: { team_id: 1, team_name: 'Arizona Diamondbacks', team_abbreviation: 'AZ' },
+  opponent: 'Los Angeles Dodgers', opponent_abbreviation: 'LAD', game_date: '2026-06-04',
+  home_away: null, scheduled_time: null, game_status: 'final', is_today: false,
+  missing_fields: ['home_away', 'scheduled_time'],
+}
+
+// ── Matchup is the hero ────────────────────────────────────────────────────
+
+test('the matchup (team vs opponent) is rendered prominently', () => {
+  const html = render({ gameContext: present })
+  assert.ok(htmlIncludes(html, 'Arizona Diamondbacks'))
+  assert.ok(htmlIncludes(html, 'Los Angeles Dodgers'))
+  assert.ok(htmlIncludes(html, '>vs<'))
+  // The opponent carries the hero emphasis (display-size, amber gradient).
+  assert.ok(/text-gradient-amber[^>]*>\s*Los Angeles Dodgers/.test(html), 'opponent is the hero element')
+})
+
+test('the opponent reads before the trust metadata (hierarchy)', () => {
+  const html = render({ gameContext: present })
+  assert.ok(html.indexOf('Los Angeles Dodgers') < html.indexOf('Historical Game Log'),
+    'matchup should dominate, metadata follows')
+})
+
+// ── Trust metadata is preserved (visible, subordinate) ─────────────────────
+
+test('trust metadata stays visible: data state, confidence, status, missing fields', () => {
+  const html = render({ gameContext: present })
+  assert.ok(htmlIncludes(html, 'Historical Game Log'))
+  assert.ok(htmlIncludes(html, 'Medium Confidence'))
+  assert.ok(htmlIncludes(html, 'Final'))
+  assert.ok(htmlIncludes(html, 'Stored game-log context'))
+  assert.ok(htmlIncludes(html, 'Home/away and Scheduled time unavailable in stored game-log data.'))
+  assert.ok(htmlIncludes(html, '2026'))   // game date present
+})
+
+test('the context banner / disclaimer is present', () => {
+  const html = render({ gameContext: present })
+  assert.ok(htmlIncludes(html, 'Game context helps explain bullpen workload and availability'))
+  assert.ok(htmlIncludes(html, 'does not provide matchup advice or game predictions'))
+})
+
+// ── States ─────────────────────────────────────────────────────────────────
+
+test('no_game_found renders a clear, non-technical empty state', () => {
+  const html = render({ gameContext: { capability: 'team_game_context', available: false, state: 'no_game_found',
+    message: 'No game found in the stored game log for this date.', data_state: 'unavailable', confidence: 'none', missing_fields: [] } })
+  assert.ok(htmlIncludes(html, 'No stored game-log context found for this date.'))
+  assert.ok(htmlIncludes(html, 'Game context helps explain bullpen workload'))  // banner still shown
+})
+
+test('unavailable and loading and null states are clear', () => {
+  assert.ok(htmlIncludes(render({ gameContext: { state: 'unavailable', available: false, message: 'Schedule context unavailable.' } }), 'Schedule context unavailable.'))
+  assert.ok(htmlIncludes(render({ loading: true }), 'Loading game context'))
+  assert.ok(htmlIncludes(render({ gameContext: null }), 'Schedule context unavailable.'))
+})
+
+test('opponent-missing present state degrades gracefully', () => {
+  const html = render({ gameContext: { ...present, opponent: null } })
+  assert.ok(htmlIncludes(html, 'Opponent unavailable'))
+})
+
+// ── Guardrails: contextual framing only, never a scoreboard ─────────────────
+
+test('no scoreboard / advisory / prediction language is introduced', () => {
+  const html = render({ gameContext: present }).toLowerCase()
+  for (const term of [
+    'best bullpen', 'worst bullpen', 'recommended', 'should use', 'advantage',
+    'win probability', 'standings', 'betting', 'odds', 'projection', 'projected',
+    'expected outcome', 'expected winner', 'final score', 'box score',
+  ]) {
+    assert.ok(!html.includes(term), `leaked term: ${term}`)
+  }
+})


### PR DESCRIPTION
Refine the Today's Game Context card so the opponent/matchup is the first thing a user notices, while keeping all trust metadata visible.

- Matchup is the hero: the card leads with Team vs Opponent, the opponent rendered at display size in the amber gradient (dominant), with the game date just beneath. A user instantly reads "this bullpen belongs to a game against the Dodgers" before any metadata.
- Trust metadata is subordinate, not hidden: data state ("Historical Game Log"), confidence, and status move to a single quiet line below the matchup; missing fields (home/away, scheduled time) remain stated.
- Elevated context banner: "Game context helps explain bullpen workload and availability. BaseballOS does not provide matchup advice or game predictions."
- Polished empty states (no_game_found, unavailable, loading, null) and graceful opponent-missing degradation. No technical/debug wording.
- View helper now exposes team name (from the existing payload), a long data-state label, and status label. No backend / availability / fatigue / trust / freshness / classification logic changed — presentation only.

Guardrail: contextual framing only — no scores, standings, records, win probability, betting, projections, expected outcomes, or matchup recommendations.

Tests: frontend/tests/gameContextVisualHierarchy.test.mjs (matchup prominence + hierarchy order, trust metadata still rendered, banner/disclaimer, no_game_found / unavailable / loading / null, opponent-missing, scoreboard/advisory regression). Existing game-context tests remain green. Frontend 227 pass, build clean.

Docs: docs/GAME_CONTEXT_VISUAL_HIERARCHY.md.