### PR TITLE
ops: run migrations before production startup

### DIFF
--- a/backend/scripts/render_start.sh
+++ b/backend/scripts/render_start.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+#
+# Render production startup: apply database migrations, then start the server.
+#
+# Why this exists
+# ---------------
+# The deployed backend can reference schema (columns / tables) introduced by
+# Alembic migrations that have not yet been applied to the hosted database.
+# When that happens, every request that touches the new schema fails with a
+# Postgres UndefinedColumn / UndefinedTable error (HTTP 500). Running
+# `flask db upgrade` *before* the web server accepts traffic closes that gap.
+#
+# Fail-closed contract
+# --------------------
+#   * `set -euo pipefail` + no error suppression means a failed migration exits
+#     this script non-zero and the server is NEVER started.
+#   * The migration error from Flask-Migrate / Alembic is written to stderr,
+#     which Render captures in the service logs, so the failure is visible.
+#   * Migration errors are never swallowed, ignored, or downgraded.
+#
+# Local development is unaffected: nothing runs this script unless it is set as
+# the explicit start command. See docs/current/SETUP.md -> "Deployment notes".
+#
+# Usage (set as the Render service "Start Command")
+# -------------------------------------------------
+#   If the Render service Root Directory is the repository root:
+#       bash backend/scripts/render_start.sh
+#   If the Render service Root Directory is already `backend`:
+#       bash scripts/render_start.sh
+#
+# With no arguments the script launches the documented production server
+# (`gunicorn app:app`) bound to Render's $PORT. To run an exact / custom server
+# invocation instead, pass it as arguments and it is exec'd verbatim after
+# migrations succeed, e.g.:
+#       bash backend/scripts/render_start.sh gunicorn app:app --bind 0.0.0.0:$PORT --workers 2
+#
+set -euo pipefail
+
+# Resolve the backend/ directory (the parent of this script's scripts/ dir) and
+# run from there so FLASK_APP=app.py, the migrations/ directory, and the
+# `app:app` import target all resolve regardless of the caller's working
+# directory or the Render Root Directory setting.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BACKEND_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${BACKEND_DIR}"
+
+# Flask CLI entry point. Honour an externally provided FLASK_APP, otherwise fall
+# back to the repository's documented value so `flask db upgrade` can locate the
+# application factory.
+export FLASK_APP="${FLASK_APP:-app.py}"
+
+echo "[render_start] Applying database migrations: flask db upgrade"
+flask db upgrade
+echo "[render_start] Database migrations applied successfully."
+
+# Start the production server only after migrations succeed. An explicit server
+# command passed as arguments is exec'd verbatim; otherwise fall back to the
+# documented gunicorn invocation bound to Render's $PORT (default 10000). exec
+# replaces this shell so the server process receives signals directly.
+if [ "$#" -gt 0 ]; then
+  echo "[render_start] Starting server: $*"
+  exec "$@"
+else
+  PORT="${PORT:-10000}"
+  echo "[render_start] Starting server: gunicorn app:app --bind 0.0.0.0:${PORT}"
+  exec gunicorn app:app --bind "0.0.0.0:${PORT}"
+fi

--- a/docs/current/SETUP.md
+++ b/docs/current/SETUP.md
@@ -298,8 +298,11 @@ configured for one-command production deployment.
   (e.g. `gunicorn app:app`). For a hosted environment set `APP_ENV=production`,
   `SECRET_KEY` (a strong unique value), `DATABASE_URL` (a hosted PostgreSQL
   instance), and `ADMIN_API_TOKEN` (gates the write endpoints); the app fails
-  fast at startup if any of those production requirements aren't met. Run
-  `flask db upgrade` against that database on deploy.
+  fast at startup if any of those production requirements aren't met. Database
+  migrations are applied automatically before the server starts when the Render
+  start command runs `backend/scripts/render_start.sh` (see "Render start
+  command" below); that script fails closed if `flask db upgrade` fails, so the
+  app never serves traffic against an un-migrated database.
 - **Health check:** `GET /api/health` returns `{ status, environment, debug }`,
   so you can confirm a deploy is actually running `production` (debug `false`).
 - **Scheduler:** `AUTO_SYNC=true` starts an in-process APScheduler job (06:00
@@ -312,6 +315,41 @@ configured for one-command production deployment.
   unset/`development` keeps debug on for local work. This branch wires that
   switch and the production safety checks, but full deployment (host setup,
   managed Postgres, a production scheduler) is still future work.
+
+### Render start command (apply migrations before startup)
+
+The deployed backend can reference schema added by Alembic migrations — for
+example `game_logs.games_started`. If the production database has not run those
+migrations, every request that touches the new column fails with a Postgres
+`UndefinedColumn` error (HTTP 500). To prevent that, the Render service applies
+migrations *before* the web server starts, using a startup script that fails
+closed: if `flask db upgrade` fails, the server never starts and the migration
+error is visible in the Render logs.
+
+Set the Render service **Start Command** to:
+
+```bash
+bash backend/scripts/render_start.sh
+```
+
+If the Render service **Root Directory** is set to `backend`, use
+`bash scripts/render_start.sh` instead.
+
+With no arguments the script applies migrations and then starts the documented
+production server — `gunicorn app:app` bound to Render's `$PORT`. If the service
+needs a specific gunicorn invocation (extra `--workers`, `--timeout`, etc.),
+pass it as arguments and it is run verbatim after migrations succeed:
+
+```bash
+bash backend/scripts/render_start.sh gunicorn app:app --bind 0.0.0.0:$PORT --workers 2
+```
+
+This repository has no `Procfile` or `render.yaml`, so the exact gunicorn flags
+currently configured in the Render dashboard are not tracked in version control.
+The `gunicorn app:app` default matches the command documented in these notes;
+confirm it against the service's current Start Command, or pass the exact
+command as arguments as shown above. The script only runs when it is set as the
+start command, so local development and tests are unaffected.
 
 ### Render production configuration checklist
 


### PR DESCRIPTION
Adds a Render startup script that runs `flask db upgrade` before starting the backend server.

Why:
Production deployed Role Authority V1 code, but the database had not run the migration adding `game_logs.games_started`, causing 500s.

Validation:
- Backend: 582 passed
- Frontend: 280 passed
- Script syntax validated
- Fail-closed behavior verified: failed migration prevents server startup

Rollout:
After merge, set Render backend Start Command to:

bash backend/scripts/render_start.sh

Then trigger a redeploy.