### PR TITLE
fatigue: establish canonical availability reference date

### DIFF
--- a/backend/api/bullpen.py
+++ b/backend/api/bullpen.py
@@ -9,7 +9,6 @@ from utils.db import db
 from models.pitcher import Pitcher
 from models.game_log import GameLog
 from models.fatigue_score import FatigueScore
-from services.fatigue import calculate_fatigue, get_risk_level
 from services.availability import ACTIVE_WINDOW_DAYS, classify_availability
 from services.availability_reference_date import (
     parse_reference_date,
@@ -385,47 +384,30 @@ def get_pitcher_fatigue(pitcher_id):
 def recalculate_fatigue():
     """
     Trigger fatigue recalculation for all pitchers.
-    Uses each pitcher's last game date as the reference point — not today —
-    so historical data produces meaningful scores.
+
+    Delegates to the single canonical recalculation authority
+    (services.sync.recalculate_all_fatigue), which scores every pitcher against
+    the canonical availability reference date — the latest completed MLB
+    workload date + 1 day. This guarantees the recalculate endpoint, the
+    scheduled sync, and the GitHub Actions / manual sync all write identical
+    fatigue scores for the same game logs, so the league snapshot never changes
+    based on which path last ran.
     """
-    pitchers = Pitcher.query.filter_by(active=True).all()
-    updated  = []
+    updated = sync_service.recalculate_all_fatigue()
 
-    for pitcher in pitchers:
-        latest_log = (
-            GameLog.query
-            .filter_by(pitcher_id=pitcher.id)
-            .order_by(GameLog.game_date.desc())
-            .first()
-        )
-
-        if not latest_log:
-            continue
-
-        reference_date = latest_log.game_date
-        window_start   = reference_date - timedelta(days=14)
-
-        logs = (
-            GameLog.query
-            .filter(
-                GameLog.pitcher_id == pitcher.id,
-                GameLog.game_date  >= window_start,
-                GameLog.game_date  <= reference_date
-            )
-            .order_by(desc(GameLog.game_date))
-            .all()
-        )
-
-        score = calculate_fatigue(pitcher, logs, reference_date=reference_date)
-        db.session.add(score)
-        updated.append({
+    # Report the canonical latest scores so the response stays a faithful read
+    # of what was just persisted (one entry per scored pitcher).
+    rows = _latest_fatigue_query().all()
+    results = [
+        {
             'pitcher': pitcher.full_name,
             'score':   round(score.raw_score, 1),
             'risk':    score.risk_level,
-        })
+        }
+        for score, pitcher in rows
+    ]
 
-    db.session.commit()
-    return jsonify({'recalculated': len(updated), 'results': updated})
+    return jsonify({'recalculated': updated, 'results': results})
 
 
 # ─── Sync (Live Data Refresh) ─────────────────────────────────────────────────
@@ -483,8 +465,9 @@ def sync_recent_logs():
         })
         return jsonify({'error': f'Sync failed: {str(e)}'}), 500
 
-    # Live mode: score against today — same behavior as before.
-    fatigue_updated = sync_service.recalculate_all_fatigue(use_last_game_date=False)
+    # Canonical authority: score against the latest completed workload date + 1
+    # day — the same reference the scheduled sync and recalculate endpoint use.
+    fatigue_updated = sync_service.recalculate_all_fatigue()
     finished        = datetime.now(timezone.utc)
     # Durable first (self-healing if the start row never persisted), then the
     # best-effort cache file. The durable row is the source of truth.

--- a/backend/seed.py
+++ b/backend/seed.py
@@ -218,36 +218,39 @@ def seed_game_logs():
 
 def seed_fatigue_scores():
     """
-    Calculate fatigue scores using the 14-day window before each pitcher's
-    most recent game. Works correctly for both historical and current data.
+    Calculate fatigue scores against the canonical availability reference date
+    (latest completed workload date + 1 day), so seeded scores match what the
+    production sync paths and the dashboard read path use. This keeps a freshly
+    seeded database telling the same bullpen story as a synced one.
     """
     print("\n🔥 Calculating fatigue scores...")
+    from services.sync_metadata import canonical_fatigue_reference_date
+
+    reference_date = canonical_fatigue_reference_date()
+    if reference_date is None:
+        print("  ⚠️  No game logs to anchor fatigue scores; skipping.")
+        return 0
+
+    window_start = reference_date - timedelta(days=14)
     pitchers = Pitcher.query.filter_by(active=True).all()
     scored = 0
 
     for pitcher in pitchers:
-        latest_log = (
-            GameLog.query
-            .filter_by(pitcher_id=pitcher.id)
-            .order_by(GameLog.game_date.desc())
-            .first()
-        )
-
-        if not latest_log:
-            continue
-
-        window_start = latest_log.game_date - timedelta(days=14)
         logs = (
             GameLog.query
             .filter(
                 GameLog.pitcher_id == pitcher.id,
-                GameLog.game_date >= window_start
+                GameLog.game_date >= window_start,
+                GameLog.game_date <= reference_date,
             )
             .order_by(GameLog.game_date.desc())
             .all()
         )
 
-        score = calculate_fatigue(pitcher, logs)
+        if not logs:
+            continue
+
+        score = calculate_fatigue(pitcher, logs, reference_date=reference_date)
         db.session.add(score)
         scored += 1
 

--- a/backend/services/sync.py
+++ b/backend/services/sync.py
@@ -182,41 +182,41 @@ def sync_recent_logs(days_back: int = 7, reference_date: date | None = None):
     }
 
 
-def recalculate_all_fatigue(use_last_game_date: bool = True):
+def recalculate_all_fatigue(reference_date: date | None = None):
     """
-    Recalculate fatigue scores for every active pitcher.
+    Recalculate fatigue scores for every active pitcher against a SINGLE
+    canonical availability reference date — the latest completed MLB workload
+    date + 1 day ("tonight's availability"), resolved by
+    ``sync_metadata.canonical_fatigue_reference_date``.
 
-    If `use_last_game_date` is True (the default and the fix the daily job
-    needs) we score each pitcher relative to their most recent game date —
-    so offseason or injured-list pitchers still produce meaningful history.
-    Otherwise we score relative to today (useful for live in-season mode).
+    This is the one production authority. The scheduled APScheduler sync, the
+    GitHub Actions / manual sync endpoint, and the recalculate endpoint all flow
+    through here, so the same game logs always yield the same fatigue scores no
+    matter which path last ran. It replaces the previous split where the daily
+    job scored each pitcher at their own last game date while the sync endpoint
+    scored against the host's runtime "today" — a divergence that let one
+    database tell two different league-wide stories.
 
-    Returns the count of pitchers updated.
+    Pass ``reference_date`` only to pin the anchor explicitly (e.g. in tests);
+    production callers leave it None so the canonical date is derived from
+    durable workload metadata. Returns the count of pitchers updated.
     """
+    ref = sync_metadata.canonical_fatigue_reference_date(reference_date)
+    if ref is None:
+        # No workload data at all → nothing to anchor against.
+        return 0
+
+    window_start = ref - timedelta(days=14)
     pitchers = Pitcher.query.filter_by(active=True).all()
     updated  = 0
 
     for pitcher in pitchers:
-        if use_last_game_date:
-            latest_log = (
-                GameLog.query
-                .filter_by(pitcher_id=pitcher.id)
-                .order_by(GameLog.game_date.desc())
-                .first()
-            )
-            if not latest_log:
-                continue
-            reference_date = latest_log.game_date
-        else:
-            reference_date = date.today()
-
-        window_start = reference_date - timedelta(days=14)
         logs = (
             GameLog.query
             .filter(
                 GameLog.pitcher_id == pitcher.id,
                 GameLog.game_date  >= window_start,
-                GameLog.game_date  <= reference_date,
+                GameLog.game_date  <= ref,
             )
             .order_by(desc(GameLog.game_date))
             .all()
@@ -224,7 +224,7 @@ def recalculate_all_fatigue(use_last_game_date: bool = True):
         if not logs:
             continue
 
-        score = calculate_fatigue(pitcher, logs, reference_date=reference_date)
+        score = calculate_fatigue(pitcher, logs, reference_date=ref)
         db.session.add(score)
         updated += 1
 
@@ -323,7 +323,7 @@ def run_daily_sync(app, days_back: int = 7):
                     status['message'] = 'No games found — offseason skip.'
                     run_logger.info('No games found — offseason skip.')
 
-            pitchers_updated = recalculate_all_fatigue(use_last_game_date=True)
+            pitchers_updated = recalculate_all_fatigue()
             status['pitchers_updated'] = pitchers_updated
             run_logger.info('Recalculated fatigue for %s pitchers', pitchers_updated)
             sync_metadata.finish_sync_run(

--- a/backend/services/sync_metadata.py
+++ b/backend/services/sync_metadata.py
@@ -51,6 +51,27 @@ def collect_data_metadata():
     }
 
 
+def canonical_fatigue_reference_date(reference_date=None):
+    """
+    Single production authority for the fatigue recalculation reference date:
+    the latest completed MLB workload date + 1 day ("tonight's availability").
+
+    Every production-facing recalculation path — the scheduled APScheduler sync,
+    the GitHub Actions / manual sync endpoint, and the recalculate endpoint —
+    anchors here, so identical game logs always produce identical fatigue scores
+    regardless of which path last ran. This is the same anchor the read /
+    availability path derives from durable sync metadata
+    (product_availability_reference_date_from_metadata), so stored scores and
+    displayed availability share one calendar date instead of diverging between a
+    per-pitcher last-game-date and the host's runtime "today".
+
+    Returns None when there is no workload data to anchor against.
+    """
+    if reference_date is not None:
+        return reference_date
+    return product_availability_reference_date_from_metadata(collect_data_metadata())
+
+
 def start_sync_run(source=SOURCE_MANUAL, started_at=None):
     started_at = started_at or _now()
     # Start from a clean transaction. If an earlier statement in this request

--- a/backend/tests/test_durable_sync_write_integration.py
+++ b/backend/tests/test_durable_sync_write_integration.py
@@ -31,7 +31,7 @@ def client(tmp_path, monkeypatch):
     # Mock the network/heavy work so the endpoint's durable wiring is what's tested.
     monkeypatch.setattr(sync_service, 'sync_recent_logs',
                         lambda days_back=7: {'new_logs_added': 3, 'pitchers_touched': 2, 'errors': 0})
-    monkeypatch.setattr(sync_service, 'recalculate_all_fatigue', lambda use_last_game_date=False: 5)
+    monkeypatch.setattr(sync_service, 'recalculate_all_fatigue', lambda reference_date=None: 5)
     monkeypatch.setattr(sync_service, 'sync_team_assignments', lambda: {
         'pitchers_refreshed': 1,
         'pitchers_changed': 0,

--- a/backend/tests/test_fatigue_reference_authority.py
+++ b/backend/tests/test_fatigue_reference_authority.py
@@ -1,0 +1,243 @@
+"""
+Canonical fatigue recalculation authority.
+
+These tests pin the rule that every production-facing recalculation path scores
+fatigue against ONE reference date — the latest completed MLB workload date + 1
+day ("tonight's availability") — so the same game logs always produce the same
+fatigue scores (and therefore the same league-wide bullpen snapshot) no matter
+which path last ran: the scheduled APScheduler sync, the GitHub Actions / manual
+sync endpoint, or the recalculate endpoint.
+
+Before this authority existed, the scheduled job scored each pitcher at their own
+last game date while the sync endpoint scored against the host's runtime "today",
+so one database could tell two different stories.
+"""
+
+from datetime import date, datetime
+
+import pytest
+from flask import Flask
+
+import services.sync as sync_service
+from api.bullpen import bullpen_bp
+from models.fatigue_score import FatigueScore
+from models.game_log import GameLog
+from models.pitcher import Pitcher
+from models.sync_run import SyncRun
+from services.fatigue import calculate_fatigue
+from services.sync_metadata import canonical_fatigue_reference_date
+from services.roster_status import STATUS_ACTIVE
+from utils.db import db
+
+
+MAX_WORKLOAD_DATE = date(2026, 6, 9)
+CANONICAL_REFERENCE = date(2026, 6, 10)  # latest workload + 1 day
+
+
+@pytest.fixture
+def app(tmp_path, monkeypatch):
+    monkeypatch.setattr(sync_service, 'STATUS_FILE', tmp_path / 'sync_status.json')
+    flask_app = Flask(__name__)
+    flask_app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    flask_app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+    db.init_app(flask_app)
+    flask_app.register_blueprint(bullpen_bp, url_prefix='/api/bullpen')
+    with flask_app.app_context():
+        db.create_all()
+        try:
+            yield flask_app
+        finally:
+            db.session.remove()
+            db.drop_all()
+
+
+def _add_pitcher(mlb_id, name, abbr='REF', team_id=1):
+    pitcher = Pitcher(
+        mlb_id=mlb_id,
+        full_name=name,
+        team_id=team_id,
+        team_name='Reference Team',
+        team_abbreviation=abbr,
+        position='RP',
+        active=True,
+        roster_status=STATUS_ACTIVE,
+        roster_status_source='test_fixture',
+        roster_status_updated_at=datetime(2026, 6, 9, 12, 0, 0),
+    )
+    db.session.add(pitcher)
+    db.session.commit()
+    return pitcher
+
+
+def _add_log(pitcher, game_pk, game_date, pitches, innings=1.0):
+    db.session.add(GameLog(
+        pitcher_id=pitcher.id,
+        mlb_game_pk=game_pk,
+        game_date=game_date,
+        pitches_thrown=pitches,
+        innings_pitched=innings,
+        game_type='R',
+    ))
+    db.session.commit()
+
+
+def _seed_population():
+    """One recent reliever (inside the canonical window) and one stale reliever."""
+    recent = _add_pitcher(910001, 'Recent Reliever', abbr='REC')
+    _add_log(recent, 910010, date(2026, 6, 8), pitches=50)
+    _add_log(recent, 910011, MAX_WORKLOAD_DATE, pitches=30)
+
+    stale = _add_pitcher(910002, 'Stale Reliever', abbr='STL')
+    _add_log(stale, 910020, date(2026, 5, 1), pitches=40)
+    return recent, stale
+
+
+def _latest_scores_by_pitcher():
+    rows = (
+        db.session.query(FatigueScore)
+        .order_by(FatigueScore.pitcher_id, FatigueScore.calculated_at)
+        .all()
+    )
+    latest = {}
+    for row in rows:
+        latest[row.pitcher_id] = row  # last write wins (ordered ascending)
+    return latest
+
+
+# ── 1. The canonical reference date IS latest-workload + 1 day ──────────────
+
+def test_canonical_reference_is_latest_workload_plus_one_day(app):
+    _seed_population()
+    assert canonical_fatigue_reference_date() == CANONICAL_REFERENCE
+
+
+def test_canonical_reference_is_none_without_any_workload(app):
+    _add_pitcher(910099, 'No Logs Reliever')
+    assert canonical_fatigue_reference_date() is None
+
+
+# ── 2. Production recalc uses the canonical reference, not per-pitcher date ──
+
+def test_recalculate_uses_canonical_reference_not_per_pitcher_last_game(app):
+    recent, stale = _seed_population()
+
+    updated = sync_service.recalculate_all_fatigue()
+
+    latest = _latest_scores_by_pitcher()
+    # Recent reliever is scored at the canonical reference (max + 1 day), so the
+    # rest gap is 1 day — NOT 0, which the old per-last-game-date path produced.
+    assert latest[recent.id].days_since_last_appearance == 1
+    # The stale reliever has no appearance inside the canonical window, so the
+    # canonical authority leaves them unscored (consistent across every path).
+    assert stale.id not in latest
+    assert updated == 1
+
+
+def test_recalculate_is_independent_of_runtime_today(app, monkeypatch):
+    recent, _stale = _seed_population()
+
+    class FarFutureDate(date):
+        @classmethod
+        def today(cls):
+            return date(2027, 1, 1)
+
+    # Even if the host clock is wildly off, the anchor is the data, not today.
+    monkeypatch.setattr(sync_service, 'date', FarFutureDate)
+    sync_service.recalculate_all_fatigue()
+
+    latest = _latest_scores_by_pitcher()
+    assert latest[recent.id].days_since_last_appearance == 1
+
+
+# ── 3. Every production path produces equivalent fatigue output ─────────────
+
+def test_recalculate_is_deterministic_for_fixed_game_logs(app):
+    recent, _stale = _seed_population()
+
+    sync_service.recalculate_all_fatigue()
+    first = {pid: row.raw_score for pid, row in _latest_scores_by_pitcher().items()}
+
+    sync_service.recalculate_all_fatigue()
+    second = {pid: row.raw_score for pid, row in _latest_scores_by_pitcher().items()}
+
+    assert first == second
+
+
+def test_scheduled_authority_and_recalculate_endpoint_agree(app):
+    recent, _stale = _seed_population()
+
+    # Path used by the scheduled APScheduler sync AND the GitHub Actions /
+    # manual sync endpoint (both call recalculate_all_fatigue() with no args).
+    sync_service.recalculate_all_fatigue()
+    scheduled = {pid: row.raw_score for pid, row in _latest_scores_by_pitcher().items()}
+
+    # The admin recalculate endpoint delegates to the same canonical authority.
+    client = app.test_client()
+    res = client.post('/api/bullpen/fatigue/recalculate')
+    assert res.status_code == 200
+
+    endpoint = {pid: row.raw_score for pid, row in _latest_scores_by_pitcher().items()}
+    assert scheduled == endpoint
+
+
+# ── 4. No regression: only the reference-date authority changed ─────────────
+
+def test_recalculate_delegates_to_unchanged_scoring_engine(app):
+    recent, _stale = _seed_population()
+
+    logs = (
+        GameLog.query
+        .filter(
+            GameLog.pitcher_id == recent.id,
+            GameLog.game_date >= date(2026, 5, 27),
+            GameLog.game_date <= CANONICAL_REFERENCE,
+        )
+        .order_by(GameLog.game_date.desc())
+        .all()
+    )
+    expected = calculate_fatigue(recent, logs, reference_date=CANONICAL_REFERENCE)
+
+    sync_service.recalculate_all_fatigue()
+    stored = _latest_scores_by_pitcher()[recent.id]
+
+    # Same raw score and risk band: the weights, thresholds and formula are
+    # untouched — only the reference-date authority was centralized.
+    assert stored.raw_score == pytest.approx(expected.raw_score)
+    assert stored.risk_level == expected.risk_level
+
+
+# ── 5. Dashboard snapshot is deterministic for the same persisted state ─────
+
+def _add_success_sync_run():
+    db.session.add(SyncRun(
+        started_at=datetime(2026, 6, 9, 11, 0, 0),
+        completed_at=datetime(2026, 6, 9, 11, 0, 30),
+        status='success',
+        source='github_actions',
+        latest_game_date=MAX_WORKLOAD_DATE,
+        latest_workload_date=MAX_WORKLOAD_DATE,
+        latest_fatigue_calculated_at=datetime(2026, 6, 9, 11, 0, 30),
+        pitchers_updated=1,
+        errors=0,
+        created_at=datetime(2026, 6, 9, 11, 0, 0),
+    ))
+    db.session.commit()
+
+
+def test_dashboard_snapshot_is_deterministic_and_data_anchored(app):
+    _seed_population()
+    sync_service.recalculate_all_fatigue()
+    _add_success_sync_run()
+
+    client = app.test_client()
+    first = client.get('/api/bullpen/dashboard').get_json()
+    second = client.get('/api/bullpen/dashboard').get_json()
+
+    # Same persisted game logs + fatigue scores + sync metadata → identical story.
+    assert first['availability_summary']['statuses'] == second['availability_summary']['statuses']
+    assert first['landscape']['available_bullpens'] == second['landscape']['available_bullpens']
+    assert first['landscape']['constrained_bullpens'] == second['landscape']['constrained_bullpens']
+    assert first['landscape']['monitoring_concentration'] == second['landscape']['monitoring_concentration']
+
+    # And the snapshot is anchored to the data-derived canonical reference.
+    assert first['freshness']['availability_reference_date'] == CANONICAL_REFERENCE.isoformat()


### PR DESCRIPTION
Centralizes production fatigue recalculation around one canonical reference date: latest completed workload date + 1 day.

Why:
The league snapshot could change between refreshes because different fatigue-writing paths used different anchors. APScheduler, GitHub/manual sync, and recalculation endpoint could each write fatigue_scores using different reference dates.

What changed:
- Added canonical fatigue reference date helper
- Aligned production recalculation paths to the same authority
- Recalculate endpoint now delegates through the shared path
- Seed fatigue scores aligned to canonical reference behavior
- Added regression tests proving deterministic authority behavior

Validation:
- Backend: 590 passed
- Frontend: 280 passed

Scope:
No fatigue weights, thresholds, risk bands, availability logic, Role Authority, recommendation logic, or trust terminology changed.