### PR TITLE
ux: remove recommendation v1 from pitcher card

### DIFF
--- a/frontend/src/components/bullpen/PitcherDetail.jsx
+++ b/frontend/src/components/bullpen/PitcherDetail.jsx
@@ -4,7 +4,6 @@ import { LoadingPane, ErrorState, FatigueBar, RiskBadge, Divider } from '../UI'
 import { fmtIP, fmtDate, riskColor } from '../../utils/formatters'
 import { FATIGUE_FACTORS, RISK_BLURB } from '../../utils/fatigueModel'
 import AvailabilitySummary from './AvailabilitySummary'
-import { RecommendationPitcherDetailSection } from '../recommendations'
 import ExplanationDisclosure from '../explanations/ExplanationDisclosure'
 import {
   RadarChart, PolarGrid, PolarAngleAxis, Radar,
@@ -128,8 +127,6 @@ export default function PitcherDetail({ pitcherId, onClose }) {
             disabled={!pitcherId}
             fetchExplanation={() => getAvailabilityExplanation(pitcherId)}
           />
-
-          <RecommendationPitcherDetailSection pitcherDetail={data} />
 
           {/* Quick stats */}
           <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">


### PR DESCRIPTION
Removes Recommendation Engine V1 candidate evaluation from the pitcher detail card.

Why:
Product review found that V1 is technically successful and governance-compliant, but does not provide meaningful user value on the pitcher card. The card should help users understand the pitcher, not the recommendation engine.

What changed:
- Removed the V1 candidate evaluation mount from pitcher detail
- Preserved Recommendation Engine V1 backend infrastructure
- Preserved governance protections and documentation
- Preserved V1 frontend components/tests as infrastructure
- Added no replacement content

Validation:
- Frontend: 280 passed
- Backend: 581 passed, 1 pre-existing date-boundary flake on pristine main

Scope:
Presentation-layer removal only. No backend, engine, governance, or replacement feature changes.