### PR TITLE
homepage: make every story hook lead somewhere real

### DIFF
--- a/frontend/src/components/home/BullpenStories.jsx
+++ b/frontend/src/components/home/BullpenStories.jsx
@@ -37,14 +37,16 @@ export function SectionHeading({ title, subtitle, right }) {
   )
 }
 
+// A story card is a doorway: team stories step into that club's bullpen
+// board, league notes open the league view, data notes open Data & Trust.
+// A story with no meaningful destination renders as plain copy — no CTA, no
+// pretend link.
 function StoryCard({ story }) {
   const tone = homeTone(story.tone)
+  const hasDestination = Boolean(story.href)
 
-  return (
-    <Link
-      to={story.href || '/bullpen'}
-      className="card group flex flex-col p-4 transition-all duration-200 hover:border-amber/40 hover:bg-amber/5"
-    >
+  const inner = (
+    <>
       <span
         className="inline-flex w-fit items-center gap-1.5 rounded border px-2 py-0.5 font-mono text-[10px] uppercase tracking-widest"
         style={{ borderColor: tone.borderColor, backgroundColor: tone.backgroundColor, color: tone.color }}
@@ -59,9 +61,24 @@ function StoryCard({ story }) {
 
       <p className="mt-2 flex-1 text-sm leading-relaxed text-chalk400">{story.body}</p>
 
-      <div className="mt-3 font-mono text-[10px] uppercase tracking-widest text-chalk600 group-hover:text-amber transition-colors">
-        Open the full picture →
-      </div>
+      {hasDestination && (
+        <div className="mt-3 font-mono text-[10px] uppercase tracking-widest text-chalk600 group-hover:text-amber transition-colors">
+          {story.cta || 'Open the full picture'} →
+        </div>
+      )}
+    </>
+  )
+
+  if (!hasDestination) {
+    return <article className="card flex flex-col p-4">{inner}</article>
+  }
+
+  return (
+    <Link
+      to={story.href}
+      className="card group flex flex-col p-4 transition-all duration-200 hover:border-amber/40 hover:bg-amber/5"
+    >
+      {inner}
     </Link>
   )
 }

--- a/frontend/src/components/home/homeIntelligenceView.js
+++ b/frontend/src/components/home/homeIntelligenceView.js
@@ -202,7 +202,7 @@ export function getLeagueCards(dashboard) {
         ? 'More arms need a breather here than anywhere else in baseball.'
         : 'No pen is carrying outsized stress today — a clean league-wide picture.',
       href: stressLeader?.href || '/bullpen',
-      cta: stressLeader ? 'Step inside this pen' : 'Browse bullpens',
+      cta: stressLeader ? 'Step inside this pen' : 'Browse every bullpen',
     },
     {
       key: 'most-rested',
@@ -215,7 +215,7 @@ export function getLeagueCards(dashboard) {
         ? 'This group brings the cleanest availability picture into today.'
         : 'No pen stands out for rest today.',
       href: restLeader?.href || '/bullpen',
-      cta: restLeader ? 'Step inside this pen' : 'Browse bullpens',
+      cta: restLeader ? 'Step inside this pen' : 'Browse every bullpen',
     },
     {
       key: 'biggest-trend',
@@ -239,7 +239,7 @@ export function getLeagueCards(dashboard) {
         ? 'The surface is not alarming yet, but the recent workload is worth watching.'
         : 'No watch list stands out today.',
       href: watchLeader?.href || '/bullpen',
-      cta: watchLeader ? 'Step inside this pen' : 'Browse bullpens',
+      cta: watchLeader ? 'Step inside this pen' : 'Browse every bullpen',
     },
   ]
 }
@@ -252,47 +252,65 @@ export const STORIES_FALLBACK =
 // is constrained."). The homepage retells each family in the words a baseball
 // writer would use. Families without an editorial translation are left off
 // the page rather than shown raw — the governed text remains available on the
-// deeper surfaces.
+// deeper surfaces. Each family also carries its most useful next click:
+// league-shape stories open the league dashboard; data notes open the
+// Data & Trust page that explains what the system is working from.
 const OBSERVATION_STORY_COPY = {
   inventory: {
     kicker: 'Depth Check',
     title: 'Some clubs are running short on clean options',
     body: 'Around the league, a few pens come in with fewer fully rested arms than they would like. Depth is carrying more of the load than usual today.',
+    href: '/dashboard',
+    cta: 'See the league view',
   },
   readiness: {
     kicker: 'Rest Watch',
     title: 'Rest is becoming part of the bullpen story',
     body: 'Not every arm on a roster is truly fresh today. A handful of pens are managing rest as carefully as they manage innings.',
+    href: '/dashboard',
+    cta: 'See the league view',
   },
   workload_pressure: {
     kicker: 'Workload Watch',
     title: 'Bullpen work is running heavy around the league',
     body: 'Several pens have been busy lately, and the work has not been spread evenly. The arms carrying it have earned a closer look.',
+    href: '/dashboard',
+    cta: 'See the league view',
   },
   constraint: {
     kicker: 'Tight Margins',
     title: 'Late-inning options are tighter than usual today',
     body: 'More than one club comes in with a shorter list of fresh arms than it would like. The margin for a long night is thin in places.',
+    href: '/dashboard',
+    cta: 'See the league view',
   },
   freshness: {
     kicker: 'Data Note',
     title: 'Today’s picture is waiting on fresh games',
     body: 'Part of what BaseballOS sees comes from earlier in the week. The story sharpens as new completed games arrive.',
+    href: '/trust',
+    cta: 'Open the full picture',
   },
   trust: {
     kicker: 'Data Note',
     title: 'BaseballOS is staying quiet where the data is thin',
     body: 'When the inputs are not solid enough to stand behind, the page says less rather than guessing. A few reads are limited today.',
+    href: '/trust',
+    cta: 'Open the full picture',
   },
   availability_movement: {
     kicker: 'Movement',
     title: 'Availability is shifting around the league',
     body: 'Arms are rotating on and off rest around the league. Today’s availability picture is not yesterday’s.',
+    href: '/dashboard',
+    cta: 'See the league view',
   },
   snapshot_change: {
     kicker: 'What Changed',
     title: 'Last night rearranged a few bullpens',
     body: 'The newest completed games changed who is rested and who is not. Today’s bullpen picture reflects it.',
+    href: '/dashboard',
+    cta: 'See the league view',
   },
 }
 
@@ -321,6 +339,7 @@ export function getBullpenStories(dashboard, observations = null) {
       title: `The ${hidden.teamName} box score looks calm. The bullpen does not.`,
       body: `Nobody in this pen is flashing red, but ${hidden.monitor} of ${hidden.total} arms are carrying heavy recent work. The quiet surface is doing a lot of hiding.`,
       href: hidden.href,
+      cta: 'Step inside this pen',
     })
   }
 
@@ -333,6 +352,7 @@ export function getBullpenStories(dashboard, observations = null) {
       title: `The ${heaviest.teamName} keep handing the ball to the same relievers`,
       body: `${heaviest.monitor} of ${heaviest.total} arms sit on the watch list — the heaviest concentration of recent bullpen work in baseball today.`,
       href: heaviest.href,
+      cta: 'Step inside this pen',
     })
   }
 
@@ -345,6 +365,7 @@ export function getBullpenStories(dashboard, observations = null) {
       title: `A thin late-inning margin is forming for the ${tightening.teamName}`,
       body: `${tightening.restricted} of ${tightening.total} relievers need rest today. One long night could leave this pen with very few clean options.`,
       href: tightening.href,
+      cta: 'Step inside this pen',
     })
   }
 
@@ -357,6 +378,7 @@ export function getBullpenStories(dashboard, observations = null) {
       title: `Nobody brings a more rested pen into today than the ${freshest.teamName}`,
       body: `${freshest.available} of ${freshest.total} relievers are rested and ready — the kind of depth that lets the late innings breathe.`,
       href: freshest.href,
+      cta: 'Step inside this pen',
     })
   }
 
@@ -369,6 +391,7 @@ export function getBullpenStories(dashboard, observations = null) {
       title: `The ${steady.teamName} pen is in good shape`,
       body: `${steady.available} of ${steady.total} arms come in rested, with nothing on the workload ledger to worry about today.`,
       href: steady.href,
+      cta: 'Step inside this pen',
     })
   }
 
@@ -391,7 +414,8 @@ export function getBullpenStories(dashboard, observations = null) {
       tone: OBSERVATION_TONES[observation.severity] || 'neutral',
       title: copy.title,
       body: copy.body,
-      href: '/dashboard',
+      href: copy.href,
+      cta: copy.cta,
     })
     if (seenFamilies.size >= 2) break
   }

--- a/frontend/tests/homeIntelligence.test.mjs
+++ b/frontend/tests/homeIntelligence.test.mjs
@@ -17,6 +17,8 @@ after(async () => {
 })
 
 const { HomeView } = await server.ssrLoadModule('/src/components/home/Home.jsx')
+const { default: BullpenStories } = await server.ssrLoadModule('/src/components/home/BullpenStories.jsx')
+const { default: RankingsPreview } = await server.ssrLoadModule('/src/components/home/RankingsPreview.jsx')
 const {
   getHeroStory,
   getLeagueCards,
@@ -326,6 +328,92 @@ test('loading and error states render without data', () => {
   assert.ok(htmlIncludes(loadingHtml, 'bullpen report'))
   const errorHtml = render(React.createElement(HomeView, { dashboard: null, teams: null, error: 'API 500' }))
   assert.ok(htmlIncludes(errorHtml, 'API 500'))
+})
+
+// ── Depth links: every strong hook leads somewhere real ────────────────────
+
+test('the hero primary CTA deep-links into the featured club’s bullpen board', () => {
+  const hero = getHeroStory(dashboard)
+  assert.equal(hero.team.href, '/bullpen?view=board&team=MIL&source=home-hero')
+  const html = render(React.createElement(HomeView, { dashboard, teams, observations }))
+  assert.ok(htmlIncludes(html, 'view=board') && htmlIncludes(html, 'team=MIL'))
+})
+
+test('league intelligence cards link to team boards, and the trend to the league view', () => {
+  const cards = getLeagueCards(dashboard)
+  const byKey = Object.fromEntries(cards.map(card => [card.key, card]))
+  assert.ok(byKey['most-stressed'].href.includes('team=MIL'))
+  assert.ok(byKey['most-rested'].href.includes('team=WSH'))
+  assert.ok(byKey['bullpen-to-watch'].href.includes('team=TOR'))
+  assert.equal(byKey['biggest-trend'].href, '/dashboard')
+})
+
+test('team stories step into the club; league and data notes open their own surfaces', () => {
+  const mixedObservations = {
+    contractState: 'available',
+    observations: [
+      { family: 'workload_pressure', severity: 'elevated', title: 'x', summary: 'y' },
+      { family: 'trust', severity: 'monitor', title: 'x', summary: 'y' },
+    ],
+  }
+  const stories = getBullpenStories(dashboard, mixedObservations)
+  for (const story of stories.items) {
+    assert.ok(story.href, `story has no destination: ${story.title}`)
+    if (story.teamId != null) {
+      assert.ok(story.href.includes('/bullpen?') && story.href.includes('team='))
+      assert.equal(story.cta, 'Step inside this pen')
+    }
+  }
+  const leagueNote = stories.items.find(story => story.kicker === 'Workload Watch' && story.teamId == null)
+  assert.equal(leagueNote.href, '/dashboard')
+  assert.equal(leagueNote.cta, 'See the league view')
+  const dataNote = stories.items.find(story => story.kicker === 'Data Note')
+  assert.equal(dataNote.href, '/trust')
+  assert.equal(dataNote.cta, 'Open the full picture')
+})
+
+test('a story without a destination renders as plain copy, not a pretend link', () => {
+  const html = render(React.createElement(BullpenStories, {
+    stories: {
+      hasStories: true,
+      items: [{ kicker: 'League Note', tone: 'neutral', title: 'No destination here', body: 'Copy only.', href: null }],
+      fallback: '',
+    },
+  }))
+  assert.ok(htmlIncludes(html, 'No destination here'))
+  assert.ok(!html.includes('</a>'), 'no anchor should render without a destination')
+  assert.ok(!html.includes('→'), 'no CTA arrow should render without a destination')
+})
+
+test('live ranking rows link to team boards; coming-soon boards render no links', () => {
+  const rankings = getRankingsPreview(dashboard)
+  for (const board of rankings.boards.filter(b => !b.placeholder)) {
+    for (const entry of board.entries) {
+      assert.ok(entry.href.includes('/bullpen?') && entry.href.includes('team='), `${board.key} row missing link`)
+    }
+  }
+  const html = render(React.createElement(RankingsPreview, { rankings }))
+  const anchorCount = (html.match(/<a /g) || []).length
+  const liveRowCount = rankings.boards.filter(b => !b.placeholder)
+    .reduce((sum, board) => sum + board.entries.length, 0)
+  assert.equal(anchorCount, liveRowCount,
+    'every anchor in the rankings section must be a live team row')
+})
+
+test('every team explorer tile links into that club’s bullpen board', () => {
+  const explorer = getTeamExplorerView(teams, dashboard)
+  for (const team of explorer.items) {
+    assert.ok(team.href.includes('/bullpen?') && team.href.includes('view=board'), `${team.abbr} tile missing link`)
+  }
+})
+
+test('CTA language is specific, never vague', () => {
+  const html = render(React.createElement(HomeView, { dashboard, teams, observations }))
+  assert.ok(htmlIncludes(html, 'Step inside this pen'))
+  assert.ok(htmlIncludes(html, 'See the league view'))
+  for (const vague of ['Learn more', 'Click here', '>Details<', 'Read more']) {
+    assert.ok(!htmlIncludes(html, vague), `vague CTA leaked: ${vague}`)
+  }
 })
 
 // ── Guardrails: language stays descriptive and human ───────────────────────


### PR DESCRIPTION
Depth-linking pass over BaseballOS Today. Story cards now carry their own destination and call to action: team stories step directly into that club's bullpen board, league-shape notes open the league view, and data notes open the Data & Trust page instead of a generic landing. A story with no meaningful destination renders as plain copy — no CTA, no pretend link.

Verified the full journey against the existing /bullpen deep-link contract (view=board&team=ABBR preselects the club's board), so the hero CTA, league cards, ranking rows, and every explorer tile land on a real page that explains the bullpen behind the observation. The coming-soon ranking boards stay unlinked on purpose.

Tests cover hero/card/story/ranking/explorer destinations, the no-destination story fallback, that placeholder boards render zero anchors, and that CTA language stays specific.