### PR TITLE
trust: hide sample-state bullpen intelligence surface

### DIFF
--- a/frontend/src/components/trust/DataTrust.jsx
+++ b/frontend/src/components/trust/DataTrust.jsx
@@ -1,6 +1,5 @@
 import { useFetch } from '../../hooks/useFetch'
 import {
-  getBullpenObservations,
   getBullpenOverview,
   getRecommendationV2BullpenState,
   getSyncStatus,
@@ -11,7 +10,6 @@ import { SyncStatusContent } from '../dashboard/SyncStatus'
 import AvailabilityDashboardSummary from '../dashboard/AvailabilityDashboardSummary'
 import OperationalReadinessSection from '../dashboard/OperationalReadinessSection'
 import FatigueInsightCard from '../dashboard/FatigueInsightCard'
-import BullpenIntelligencePanel from '../observations/BullpenIntelligencePanel'
 import { FeedbackCTA } from '../feedback/FeedbackLink'
 import { getDataProvenance } from '../bullpen/board/tonightsBullpenBoardView'
 
@@ -23,7 +21,6 @@ export default function DataTrust() {
   const sync = useFetch(getSyncStatus)
   const v2BullpenState = useFetch(() => getRecommendationV2BullpenState({ limit: 750 }))
   const teamOperationsReadiness = useFetch(() => getTeamOperationsBullpenReadiness({ include_details: true }))
-  const bullpenObservations = useFetch(getBullpenObservations)
 
   return (
     <div className="p-4 sm:p-6 lg:p-8 max-w-7xl mx-auto">
@@ -82,14 +79,6 @@ export default function DataTrust() {
         readinessLoading={teamOperationsReadiness.loading}
         readinessError={teamOperationsReadiness.error}
         onRetryReadiness={teamOperationsReadiness.refetch}
-      />
-
-      {/* Observations */}
-      <BullpenIntelligencePanel
-        state={bullpenObservations.data}
-        loading={bullpenObservations.loading}
-        error={bullpenObservations.error}
-        onRetry={bullpenObservations.refetch}
       />
 
       {/* Exploratory study */}

--- a/frontend/tests/dashboardRealignment.test.mjs
+++ b/frontend/tests/dashboardRealignment.test.mjs
@@ -116,6 +116,10 @@ test('Data & Trust page hosts the relocated trust and governance detail', () => 
   assert.ok(htmlIncludes(html, 'Freshness'))
   assert.ok(htmlIncludes(html, 'Availability Confidence'))
   assert.ok(htmlIncludes(html, 'Exploratory Fatigue Insight'))
+  // The V5 Bullpen Intelligence surface runs on deterministic sample state, so it
+  // is not mounted on the live Trust page until it is wired to live MLB data.
+  assert.ok(!htmlIncludes(html, 'V5 Bullpen Intelligence'))
+  assert.ok(!htmlIncludes(html, 'Governed Observations'))
 })
 
 test('sidebar navigation includes a Data & Trust destination', () => {


### PR DESCRIPTION
Hides the V5 Bullpen Intelligence sample-state panel from the live Data & Trust page.

Why:
The production audit identified that the V5 panel was visible to users while still running on deterministic sample state, not live MLB data. That created a trust risk.

What changed:
- Removed the V5 panel mount from `/trust`
- Preserved backend V5 contracts/endpoints
- Preserved the frontend V5 component and isolated tests
- Added negative assertions confirming the panel is no longer mounted on Data & Trust

Validation:
- Backend: 582 passed
- Frontend: 280 passed

Scope:
Trust-presentation fix only. No engine changes.