### PR TITLE
homepage: lead with bullpen stories instead of classifications

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import { Analytics } from '@vercel/analytics/react'
 import Sidebar from './components/Sidebar'
+import Home from './components/home/Home'
 import Dashboard from './components/dashboard/Dashboard'
 import Bullpen from './components/bullpen/Bullpen'
 import Prospects from './components/prospects/Prospects'
@@ -14,7 +15,8 @@ export default function App() {
         <Sidebar />
         <main className="flex-1 min-w-0">
           <Routes>
-            <Route path="/"            element={<Dashboard />} />
+            <Route path="/"            element={<Home />} />
+            <Route path="/dashboard"   element={<Dashboard />} />
             <Route path="/bullpen"     element={<Bullpen />} />
             <Route path="/prospects"   element={<Prospects />} />
             <Route path="/methodology" element={<Methodology />} />

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -3,7 +3,8 @@ import { NavLink } from 'react-router-dom'
 import FeedbackLink from './feedback/FeedbackLink'
 
 const NAV = [
-  { to: '/',            icon: '⬡',  label: 'Dashboard'   },
+  { to: '/',            icon: '☀',  label: 'Today'       },
+  { to: '/dashboard',   icon: '⬡',  label: 'Dashboard'   },
   { to: '/bullpen',     icon: '🔥', label: 'Bullpen'     },
   { to: '/prospects',   icon: '📈', label: 'Pipeline', tag: 'Preview' },
   { to: '/methodology', icon: '📐', label: 'Methodology' },

--- a/frontend/src/components/home/BullpenStories.jsx
+++ b/frontend/src/components/home/BullpenStories.jsx
@@ -1,0 +1,67 @@
+import { Link } from 'react-router-dom'
+import { homeTone } from './homeIntelligenceView'
+
+// Section 3 — Today's Bullpen Stories. Observation-led story cards in plain
+// baseball language: what the workload data shows, never what anyone should
+// do about it.
+export default function BullpenStories({ stories }) {
+  return (
+    <section className="mb-8" aria-label="Today's bullpen stories">
+      <SectionHeading
+        title="Today’s Bullpen Stories"
+        subtitle="What the workload data is saying around the league — observations, not verdicts."
+      />
+
+      {!stories?.hasStories ? (
+        <div className="card p-5 text-sm text-chalk400">{stories?.fallback}</div>
+      ) : (
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-3">
+          {stories.items.map((story, index) => (
+            <StoryCard key={`${story.kicker}-${index}`} story={story} />
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}
+
+export function SectionHeading({ title, subtitle, right }) {
+  return (
+    <div className="mb-3 flex flex-wrap items-end justify-between gap-2 border-b border-dirt pb-2">
+      <div>
+        <h2 className="font-display text-2xl tracking-wider text-chalk100 uppercase">{title}</h2>
+        {subtitle && <p className="mt-0.5 text-xs leading-relaxed text-chalk400">{subtitle}</p>}
+      </div>
+      {right}
+    </div>
+  )
+}
+
+function StoryCard({ story }) {
+  const tone = homeTone(story.tone)
+
+  return (
+    <Link
+      to={story.href || '/bullpen'}
+      className="card group flex flex-col p-4 transition-all duration-200 hover:border-amber/40 hover:bg-amber/5"
+    >
+      <span
+        className="inline-flex w-fit items-center gap-1.5 rounded border px-2 py-0.5 font-mono text-[10px] uppercase tracking-widest"
+        style={{ borderColor: tone.borderColor, backgroundColor: tone.backgroundColor, color: tone.color }}
+      >
+        <span className="h-1 w-1 rounded-full" style={{ backgroundColor: tone.dot }} aria-hidden="true" />
+        {story.kicker}
+      </span>
+
+      <h3 className="mt-3 font-display text-xl leading-tight tracking-wide text-chalk100 group-hover:text-amber transition-colors">
+        {story.title}
+      </h3>
+
+      <p className="mt-2 flex-1 text-sm leading-relaxed text-chalk400">{story.body}</p>
+
+      <div className="mt-3 font-mono text-[10px] uppercase tracking-widest text-chalk600 group-hover:text-amber transition-colors">
+        Open the full picture →
+      </div>
+    </Link>
+  )
+}

--- a/frontend/src/components/home/Home.jsx
+++ b/frontend/src/components/home/Home.jsx
@@ -1,0 +1,188 @@
+import { Link } from 'react-router-dom'
+import { useFetch } from '../../hooks/useFetch'
+import { getBullpenDashboard, getBullpenObservations, getTeams } from '../../utils/api'
+import { LoadingPane, ErrorState } from '../UI'
+import { FeedbackCTA } from '../feedback/FeedbackLink'
+import LeagueIntelligenceCards from './LeagueIntelligenceCards'
+import BullpenStories from './BullpenStories'
+import RankingsPreview from './RankingsPreview'
+import TeamExplorer from './TeamExplorer'
+import {
+  getBullpenStories,
+  getHeroStory,
+  getLeagueCards,
+  getMastheadView,
+  getRankingsPreview,
+  getTeamExplorerView,
+  homeTone,
+} from './homeIntelligenceView'
+
+// The Morning Bullpen Report — BaseballOS's story-led front page. Leads with
+// the most interesting bullpen situation in baseball today, then opens doors
+// into the rest of the platform. Reads like a baseball publication; every
+// number underneath comes from the same league dashboard, landscape, and
+// governed observation outputs the deeper pages already use.
+export default function Home() {
+  const dash = useFetch(getBullpenDashboard)
+  const teams = useFetch(getTeams)
+  // Observations enrich the story list when the governed feed has content;
+  // the page never blocks on them (only .data is read, so a failed fetch
+  // simply means no observation stories).
+  const observations = useFetch(getBullpenObservations)
+
+  return (
+    <HomeView
+      dashboard={dash.data}
+      teams={teams.data}
+      observations={observations.data}
+      loading={dash.loading}
+      error={dash.error}
+      onRetry={dash.refetch}
+    />
+  )
+}
+
+export function HomeView({
+  dashboard,
+  teams,
+  observations = null,
+  loading = false,
+  error = null,
+  onRetry,
+}) {
+  const masthead = getMastheadView(dashboard)
+  const hero = getHeroStory(dashboard)
+  const cards = getLeagueCards(dashboard)
+  const stories = getBullpenStories(dashboard, observations)
+  const rankings = getRankingsPreview(dashboard)
+  const explorer = getTeamExplorerView(teams, dashboard)
+
+  return (
+    <div className="p-4 sm:p-5 lg:p-6 max-w-7xl mx-auto">
+      <Masthead masthead={masthead} />
+
+      {loading && !dashboard ? (
+        <LoadingPane message="Pulling together this morning's bullpen report..." />
+      ) : error && !dashboard ? (
+        <ErrorState message={error} onRetry={onRetry} />
+      ) : (
+        <>
+          <HeroStory hero={hero} />
+          <LeagueIntelligenceCards cards={cards} />
+          <BullpenStories stories={stories} />
+          <RankingsPreview rankings={rankings} />
+        </>
+      )}
+
+      <TeamExplorer explorer={explorer} />
+
+      <FeedbackCTA
+        compact
+        className="mb-2"
+        eyebrow="User Validation"
+        title="Help shape BaseballOS"
+        body="Share what is useful, unclear, or missing while BaseballOS is being tested with real users."
+      />
+    </div>
+  )
+}
+
+function Masthead({ masthead }) {
+  return (
+    <header className="mb-5 flex flex-wrap items-end justify-between gap-3 border-b border-dirt pb-4 animate-fade-up opacity-0" style={{ animationFillMode: 'forwards' }}>
+      <div>
+        <div className="font-mono text-[10px] uppercase tracking-widest text-amber/70">
+          The Morning Bullpen Report
+        </div>
+        <h1 className="mt-1 font-display text-4xl tracking-wider text-chalk100 leading-none">
+          BASEBALL<span className="text-gradient-amber">OS</span> TODAY
+        </h1>
+      </div>
+      <div className="flex flex-wrap items-center gap-2 font-mono text-[11px] text-chalk400">
+        <span>{masthead.editionDate}</span>
+        <span className="text-chalk600" aria-hidden="true">·</span>
+        <span className="rounded border border-dirt bg-dugout px-2 py-1 text-chalk400">
+          {masthead.dataLine}
+        </span>
+        <Link
+          to="/dashboard"
+          className="rounded border border-dirt bg-dugout px-2 py-1 text-chalk200 transition-colors hover:border-amber/40 hover:text-amber"
+        >
+          League dashboard →
+        </Link>
+      </div>
+    </header>
+  )
+}
+
+// Section 1 — What BaseballOS Sees Today: one flagship observation, told the
+// way a baseball writer would lead a column.
+function HeroStory({ hero }) {
+  const tone = homeTone(hero.tone)
+
+  return (
+    <section className="mb-8" aria-label="What BaseballOS sees today">
+      <div className="mb-3 font-mono text-xs uppercase tracking-widest text-chalk400">
+        What BaseballOS Sees Today
+      </div>
+
+      <div className="relative overflow-hidden rounded-xl border border-dirt bg-dugout bg-stadium-glow p-5 sm:p-7">
+        <div className="absolute inset-0 bg-grid-lines opacity-100 pointer-events-none" />
+        <div className="relative z-10">
+          <span
+            className="inline-flex items-center gap-1.5 rounded border px-2 py-0.5 font-mono text-[10px] uppercase tracking-widest"
+            style={{ borderColor: tone.borderColor, backgroundColor: tone.backgroundColor, color: tone.color }}
+          >
+            <span className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: tone.dot }} aria-hidden="true" />
+            {hero.kicker}
+          </span>
+
+          <h2 className="mt-3 max-w-4xl font-display text-4xl leading-none tracking-wide text-chalk100 sm:text-5xl">
+            {hero.headline}
+          </h2>
+
+          <p className="mt-4 max-w-3xl text-sm leading-relaxed text-chalk200 sm:text-base">
+            {hero.observation}
+          </p>
+
+          <div className="mt-4 max-w-3xl rounded border-l-4 border-amber/70 bg-field/60 p-3 sm:p-4">
+            <div className="font-mono text-[10px] uppercase tracking-widest text-amber/80">Why It Matters</div>
+            <p className="mt-1 text-sm leading-relaxed text-chalk200">{hero.whyItMatters}</p>
+          </div>
+
+          {hero.chips.length > 0 && (
+            <div className="mt-4 flex flex-wrap gap-2">
+              {hero.chips.map(chip => (
+                <span
+                  key={chip.key}
+                  className="inline-flex items-center gap-2 rounded border border-dirt bg-field/60 px-2.5 py-1 font-mono text-[11px] text-chalk400"
+                >
+                  <span className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: homeTone(chip.tone).dot }} aria-hidden="true" />
+                  {chip.label}
+                  <span className="text-sm text-chalk100">{chip.value}</span>
+                </span>
+              ))}
+            </div>
+          )}
+
+          <div className="mt-5 flex flex-wrap items-center gap-3">
+            {hero.team?.href && (
+              <Link
+                to={hero.team.href}
+                className="rounded border border-amber/40 bg-amber/10 px-4 py-2 font-mono text-xs uppercase tracking-wider text-amber transition-colors hover:bg-amber/20"
+              >
+                Step inside the {hero.team.abbr || hero.team.teamName} pen →
+              </Link>
+            )}
+            <Link
+              to="/bullpen"
+              className="rounded border border-dirt bg-field/60 px-4 py-2 font-mono text-xs uppercase tracking-wider text-chalk200 transition-colors hover:border-amber/40 hover:text-amber"
+            >
+              Browse every bullpen →
+            </Link>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/frontend/src/components/home/LeagueIntelligenceCards.jsx
+++ b/frontend/src/components/home/LeagueIntelligenceCards.jsx
@@ -1,0 +1,65 @@
+import { Link } from 'react-router-dom'
+import { homeTone } from './homeIntelligenceView'
+
+// Section 2 — four league intelligence cards: Most Stressed, Most Rested,
+// Biggest Trend, Bullpen To Watch. Each card is a doorway into an existing
+// page, not a verdict — counts and situations only.
+export default function LeagueIntelligenceCards({ cards }) {
+  if (!Array.isArray(cards) || cards.length === 0) return null
+
+  return (
+    <section className="mb-8" aria-label="League intelligence">
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        {cards.map((card, index) => (
+          <IntelligenceCard key={card.key} card={card} delayClass={`delay-${Math.min(index + 1, 5)}`} />
+        ))}
+      </div>
+    </section>
+  )
+}
+
+function IntelligenceCard({ card, delayClass }) {
+  const tone = homeTone(card.tone)
+
+  return (
+    <Link
+      to={card.href}
+      className={`card group flex flex-col p-4 transition-all duration-200 hover:border-amber/40 hover:bg-amber/5 animate-fade-up ${delayClass}`}
+    >
+      <div className="flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-widest text-chalk400">
+        <span className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: tone.dot }} aria-hidden="true" />
+        {card.title}
+      </div>
+
+      <div className="mt-3 flex items-baseline gap-2">
+        {card.team ? (
+          <span className="font-display text-4xl tracking-wider text-chalk100 group-hover:text-amber transition-colors">
+            {card.team.abbr || card.team.teamName}
+          </span>
+        ) : card.stat ? (
+          <span className="font-display text-4xl tracking-wider text-chalk100 group-hover:text-amber transition-colors">
+            {card.stat}
+          </span>
+        ) : (
+          <span className="font-display text-2xl tracking-wider text-chalk400">Quiet day</span>
+        )}
+      </div>
+      {card.team?.teamName && (
+        <div className="mt-0.5 truncate text-xs text-chalk400">{card.team.teamName}</div>
+      )}
+
+      {card.stat && (
+        <div className="mt-2 font-mono text-sm" style={{ color: tone.color }}>
+          {card.team ? `${card.stat} ` : ''}
+          <span className="text-chalk400">{card.statLabel}</span>
+        </div>
+      )}
+
+      <p className="mt-2 flex-1 text-xs leading-relaxed text-chalk400">{card.line}</p>
+
+      <div className="mt-3 font-mono text-[10px] uppercase tracking-widest text-chalk400 group-hover:text-amber transition-colors">
+        {card.cta} →
+      </div>
+    </Link>
+  )
+}

--- a/frontend/src/components/home/RankingsPreview.jsx
+++ b/frontend/src/components/home/RankingsPreview.jsx
@@ -1,0 +1,83 @@
+import { Link } from 'react-router-dom'
+import { SectionHeading } from './BullpenStories'
+
+// Section 4 — Rankings Preview. Two boards run live off today's availability
+// counts; the movement boards are honest placeholders until day-over-day
+// tracking exists. Positions reflect today's deterministic count ordering.
+export default function RankingsPreview({ rankings }) {
+  if (!rankings) return null
+
+  return (
+    <section className="mb-8" aria-label="Bullpen rankings preview">
+      <SectionHeading
+        title="Bullpen Rankings"
+        subtitle={rankings.intro}
+        right={(
+          <span className="rounded border border-amber/30 bg-amber/5 px-2 py-0.5 font-mono text-[10px] uppercase tracking-widest text-amber/80">
+            Preview
+          </span>
+        )}
+      />
+
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        {rankings.boards.map(board => (
+          <RankingBoard key={board.key} board={board} />
+        ))}
+      </div>
+    </section>
+  )
+}
+
+function RankingBoard({ board }) {
+  return (
+    <div className="card flex flex-col p-4">
+      <div className="font-mono text-[10px] uppercase tracking-widest text-chalk400">{board.title}</div>
+      <div className="mt-0.5 text-[11px] text-chalk600">{board.note}</div>
+
+      <div className="mt-3 flex-1 space-y-1.5">
+        {board.placeholder ? (
+          <PlaceholderRows copy={board.placeholderCopy} />
+        ) : board.entries.length === 0 ? (
+          <div className="py-2 text-xs text-chalk400">Nothing stands out in the current snapshot.</div>
+        ) : (
+          board.entries.map(entry => (
+            <Link
+              key={entry.position}
+              to={entry.href || '/bullpen'}
+              className="group flex items-center gap-3 rounded border border-transparent px-2 py-1.5 transition-colors hover:border-dirt hover:bg-chalk/40"
+            >
+              <span className="font-display text-lg text-amber/80 w-4 text-center">{entry.position}</span>
+              <span className="min-w-0 flex-1">
+                <span className="block font-mono text-sm text-chalk100 group-hover:text-amber transition-colors">
+                  {entry.abbr}
+                </span>
+                <span className="block truncate text-[11px] text-chalk600">{entry.teamName}</span>
+              </span>
+              <span className="font-mono text-[11px] text-chalk400">{entry.stat}</span>
+            </Link>
+          ))
+        )}
+      </div>
+    </div>
+  )
+}
+
+function PlaceholderRows({ copy }) {
+  return (
+    <div>
+      {[1, 2, 3].map(position => (
+        <div key={position} className="flex items-center gap-3 px-2 py-1.5 opacity-40" aria-hidden="true">
+          <span className="font-display text-lg text-chalk600 w-4 text-center">{position}</span>
+          <span className="h-2 flex-1 rounded bg-dirt" />
+          <span className="h-2 w-10 rounded bg-dirt" />
+        </div>
+      ))}
+      <div className="mt-2 flex items-center gap-2 px-2">
+        <span className="rounded border border-dirt px-1.5 py-0.5 font-mono text-[9px] uppercase tracking-widest text-chalk600">
+          Coming Soon
+        </span>
+        <span className="text-[11px] leading-snug text-chalk400">{copy}</span>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/home/TeamExplorer.jsx
+++ b/frontend/src/components/home/TeamExplorer.jsx
@@ -1,0 +1,58 @@
+import { Link } from 'react-router-dom'
+import { SectionHeading } from './BullpenStories'
+import { homeTone } from './homeIntelligenceView'
+
+// Section 5 — Team Explorer. Every tracked club, one click from its bullpen
+// board. Clubs that show up in today's landscape carry a story hook so the
+// grid invites investigation instead of reading like a directory.
+export default function TeamExplorer({ explorer }) {
+  return (
+    <section className="mb-8" aria-label="Team explorer">
+      <SectionHeading
+        title="Explore Every Bullpen"
+        subtitle="Pick a club and step inside its pen — availability, workload, and the arms behind tonight's story."
+      />
+
+      {!explorer?.hasTeams ? (
+        <div className="card p-5 text-sm text-chalk400">
+          Team list unavailable right now — head to the Bullpen page to pick a club directly.
+        </div>
+      ) : (
+        <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
+          {explorer.items.map(team => (
+            <TeamCard key={team.teamId ?? team.abbr} team={team} />
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}
+
+function TeamCard({ team }) {
+  const tone = team.tag ? homeTone(team.tag.tone) : null
+
+  return (
+    <Link
+      to={team.href || '/bullpen'}
+      className="card group relative flex flex-col p-3 transition-all duration-200 hover:border-amber/40 hover:bg-amber/5"
+    >
+      {team.tag && (
+        <span
+          className="absolute right-2 top-2 inline-flex items-center gap-1 rounded border px-1.5 py-0.5 font-mono text-[9px] uppercase tracking-widest"
+          style={{ borderColor: tone.borderColor, backgroundColor: tone.backgroundColor, color: tone.color }}
+        >
+          <span className="h-1 w-1 rounded-full" style={{ backgroundColor: tone.dot }} aria-hidden="true" />
+          {team.tag.label}
+        </span>
+      )}
+
+      <span className="font-display text-2xl tracking-wider text-chalk100 group-hover:text-amber transition-colors">
+        {team.abbr}
+      </span>
+      <span className="mt-0.5 line-clamp-2 text-[11px] leading-snug text-chalk400">{team.name}</span>
+      <span className="mt-2 font-mono text-[10px] uppercase tracking-wider text-chalk600">
+        {team.armsTracked} arms tracked
+      </span>
+    </Link>
+  )
+}

--- a/frontend/src/components/home/homeIntelligenceView.js
+++ b/frontend/src/components/home/homeIntelligenceView.js
@@ -1,0 +1,473 @@
+import { fmtDataDate } from '../dashboard/syncStatusView'
+
+// The Morning Bullpen Report — view-model for the story-led homepage.
+//
+// Everything on the homepage is derived from outputs the platform already
+// publishes: the league dashboard payload (availability counts, team context,
+// landscape) and the governed observation feed. This module only retells those
+// signals in plain baseball language. Descriptive only — nothing here ranks
+// pitchers, selects arms, recommends usage, or predicts outcomes.
+
+const COUNT_WORDS = ['zero', 'one', 'two', 'three', 'four', 'five', 'six',
+                     'seven', 'eight', 'nine', 'ten', 'eleven', 'twelve']
+
+const countWord = (n) => COUNT_WORDS[n] || String(n)
+
+const capitalize = (text) => (text ? text.charAt(0).toUpperCase() + text.slice(1) : text)
+
+// "Toronto Blue Jays" → "Toronto Blue Jays'", "Milwaukee" → "Milwaukee's".
+const possessive = (name) => (name?.endsWith('s') ? `${name}'` : `${name}'s`)
+
+// Neutral display tones shared across the homepage. Tones describe the
+// situation being observed (stress / watch / rest), never quality.
+export const HOME_TONES = {
+  stress: { color: '#fca5a5', dot: '#ef4444', borderColor: 'rgba(239,68,68,0.35)', backgroundColor: 'rgba(239,68,68,0.06)' },
+  watch: { color: '#fde047', dot: '#eab308', borderColor: 'rgba(234,179,8,0.35)', backgroundColor: 'rgba(234,179,8,0.06)' },
+  rest: { color: '#6ee7b7', dot: '#10b981', borderColor: 'rgba(16,185,129,0.35)', backgroundColor: 'rgba(16,185,129,0.06)' },
+  neutral: { color: '#8899aa', dot: '#8899aa', borderColor: 'rgba(136,153,170,0.30)', backgroundColor: 'rgba(136,153,170,0.05)' },
+}
+
+export const homeTone = (key) => HOME_TONES[key] || HOME_TONES.neutral
+
+// Deep-link into the existing bullpen board, reusing the /bullpen?view= pattern
+// the rest of the app already understands. source= identifies the homepage
+// section for later UX analytics.
+export function buildHomeTeamHref(entry, source = 'home') {
+  const param = entry?.team_abbreviation || entry?.abbr
+    || (entry?.team_id != null ? String(entry.team_id) : null)
+    || (entry?.teamId != null ? String(entry.teamId) : null)
+  if (!param) return null
+  const query = new URLSearchParams({ view: 'board', team: param, source })
+  return `/bullpen?${query.toString()}`
+}
+
+function mapEntry(entry, source) {
+  if (!entry) return null
+  return {
+    teamId: entry.team_id ?? null,
+    teamName: entry.team_name || entry.team_abbreviation || null,
+    abbr: entry.team_abbreviation || null,
+    available: Number(entry.available) || 0,
+    monitor: Number(entry.monitor) || 0,
+    restricted: Number(entry.restricted) || 0,
+    total: Number(entry.total_relievers) || 0,
+    pctAvailable: Number(entry.pct_available) || 0,
+    pctRestricted: Number(entry.pct_restricted) || 0,
+    href: buildHomeTeamHref(entry, source),
+  }
+}
+
+// The landscape's three situation lists, in plain objects the homepage can use.
+function landscapeLists(dashboard, source = 'home') {
+  const landscape = dashboard?.landscape || {}
+  const mapList = (list) => (Array.isArray(list) ? list : [])
+    .map(entry => mapEntry(entry, source))
+    .filter(entry => entry && entry.teamName)
+  return {
+    constrained: mapList(landscape.constrained_bullpens),
+    available: mapList(landscape.available_bullpens),
+    monitoring: mapList(landscape.monitoring_concentration),
+  }
+}
+
+function leagueMetrics(dashboard) {
+  const metrics = dashboard?.context?.metrics || {}
+  return {
+    total: Number(metrics.total_relievers) || 0,
+    available: Number(metrics.available) || 0,
+    monitor: Number(metrics.monitor) || 0,
+    restricted: Number(metrics.restricted) || 0,
+    pctAvailable: Number(metrics.pct_available) || 0,
+    pctRestricted: Number(metrics.pct_restricted) || 0,
+  }
+}
+
+const heroChips = (team) => [
+  { key: 'ready', label: 'Rested & Ready', value: team.available, tone: 'rest' },
+  { key: 'watch', label: 'Workload Watch', value: team.monitor, tone: 'watch' },
+  { key: 'rest', label: 'Needing Rest', value: team.restricted, tone: 'stress' },
+  { key: 'total', label: 'Relievers', value: team.total, tone: 'neutral' },
+]
+
+// ── Section 1 — What BaseballOS Sees Today ─────────────────────────────────
+// One flagship observation, picked by a fixed priority: the most constrained
+// pen, then the heaviest watch list, then the most rested group, then a quiet
+// league day. Same data the landscape already publishes — retold as a story.
+export function getHeroStory(dashboard, source = 'home-hero') {
+  const { constrained, available, monitoring } = landscapeLists(dashboard, source)
+
+  const stressed = constrained.find(entry => entry.restricted > 0)
+  if (stressed) {
+    return {
+      hasStory: true,
+      angle: 'stress',
+      tone: 'stress',
+      kicker: 'Workload Stress',
+      team: stressed,
+      headline: `The ${stressed.teamName} bullpen is running out of fresh arms`,
+      observation: `BaseballOS counts ${stressed.restricted} of the ${possessive(stressed.teamName)} ${stressed.total} relievers as needing rest after their recent workloads — the most constrained pen in baseball today.`,
+      whyItMatters: 'A short pen narrows the late innings. If the next few games stay close, the heaviest work lands on the arms that have already been carrying it.',
+      chips: heroChips(stressed),
+    }
+  }
+
+  const watched = monitoring.find(entry => entry.monitor > 0)
+  if (watched) {
+    return {
+      hasStory: true,
+      angle: 'concentration',
+      tone: 'watch',
+      kicker: 'Workload Watch',
+      team: watched,
+      headline: `${watched.teamName} keep going back to the same arms`,
+      observation: `${watched.monitor} of the ${possessive(watched.teamName)} ${watched.total} relievers are carrying workloads heavy enough to watch — the largest watch list in baseball today, even with nobody down outright.`,
+      whyItMatters: 'Workload that concentrates in a few relievers stacks up quietly. Heavy weeks tend to surface later as shorter outings and forced nights off.',
+      chips: heroChips(watched),
+    }
+  }
+
+  const rested = available.find(entry => entry.available > 0)
+  if (rested) {
+    return {
+      hasStory: true,
+      angle: 'rest',
+      tone: 'rest',
+      kicker: 'Fresh Arms',
+      team: rested,
+      headline: `The ${rested.teamName} bullpen comes in fully rested`,
+      observation: `${rested.available} of the ${possessive(rested.teamName)} ${rested.total} relievers enter tonight rested and ready — the largest group of fresh arms in baseball today.`,
+      whyItMatters: 'Rest is flexibility. A full pen lets a manager shape the late innings on his terms instead of his bullpen’s.',
+      chips: heroChips(rested),
+    }
+  }
+
+  return {
+    hasStory: false,
+    angle: 'quiet',
+    tone: 'neutral',
+    kicker: 'League Check-In',
+    team: null,
+    headline: 'A quiet morning across major-league bullpens',
+    observation: dashboard?.context?.health?.label
+      || 'No club stands out for bullpen stress or workload concentration in the current snapshot.',
+    whyItMatters: 'Quiet days are when pens reset. The interesting stories usually start the night after.',
+    chips: [],
+  }
+}
+
+// ── Section 2 — League Intelligence Cards ──────────────────────────────────
+export function getLeagueCards(dashboard) {
+  const { constrained, available, monitoring } = landscapeLists(dashboard, 'home-cards')
+  const metrics = leagueMetrics(dashboard)
+
+  const stressLeader = constrained.find(entry => entry.restricted > 0) || null
+  const restLeader = available.find(entry => entry.available > 0) || null
+  const watchLeader = monitoring.find(entry => entry.monitor > 0) || null
+  const stressedClubs = constrained.filter(entry => entry.restricted > 0).length
+
+  let trend
+  if (stressedClubs >= 2) {
+    trend = {
+      stat: String(stressedClubs),
+      statLabel: 'clubs showing stress',
+      line: `${capitalize(countWord(stressedClubs))} bullpens are carrying real stress at the same time — workload is the league-wide story today.`,
+    }
+  } else if (metrics.monitor > 0 && metrics.monitor >= metrics.restricted) {
+    trend = {
+      stat: String(metrics.monitor),
+      statLabel: 'arms on workload watch',
+      line: 'The watch list is the story today: heavy recent usage is spread across the league.',
+    }
+  } else if (metrics.pctAvailable > 0) {
+    trend = {
+      stat: `${metrics.pctAvailable}%`,
+      statLabel: 'of arms rested league-wide',
+      line: 'Most pens enter tonight with their arms rested.',
+    }
+  } else {
+    trend = {
+      stat: null,
+      statLabel: null,
+      line: 'No single league-wide trend stands out in the current snapshot.',
+    }
+  }
+
+  return [
+    {
+      key: 'most-stressed',
+      title: 'Most Stressed Bullpen',
+      tone: 'stress',
+      team: stressLeader,
+      stat: stressLeader ? `${stressLeader.restricted} of ${stressLeader.total}` : null,
+      statLabel: stressLeader ? 'arms needing rest' : null,
+      line: stressLeader
+        ? 'More relievers need a breather here than anywhere else in baseball.'
+        : 'No bullpen is carrying notable stress in the current snapshot.',
+      href: stressLeader?.href || '/bullpen',
+      cta: stressLeader ? 'Step inside this pen' : 'Browse bullpens',
+    },
+    {
+      key: 'most-rested',
+      title: 'Most Rested Bullpen',
+      tone: 'rest',
+      team: restLeader,
+      stat: restLeader ? `${restLeader.available} of ${restLeader.total}` : null,
+      statLabel: restLeader ? 'arms rested & ready' : null,
+      line: restLeader
+        ? 'The largest group of fresh relievers in baseball today.'
+        : 'No bullpen stands out for rest in the current snapshot.',
+      href: restLeader?.href || '/bullpen',
+      cta: restLeader ? 'Step inside this pen' : 'Browse bullpens',
+    },
+    {
+      key: 'biggest-trend',
+      title: 'Biggest Trend',
+      tone: 'neutral',
+      team: null,
+      stat: trend.stat,
+      statLabel: trend.statLabel,
+      line: trend.line,
+      href: '/dashboard',
+      cta: 'See the league view',
+    },
+    {
+      key: 'bullpen-to-watch',
+      title: 'Bullpen To Watch',
+      tone: 'watch',
+      team: watchLeader,
+      stat: watchLeader ? `${watchLeader.monitor} of ${watchLeader.total}` : null,
+      statLabel: watchLeader ? 'arms on workload watch' : null,
+      line: watchLeader
+        ? 'Nobody is down yet — but the recent usage here is piling up.'
+        : 'No watch list stands out in the current snapshot.',
+      href: watchLeader?.href || '/bullpen',
+      cta: watchLeader ? 'Step inside this pen' : 'Browse bullpens',
+    },
+  ]
+}
+
+// ── Section 3 — Today's Bullpen Stories ────────────────────────────────────
+export const STORIES_FALLBACK =
+  'No standout bullpen stories in the current snapshot — check back after tonight’s games.'
+
+const OBSERVATION_KICKERS = {
+  inventory: 'Depth Check',
+  readiness: 'Readiness Note',
+  workload_pressure: 'Workload Watch',
+  constraint: 'Constraint Note',
+  freshness: 'Data Check',
+  trust: 'Data Check',
+  availability_movement: 'Movement',
+  snapshot_change: 'What Changed',
+}
+
+const OBSERVATION_TONES = {
+  informational: 'neutral',
+  monitor: 'watch',
+  elevated: 'watch',
+  significant: 'stress',
+}
+
+export function getBullpenStories(dashboard, observations = null) {
+  const { constrained, available, monitoring } = landscapeLists(dashboard, 'home-stories')
+  const hero = getHeroStory(dashboard)
+  const usedTeamIds = new Set(hero.team?.teamId != null ? [hero.team.teamId] : [])
+
+  const candidates = []
+
+  // Hidden workload — a club whose surface looks calm but whose watch list is
+  // long. The most magazine-worthy shape in the data when it shows up.
+  const hidden = monitoring.find(entry => entry.monitor >= 3 && entry.restricted <= 1)
+  if (hidden) {
+    candidates.push({
+      teamId: hidden.teamId,
+      kicker: 'Hidden Workload Story',
+      tone: 'watch',
+      title: `${hidden.teamName} look fine on the surface — the workload says look closer`,
+      body: `Nobody in this pen is flashing red yet, but ${hidden.monitor} of ${hidden.total} arms are carrying heavy recent usage. The surface is calmer than the workload underneath.`,
+      href: hidden.href,
+    })
+  }
+
+  const heaviest = monitoring.find(entry => entry.monitor > 0)
+  if (heaviest) {
+    candidates.push({
+      teamId: heaviest.teamId,
+      kicker: 'Carrying The Load',
+      tone: 'watch',
+      title: `${heaviest.teamName} keep handing the ball to the same relievers`,
+      body: `${heaviest.monitor} of ${heaviest.total} arms sit on the workload watch list — the heaviest concentration of recent usage in baseball today.`,
+      href: heaviest.href,
+    })
+  }
+
+  const tightening = constrained.find(entry => entry.restricted > 0 && !usedTeamIds.has(entry.teamId))
+  if (tightening) {
+    candidates.push({
+      teamId: tightening.teamId,
+      kicker: 'Emerging Pressure Point',
+      tone: 'stress',
+      title: `The ${tightening.teamName} pen is tightening`,
+      body: `${tightening.restricted} of ${tightening.total} relievers need rest tonight. One long, close game could stretch this group thin.`,
+      href: tightening.href,
+    })
+  }
+
+  const freshest = available.find(entry => entry.available > 0)
+  if (freshest) {
+    candidates.push({
+      teamId: freshest.teamId,
+      kicker: 'Fresh And Ready',
+      tone: 'rest',
+      title: `${freshest.teamName} bring the most rested pen to the park`,
+      body: `${freshest.available} of ${freshest.total} relievers come in rested and ready — rest that buys a manager options late.`,
+      href: freshest.href,
+    })
+  }
+
+  const steady = available.find(entry => entry.available > 0 && entry.teamId !== freshest?.teamId)
+  if (steady) {
+    candidates.push({
+      teamId: steady.teamId,
+      kicker: 'Quiet Strength',
+      tone: 'rest',
+      title: `The ${steady.teamName} pen is in good shape`,
+      body: `${steady.available} of ${steady.total} arms enter tonight rested, with no notable stress signals in the current snapshot.`,
+      href: steady.href,
+    })
+  }
+
+  // Governed observations, retold as league-level notes. Only a contract-safe
+  // collection is used, and the governed title/summary text is shown verbatim.
+  const observationItems = observations?.contractState === 'available'
+    && Array.isArray(observations.observations)
+    ? observations.observations
+    : []
+  for (const observation of observationItems.slice(0, 2)) {
+    if (!observation?.title || !observation?.summary) continue
+    candidates.push({
+      teamId: null,
+      kicker: OBSERVATION_KICKERS[observation.family] || 'League Note',
+      tone: OBSERVATION_TONES[observation.severity] || 'neutral',
+      title: observation.title,
+      body: observation.summary,
+      href: '/dashboard',
+    })
+  }
+
+  const items = []
+  for (const story of candidates) {
+    if (story.teamId != null) {
+      if (usedTeamIds.has(story.teamId)) continue
+      usedTeamIds.add(story.teamId)
+    }
+    items.push(story)
+    if (items.length >= 6) break
+  }
+
+  return { hasStories: items.length > 0, items, fallback: STORIES_FALLBACK }
+}
+
+// ── Section 4 — Rankings Preview ───────────────────────────────────────────
+// A preview of where bullpen rankings are headed. The two live boards reuse
+// the landscape's deterministic count ordering; the movement boards are
+// placeholders until day-over-day tracking exists. No new backend signals.
+export function getRankingsPreview(dashboard) {
+  const { constrained, available } = landscapeLists(dashboard, 'home-rankings')
+
+  const toEntries = (list, statFor) => list.map((team, index) => ({
+    position: index + 1,
+    abbr: team.abbr || team.teamName,
+    teamName: team.teamName,
+    stat: statFor(team),
+    href: team.href,
+  }))
+
+  return {
+    intro: 'Where full bullpen rankings are headed — assembled from the same availability signals on this page and refreshed as new games sync in.',
+    boards: [
+      {
+        key: 'health',
+        title: 'Top Bullpen Health',
+        note: 'Most rested arms in today’s snapshot',
+        placeholder: false,
+        entries: toEntries(
+          available.filter(team => team.available > 0),
+          team => `${team.available}/${team.total} rested`,
+        ),
+      },
+      {
+        key: 'stress',
+        title: 'Most Stressed Bullpens',
+        note: 'Most arms needing rest tonight',
+        placeholder: false,
+        entries: toEntries(
+          constrained.filter(team => team.restricted > 0),
+          team => `${team.restricted}/${team.total} needing rest`,
+        ),
+      },
+      {
+        key: 'risers',
+        title: 'Biggest Risers',
+        note: 'Day-over-day improvement',
+        placeholder: true,
+        placeholderCopy: 'Movement tracking arrives with the full rankings release.',
+        entries: [],
+      },
+      {
+        key: 'fallers',
+        title: 'Biggest Fallers',
+        note: 'Day-over-day decline',
+        placeholder: true,
+        placeholderCopy: 'Movement tracking arrives with the full rankings release.',
+        entries: [],
+      },
+    ],
+  }
+}
+
+// ── Section 5 — Team Explorer ──────────────────────────────────────────────
+export function getTeamExplorerView(teams, dashboard) {
+  const { constrained, available, monitoring } = landscapeLists(dashboard, 'home-explorer')
+
+  // Story hooks for clubs that show up in today's landscape. Later writes win,
+  // so apply in reverse priority: rest, then watch, then stress.
+  const tagByTeamId = new Map()
+  for (const team of available) {
+    if (team.teamId != null && team.available > 0) tagByTeamId.set(team.teamId, { label: 'Rested', tone: 'rest' })
+  }
+  for (const team of monitoring) {
+    if (team.teamId != null && team.monitor > 0) tagByTeamId.set(team.teamId, { label: 'Watch', tone: 'watch' })
+  }
+  for (const team of constrained) {
+    if (team.teamId != null && team.restricted > 0) tagByTeamId.set(team.teamId, { label: 'Stressed', tone: 'stress' })
+  }
+
+  const items = (Array.isArray(teams) ? teams : []).map(team => ({
+    teamId: team.team_id,
+    name: team.team_name || team.team_abbreviation || `Team ${team.team_id}`,
+    abbr: team.team_abbreviation || '—',
+    armsTracked: Number(team.pitcher_count) || 0,
+    tag: tagByTeamId.get(team.team_id) || null,
+    href: buildHomeTeamHref(team, 'home-explorer'),
+  }))
+
+  return { hasTeams: items.length > 0, items, count: items.length }
+}
+
+// ── Masthead ───────────────────────────────────────────────────────────────
+export function getMastheadView(dashboard, now = new Date()) {
+  const freshness = dashboard?.freshness || {}
+  const dataThrough = fmtDataDate(freshness.data_through)
+  const isLive = freshness.is_current !== false
+    && (freshness.sync_status === 'success' || freshness.sync_status === 'ok')
+  return {
+    editionDate: now.toLocaleDateString('en-US', {
+      weekday: 'long', month: 'long', day: 'numeric', year: 'numeric',
+    }),
+    dataLine: dataThrough
+      ? `Built from completed games through ${dataThrough}`
+      : 'Awaiting the first data sync',
+    isLive,
+  }
+}

--- a/frontend/tests/homeIntelligence.test.mjs
+++ b/frontend/tests/homeIntelligence.test.mjs
@@ -1,0 +1,280 @@
+import assert from 'node:assert/strict'
+import test, { after } from 'node:test'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import { createServer } from 'vite'
+
+const server = await createServer({
+  root: process.cwd(),
+  server: { middlewareMode: true },
+  appType: 'custom',
+  logLevel: 'silent',
+})
+
+after(async () => {
+  await server.close()
+})
+
+const { HomeView } = await server.ssrLoadModule('/src/components/home/Home.jsx')
+const {
+  getHeroStory,
+  getLeagueCards,
+  getBullpenStories,
+  getRankingsPreview,
+  getTeamExplorerView,
+  getMastheadView,
+  STORIES_FALLBACK,
+} = await server.ssrLoadModule('/src/components/home/homeIntelligenceView.js')
+
+const escapeRegExp = (value) => String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+const htmlIncludes = (html, text) => new RegExp(escapeRegExp(text)).test(html)
+const render = (el) => renderToStaticMarkup(React.createElement(MemoryRouter, null, el))
+
+// League dashboard payload shaped like /api/bullpen/dashboard.
+const dashboard = {
+  capability: 'bullpen_dashboard',
+  ranking_applied: false,
+  selection_made: false,
+  context: {
+    health: { state: 'strained', label: 'Several bullpens are working through heavy recent usage.', reasons: [] },
+    metrics: {
+      total_relievers: 64, available: 38, monitor: 14, restricted: 9,
+      pct_available: 59, pct_restricted: 14,
+    },
+    confidence: 'high',
+  },
+  roles: { order: [], counts: {}, total: 64 },
+  landscape: {
+    capability: 'tonights_bullpen_landscape',
+    reference_date: '2026-06-06',
+    teams_evaluated: 8,
+    games: { available: true, data_state: 'historical', today_count: 0, as_of_date: '2026-06-05', as_of_count: 6, is_today: false, message: null },
+    constrained_bullpens: [
+      { team_id: 158, team_name: 'Milwaukee Brewers', team_abbreviation: 'MIL', total_relievers: 8, available: 2, monitor: 2, restricted: 4, pct_available: 25, pct_restricted: 50 },
+      { team_id: 121, team_name: 'New York Mets', team_abbreviation: 'NYM', total_relievers: 8, available: 3, monitor: 2, restricted: 3, pct_available: 37, pct_restricted: 37 },
+    ],
+    available_bullpens: [
+      { team_id: 120, team_name: 'Washington Nationals', team_abbreviation: 'WSH', total_relievers: 8, available: 6, monitor: 1, restricted: 1, pct_available: 75, pct_restricted: 12 },
+      { team_id: 137, team_name: 'San Francisco Giants', team_abbreviation: 'SF', total_relievers: 8, available: 5, monitor: 2, restricted: 1, pct_available: 62, pct_restricted: 12 },
+    ],
+    monitoring_concentration: [
+      { team_id: 141, team_name: 'Toronto Blue Jays', team_abbreviation: 'TOR', total_relievers: 8, available: 4, monitor: 4, restricted: 0, pct_available: 50, pct_restricted: 0 },
+    ],
+    notes: [],
+  },
+  freshness: { data_through: '2026-06-05', last_successful_sync: '2026-06-06T08:00:00Z', is_current: true, sync_status: 'success' },
+  availability_summary: { statuses: {} },
+}
+
+const teams = [
+  { team_id: 158, team_name: 'Milwaukee Brewers', team_abbreviation: 'MIL', pitcher_count: 8 },
+  { team_id: 121, team_name: 'New York Mets', team_abbreviation: 'NYM', pitcher_count: 8 },
+  { team_id: 141, team_name: 'Toronto Blue Jays', team_abbreviation: 'TOR', pitcher_count: 8 },
+  { team_id: 120, team_name: 'Washington Nationals', team_abbreviation: 'WSH', pitcher_count: 8 },
+  { team_id: 112, team_name: 'Chicago Cubs', team_abbreviation: 'CHC', pitcher_count: 7 },
+]
+
+const observations = {
+  contractState: 'available',
+  observations: [
+    {
+      observation_id: 'obs-1', observation_type: 'workload_pressure', family: 'workload_pressure',
+      severity: 'elevated', title: 'Bullpen workload pressure is elevated.',
+      summary: 'Recent appearance density is elevated across several tracked bullpens.',
+    },
+  ],
+}
+
+// ── Hero story ──────────────────────────────────────────────────────────────
+
+test('the hero leads with the most constrained bullpen', () => {
+  const hero = getHeroStory(dashboard)
+  assert.ok(hero.hasStory)
+  assert.equal(hero.angle, 'stress')
+  assert.equal(hero.team.teamName, 'Milwaukee Brewers')
+  assert.ok(/Milwaukee Brewers/.test(hero.headline))
+  assert.ok(/4 of/.test(hero.observation))
+  assert.ok(hero.whyItMatters.length > 0)
+})
+
+test('the hero falls back to the heaviest watch list, then the most rested pen', () => {
+  const noStress = {
+    ...dashboard,
+    landscape: { ...dashboard.landscape, constrained_bullpens: [] },
+  }
+  const watchHero = getHeroStory(noStress)
+  assert.equal(watchHero.angle, 'concentration')
+  assert.equal(watchHero.team.teamName, 'Toronto Blue Jays')
+
+  const restOnly = {
+    ...dashboard,
+    landscape: { ...dashboard.landscape, constrained_bullpens: [], monitoring_concentration: [] },
+  }
+  const restHero = getHeroStory(restOnly)
+  assert.equal(restHero.angle, 'rest')
+  assert.equal(restHero.team.teamName, 'Washington Nationals')
+})
+
+test('a quiet league day still produces a hero story', () => {
+  const quiet = getHeroStory({})
+  assert.equal(quiet.hasStory, false)
+  assert.equal(quiet.angle, 'quiet')
+  assert.ok(quiet.headline.length > 0)
+  assert.ok(quiet.whyItMatters.length > 0)
+})
+
+// ── League intelligence cards ───────────────────────────────────────────────
+
+test('all four league intelligence cards are derived from the landscape', () => {
+  const cards = getLeagueCards(dashboard)
+  const byKey = Object.fromEntries(cards.map(card => [card.key, card]))
+  assert.equal(cards.length, 4)
+  assert.equal(byKey['most-stressed'].team.abbr, 'MIL')
+  assert.equal(byKey['most-rested'].team.abbr, 'WSH')
+  assert.equal(byKey['bullpen-to-watch'].team.abbr, 'TOR')
+  // Two constrained clubs → the trend card reads league-wide stress.
+  assert.equal(byKey['biggest-trend'].stat, '2')
+  assert.ok(/clubs/.test(byKey['biggest-trend'].statLabel))
+})
+
+test('cards degrade to quiet copy when the landscape is empty', () => {
+  const cards = getLeagueCards({})
+  assert.equal(cards.length, 4)
+  for (const card of cards) {
+    assert.equal(card.team, null)
+    assert.ok(card.line.length > 0)
+    assert.ok(card.href)
+  }
+})
+
+// ── Bullpen stories ─────────────────────────────────────────────────────────
+
+test('stories are derived from the landscape without repeating the hero club', () => {
+  const stories = getBullpenStories(dashboard, null)
+  assert.ok(stories.hasStories)
+  const titles = stories.items.map(story => story.title).join(' | ')
+  // Hero features Milwaukee; the stories pick up the other clubs.
+  assert.ok(!/Milwaukee/.test(titles))
+  assert.ok(/Toronto Blue Jays/.test(titles))
+  assert.ok(/New York Mets/.test(titles))
+  assert.ok(/Washington Nationals/.test(titles))
+  // Toronto (4 monitor, 0 restricted) reads as a hidden workload story.
+  assert.ok(stories.items.some(story => story.kicker === 'Hidden Workload Story'))
+})
+
+test('governed observations join the story list when contract-safe', () => {
+  const stories = getBullpenStories(dashboard, observations)
+  assert.ok(stories.items.some(story => story.title === 'Bullpen workload pressure is elevated.'))
+})
+
+test('unsafe or empty observation feeds are ignored', () => {
+  const unsafe = { contractState: 'unavailable', observations: [{ title: 'X', summary: 'Y', family: 'trust', severity: 'monitor' }] }
+  const stories = getBullpenStories(dashboard, unsafe)
+  assert.ok(!stories.items.some(story => story.title === 'X'))
+})
+
+test('story list is capped and falls back gracefully', () => {
+  const stories = getBullpenStories(dashboard, observations)
+  assert.ok(stories.items.length <= 6)
+  const empty = getBullpenStories({}, null)
+  assert.equal(empty.hasStories, false)
+  assert.equal(empty.fallback, STORIES_FALLBACK)
+})
+
+// ── Rankings preview ────────────────────────────────────────────────────────
+
+test('rankings preview runs live boards from counts and marks movement boards as placeholders', () => {
+  const rankings = getRankingsPreview(dashboard)
+  const byKey = Object.fromEntries(rankings.boards.map(board => [board.key, board]))
+  assert.equal(rankings.boards.length, 4)
+  assert.equal(byKey.health.entries[0].abbr, 'WSH')
+  assert.equal(byKey.health.entries[0].stat, '6/8 rested')
+  assert.equal(byKey.stress.entries[0].abbr, 'MIL')
+  assert.ok(byKey.risers.placeholder)
+  assert.ok(byKey.fallers.placeholder)
+  assert.ok(byKey.risers.placeholderCopy.length > 0)
+})
+
+// ── Team explorer ───────────────────────────────────────────────────────────
+
+test('the team explorer lists every tracked club with board deep-links', () => {
+  const explorer = getTeamExplorerView(teams, dashboard)
+  assert.equal(explorer.count, 5)
+  const cubs = explorer.items.find(team => team.abbr === 'CHC')
+  assert.ok(cubs)
+  assert.ok(cubs.href.includes('/bullpen?'))
+  assert.ok(cubs.href.includes('team=CHC'))
+  assert.equal(cubs.tag, null)
+})
+
+test('clubs in the landscape carry story hooks, with stress taking priority', () => {
+  const explorer = getTeamExplorerView(teams, dashboard)
+  const byAbbr = Object.fromEntries(explorer.items.map(team => [team.abbr, team]))
+  assert.equal(byAbbr.MIL.tag.label, 'Stressed')
+  assert.equal(byAbbr.TOR.tag.label, 'Watch')
+  assert.equal(byAbbr.WSH.tag.label, 'Rested')
+})
+
+// ── Masthead ────────────────────────────────────────────────────────────────
+
+test('the masthead reports the data window in plain language', () => {
+  const masthead = getMastheadView(dashboard, new Date('2026-06-06T12:00:00Z'))
+  assert.ok(/Built from completed games through Jun 5, 2026/.test(masthead.dataLine))
+  assert.ok(masthead.editionDate.includes('2026'))
+  const cold = getMastheadView({}, new Date('2026-06-06T12:00:00Z'))
+  assert.equal(cold.dataLine, 'Awaiting the first data sync')
+})
+
+// ── Rendering & placement ───────────────────────────────────────────────────
+
+test('the homepage renders all five sections in story-first order', () => {
+  const html = render(React.createElement(HomeView, { dashboard, teams, observations }))
+  const sections = [
+    'What BaseballOS Sees Today',
+    'Most Stressed Bullpen',
+    'Bullpen Stories',
+    'Bullpen Rankings',
+    'Explore Every Bullpen',
+  ]
+  let lastIndex = -1
+  for (const section of sections) {
+    const index = html.indexOf(section)
+    assert.ok(index >= 0, `missing section: ${section}`)
+    assert.ok(index > lastIndex, `out of order: ${section}`)
+    lastIndex = index
+  }
+})
+
+test('the hero renders the flagship observation with Why It Matters', () => {
+  const html = render(React.createElement(HomeView, { dashboard, teams, observations }))
+  assert.ok(htmlIncludes(html, 'Why It Matters'))
+  assert.ok(htmlIncludes(html, 'Milwaukee Brewers'))
+  assert.ok(htmlIncludes(html, 'Step inside the MIL pen'))
+})
+
+test('the homepage keeps a path to the original dashboard', () => {
+  const html = render(React.createElement(HomeView, { dashboard, teams, observations }))
+  assert.ok(htmlIncludes(html, 'href="/dashboard"'))
+})
+
+test('loading and error states render without data', () => {
+  const loadingHtml = render(React.createElement(HomeView, { dashboard: null, teams: null, loading: true }))
+  assert.ok(htmlIncludes(loadingHtml, 'bullpen report'))
+  const errorHtml = render(React.createElement(HomeView, { dashboard: null, teams: null, error: 'API 500' }))
+  assert.ok(htmlIncludes(errorHtml, 'API 500'))
+})
+
+// ── Guardrails: stories stay descriptive ────────────────────────────────────
+
+test('the homepage avoids advisory, ranking, and prediction language', () => {
+  const html = render(React.createElement(HomeView, { dashboard, teams, observations })).toLowerCase()
+  for (const term of [
+    'should use', 'best option', 'best bullpen', 'worst bullpen', 'best arm',
+    'recommended', 'recommendation', 'strongest bullpen', 'weakest bullpen',
+    'expected to win', 'likely to win', 'win probability', 'odds', 'projection',
+    'prediction', 'preferred arm',
+  ]) {
+    assert.ok(!html.includes(term), `leaked term: ${term}`)
+  }
+})


### PR DESCRIPTION
New story-first front page for the intelligence platform experiment. The morning report opens with the most interesting bullpen situation in baseball today, then four league intelligence cards, a set of bullpen story cards, a rankings preview, and a team explorer covering every tracked club.

Everything on the page is derived from outputs the platform already publishes — the league dashboard payload, the bullpen landscape, and the governed observation feed. Descriptive baseball language only: no rankings, selections, recommendations, or predictions. The original dashboard moves to /dashboard unchanged; all other pages untouched.