### PR TITLE
feat: add dashboard orientation layer

### DIFF
--- a/docs/DASHBOARD_ORIENTATION_LAYER.md
+++ b/docs/DASHBOARD_ORIENTATION_LAYER.md
@@ -1,0 +1,57 @@
+# Dashboard Orientation Layer
+
+## Decision
+
+Add a compact, always-visible **orientation layer** to the top of the dashboard
+that states what BaseballOS is and what to do next.
+
+## Reason
+
+Real user feedback: a first-time visitor did not immediately understand what the
+product does, why they were seeing a specific team, or how to navigate. Recent
+work (Tonight's Bullpen Landscape, team drilldown, Today's Game Context) improved
+the workflow; the missing piece was making the product's *purpose* obvious within
+a few seconds of landing.
+
+## Outcome
+
+Directly under the hero, a single quiet strip now answers, at a glance:
+
+- **What it is:** "Bullpen Availability & Workload Intelligence."
+- **What it provides:** "BaseballOS helps you understand bullpen availability,
+  workload, readiness, and constraints across Major League Baseball bullpens —
+  transparently, with the data date and confidence always shown."
+- **What to do next:** a short "Start by" list — explore Tonight's Bullpen
+  Landscape (the section just below), select a team bullpen
+  (`/bullpen?view=board`), or compare bullpen conditions
+  (`/bullpen?view=compare`).
+
+## Design notes
+
+- **Lightweight, not a hero.** One bordered strip, one-line description, a short
+  guidance list — it reads as "this is what this product does," never "Welcome to
+  BaseballOS." No giant banner, no marketing paragraphs.
+- **Always visible.** Rendered outside the data conditional so it orients
+  first-time users even while the dashboard data loads.
+- **Reuses existing patterns.** The guidance links reuse the existing
+  `/bullpen?view=` deep links; no new routing or navigation system.
+- **Mobile.** Stacks vertically, stays concise, adds minimal vertical space; the
+  dashboard remains information-dense.
+
+## Guardrail
+
+The orientation layer explains the product only. It introduces **no**
+recommendations, predictions, rankings, matchup advice, onboarding flows,
+tutorials, or product tours, and **no** hype/marketing language (no
+"revolutionary", "cutting edge", "AI-powered", "smartest", "best"). It reinforces
+the trust-first identity — transparent, availability, workload, readiness,
+constraints, context — and changes no analytics, trust, freshness, or governance
+behavior.
+
+## Tests
+
+`frontend/tests/dashboardOrientation.test.mjs` — product description rendering,
+next-step guidance rendering, deep-link reuse, always-visible (renders while the
+dashboard is loading), a marketing/hype-language regression, a
+recommendation/ranking/prediction regression, and a check that the trust-first
+vocabulary is present. Existing dashboard tests remain green.

--- a/frontend/src/components/dashboard/Dashboard.jsx
+++ b/frontend/src/components/dashboard/Dashboard.jsx
@@ -4,6 +4,7 @@ import { getBullpenDashboard } from '../../utils/api'
 import { LoadingPane, ErrorState } from '../UI'
 import SeasonBanner from './SeasonBanner'
 import BullpenLandscape from './BullpenLandscape'
+import DashboardOrientation from './DashboardOrientation'
 import { fmtSyncDate } from './syncStatusView'
 import {
   getBoardContextView,
@@ -75,6 +76,9 @@ export function DashboardView({ data, loading = false, error = null, onRetry }) 
           </div>
         </div>
       </div>
+
+      {/* Orientation layer — what BaseballOS is + what to do next (always shown) */}
+      <DashboardOrientation />
 
       {loading && !data ? (
         <LoadingPane message="Loading bullpen overview..." />

--- a/frontend/src/components/dashboard/DashboardOrientation.jsx
+++ b/frontend/src/components/dashboard/DashboardOrientation.jsx
@@ -1,0 +1,51 @@
+import { Link } from 'react-router-dom'
+
+// Dashboard Orientation Layer — a compact, always-visible "this is what this
+// product does" strip. Product comprehension only: it explains BaseballOS and
+// points to the next click. No analytics, recommendations, rankings, predictions,
+// onboarding flows, or marketing copy.
+const GUIDANCE = [
+  { label: 'Explore Tonight\'s Bullpen Landscape', to: null },          // the section just below
+  { label: 'Select a team bullpen', to: '/bullpen?view=board' },
+  { label: 'Compare bullpen conditions across teams', to: '/bullpen?view=compare' },
+]
+
+export default function DashboardOrientation() {
+  return (
+    <section
+      className="mb-6 rounded-lg border border-dirt bg-field/40 px-4 py-3"
+      aria-label="What BaseballOS is"
+    >
+      <div className="flex flex-col gap-2 lg:flex-row lg:items-baseline lg:justify-between lg:gap-6">
+        <div className="min-w-0">
+          <h2 className="font-mono text-xs uppercase tracking-widest text-amber/80">
+            Bullpen Availability &amp; Workload Intelligence
+          </h2>
+          <p className="mt-1 max-w-2xl text-sm leading-relaxed text-chalk300">
+            BaseballOS helps you understand bullpen availability, workload, readiness, and
+            constraints across Major League Baseball bullpens — transparently, with the data
+            date and confidence always shown.
+          </p>
+        </div>
+
+        <div className="shrink-0 text-xs font-mono text-chalk500">
+          <span className="uppercase tracking-widest text-chalk600">Start by</span>
+          <ul className="mt-1 space-y-0.5">
+            {GUIDANCE.map(item => (
+              <li key={item.label} className="flex items-baseline gap-1.5">
+                <span className="text-chalk600" aria-hidden="true">•</span>
+                {item.to ? (
+                  <Link to={item.to} className="text-chalk300 hover:text-amber hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-amber/60">
+                    {item.label}
+                  </Link>
+                ) : (
+                  <span className="text-chalk400">{item.label}</span>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/frontend/tests/dashboardOrientation.test.mjs
+++ b/frontend/tests/dashboardOrientation.test.mjs
@@ -1,0 +1,83 @@
+import assert from 'node:assert/strict'
+import test, { after } from 'node:test'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import { createServer } from 'vite'
+
+const server = await createServer({
+  root: process.cwd(),
+  server: { middlewareMode: true },
+  appType: 'custom',
+  logLevel: 'silent',
+})
+
+after(async () => {
+  await server.close()
+})
+
+const { default: DashboardOrientation } = await server.ssrLoadModule('/src/components/dashboard/DashboardOrientation.jsx')
+const { DashboardView } = await server.ssrLoadModule('/src/components/dashboard/Dashboard.jsx')
+
+const escapeRegExp = (value) => String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+const htmlIncludes = (html, text) => new RegExp(escapeRegExp(text)).test(html)
+const inRouter = (el) => renderToStaticMarkup(React.createElement(MemoryRouter, null, el))
+
+const orientation = inRouter(React.createElement(DashboardOrientation))
+
+// ── Orientation content ────────────────────────────────────────────────────
+
+test('orientation states what BaseballOS is', () => {
+  assert.ok(htmlIncludes(orientation, 'Bullpen Availability'))
+  assert.ok(htmlIncludes(orientation, 'Workload Intelligence'))
+  assert.ok(htmlIncludes(orientation, 'BaseballOS helps you understand bullpen availability, workload, readiness, and'))
+  assert.ok(htmlIncludes(orientation, 'Major League Baseball bullpens'))
+})
+
+test('orientation gives lightweight next-step guidance', () => {
+  assert.ok(htmlIncludes(orientation, 'Start by'))
+  assert.ok(htmlIncludes(orientation, 'Bullpen Landscape'))          // explore the landscape
+  assert.ok(htmlIncludes(orientation, 'Select a team bullpen'))
+  assert.ok(htmlIncludes(orientation, 'Compare bullpen conditions across teams'))
+})
+
+test('guidance reuses existing deep-link patterns', () => {
+  assert.ok(htmlIncludes(orientation, 'href="/bullpen?view=board"'))
+  assert.ok(htmlIncludes(orientation, 'href="/bullpen?view=compare"'))
+})
+
+test('orientation is shown on the dashboard even while data is loading', () => {
+  const html = inRouter(React.createElement(DashboardView, { data: null, loading: true }))
+  assert.ok(htmlIncludes(html, 'Bullpen Availability'))
+  assert.ok(htmlIncludes(html, 'Loading bullpen overview'))   // still loading
+})
+
+// ── Guardrails ─────────────────────────────────────────────────────────────
+
+test('no marketing / hype language', () => {
+  const low = orientation.toLowerCase()
+  for (const term of [
+    'revolutionary', 'cutting edge', 'cutting-edge', 'ai-powered', 'ai powered',
+    'powered by ai', 'smartest', 'world-class', 'game-changing', 'welcome to baseballos',
+  ]) {
+    assert.ok(!low.includes(term), `marketing term leaked: ${term}`)
+  }
+})
+
+test('no recommendation / ranking / prediction language', () => {
+  const low = orientation.toLowerCase()
+  for (const term of [
+    'recommended', 'recommendation', 'ranking', 'ranked', 'prediction', 'predict',
+    'matchup advice', 'should use', 'best arm', 'best bullpen', 'win probability',
+  ]) {
+    assert.ok(!low.includes(term), `forbidden term leaked: ${term}`)
+  }
+})
+
+test('reinforces transparent, trust-first vocabulary', () => {
+  const low = orientation.toLowerCase()
+  assert.ok(low.includes('transparent'))
+  for (const word of ['availability', 'workload', 'readiness', 'constraint']) {
+    assert.ok(low.includes(word), `missing identity word: ${word}`)
+  }
+})


### PR DESCRIPTION
Add a compact, always-visible orientation strip to the top of the dashboard so a first-time visitor immediately understands what BaseballOS is and what to do next.

- States the product: "Bullpen Availability & Workload Intelligence" with a one-line description (availability, workload, readiness, constraints across MLB bullpens, transparently with data date and confidence shown).
- Lightweight next-step guidance ("Start by"): explore Tonight's Bullpen Landscape, select a team bullpen (/bullpen?view=board), or compare bullpen conditions (/bullpen?view=compare) — reusing existing deep links.
- Rendered outside the data conditional so it orients users even while data loads; stacks on mobile and stays concise. Not a hero banner, tutorial, or product tour.

Product comprehension only — no analytics, recommendations, predictions, rankings, matchup advice, onboarding flows, or marketing/hype language. Reinforces the trust-first identity; no trust/freshness/governance behavior changed.

Tests: frontend/tests/dashboardOrientation.test.mjs (description + guidance rendering, deep-link reuse, always-visible while loading, marketing-language and recommendation/ranking/prediction regressions, trust-vocabulary check). Existing dashboard tests remain green. Frontend 234 pass, build clean.

Docs: docs/DASHBOARD_ORIENTATION_LAYER.md.