### PR TITLE
routing: fix vercel spa refresh handling

### DIFF
--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
Fixes direct-route refreshes on Vercel for the React/Vite SPA.

Why:
Refreshing or directly opening non-root routes like /bullpen, /trust, /methodology, or /prospects returned Vercel 404: NOT_FOUND because Vercel tried to resolve those paths as static files instead of serving index.html.

What changed:
- Added frontend/vercel.json
- Configured catch-all rewrite to /index.html
- Allows React Router to handle client-side routes after load

Validation:
- npm run build: passed
- npm test: 280 passed

Scope:
Deployment routing only. No application routes, backend APIs, fatigue logic, availability logic, or trust logic changed.