### PR TITLE
bullpen board: open with today's story for the selected pen

### DIFF
--- a/frontend/src/components/bullpen/board/BullpenBoardView.jsx
+++ b/frontend/src/components/bullpen/board/BullpenBoardView.jsx
@@ -1,6 +1,7 @@
 import { EmptyState } from '../../UI'
 import BullpenStressSummary from './BullpenStressSummary'
 import BullpenContextSummary from './BullpenContextSummary'
+import TeamBullpenStoryPanel from './TeamBullpenStoryPanel'
 import {
   getBoardCardView,
   getBoardFreshnessView,
@@ -303,7 +304,10 @@ function BoardGroup({ group, onViewDetails }) {
   )
 }
 
-export default function BullpenBoardView({ board, onSelectPitcher }) {
+// `showStoryPanel` mounts Today's Bullpen Story between the context strips and
+// the board. Tonight's Board (the homepage destination) opts in; embedded uses
+// like the side-by-side comparison stay as they are.
+export default function BullpenBoardView({ board, onSelectPitcher, showStoryPanel = false }) {
   const groups = getBoardGroups(board)
   const totals = getBoardTotals(board)
   const teamName = board?.team?.team_name || board?.team?.team_abbreviation
@@ -313,6 +317,7 @@ export default function BullpenBoardView({ board, onSelectPitcher }) {
     <div>
       <FreshnessBanner freshness={board?.freshness} />
       <RosterStatusBanner summary={board?.roster_status} />
+      {showStoryPanel && <TeamBullpenStoryPanel board={board} />}
 
       <div className="mb-5">
         <h2 className="font-display text-2xl tracking-wide text-chalk100">

--- a/frontend/src/components/bullpen/board/TeamBullpenStoryPanel.jsx
+++ b/frontend/src/components/bullpen/board/TeamBullpenStoryPanel.jsx
@@ -1,0 +1,61 @@
+import { getTeamBullpenStoryView } from './teamBullpenStoryView'
+
+// Today's Bullpen Story — a compact analyst note that sits between the
+// context strips and the availability board. It answers why BaseballOS is
+// watching this pen, what the workload shape says, and what to look at on
+// the board below. Additive context only; the board remains the detail.
+export default function TeamBullpenStoryPanel({ board }) {
+  const story = getTeamBullpenStoryView(board)
+  if (!story.hasStory) return null
+
+  return (
+    <section
+      className="mb-6 rounded-lg border border-dirt bg-dugout p-4 sm:p-5"
+      aria-label="Today's bullpen story"
+    >
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="font-mono text-[10px] uppercase tracking-widest text-amber/70">
+          Why BaseballOS Is Watching This Pen
+        </div>
+        <span
+          className="inline-flex items-center gap-1.5 rounded border px-2 py-0.5 font-mono text-[10px] uppercase tracking-widest"
+          style={story.tone}
+        >
+          <span className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: story.tone.dot }} aria-hidden="true" />
+          {story.label}
+        </span>
+      </div>
+
+      <h3 className="mt-2 font-display text-2xl leading-tight tracking-wide text-chalk100">
+        {story.headline}
+      </h3>
+
+      <p className="mt-2 max-w-3xl text-sm leading-relaxed text-chalk200">{story.summary}</p>
+
+      <div className="mt-4 grid gap-4 sm:grid-cols-2">
+        <div>
+          <div className="font-mono text-[10px] uppercase tracking-widest text-chalk400">
+            What The Workload Shape Says
+          </div>
+          <ul className="mt-2 space-y-1.5">
+            {story.workloadBullets.map((bullet, index) => (
+              <li key={index} className="text-xs leading-relaxed text-chalk200">• {bullet}</li>
+            ))}
+          </ul>
+        </div>
+        <div>
+          <div className="font-mono text-[10px] uppercase tracking-widest text-chalk400">
+            What To Watch On The Board
+          </div>
+          <ul className="mt-2 space-y-1.5">
+            {story.watchBullets.map((bullet, index) => (
+              <li key={index} className="text-xs leading-relaxed text-chalk200">• {bullet}</li>
+            ))}
+          </ul>
+        </div>
+      </div>
+
+      <p className="mt-3 border-t border-dirt/60 pt-2 text-[11px] text-chalk600">{story.framing}</p>
+    </section>
+  )
+}

--- a/frontend/src/components/bullpen/board/TonightsBullpenBoard.jsx
+++ b/frontend/src/components/bullpen/board/TonightsBullpenBoard.jsx
@@ -131,7 +131,7 @@ export default function TonightsBullpenBoard({ teams, requestedTeam = null }) {
               loading={gameContext.loading}
               error={gameContext.error}
             />
-            <BullpenBoardView board={board.data} onSelectPitcher={setDetailPitcherId} />
+            <BullpenBoardView board={board.data} onSelectPitcher={setDetailPitcherId} showStoryPanel />
           </div>
           {detailPitcherId != null && (
             <div

--- a/frontend/src/components/bullpen/board/teamBullpenStoryView.js
+++ b/frontend/src/components/bullpen/board/teamBullpenStoryView.js
@@ -1,0 +1,183 @@
+// Today's Bullpen Story — the bridge between a homepage hook and the full
+// board. Derives one team-level story from the board payload the page already
+// fetched: the engine's own health state plus the five availability counts.
+// Pure retelling in baseball language — descriptive only, no predictions,
+// no recommendations, no new signals.
+
+const STORY_TONES = {
+  constrained: { borderColor: '#ef444455', backgroundColor: '#ef444412', color: '#fca5a5', dot: '#ef4444' },
+  watch: { borderColor: '#eab30855', backgroundColor: '#eab30812', color: '#fde047', dot: '#eab308' },
+  rested: { borderColor: '#10b98155', backgroundColor: '#10b98112', color: '#6ee7b7', dot: '#10b981' },
+  balanced: { borderColor: 'rgba(148,163,184,0.32)', backgroundColor: 'rgba(148,163,184,0.09)', color: '#cbd5e1', dot: '#94a3b8' },
+  data_limited: { borderColor: 'rgba(148,163,184,0.32)', backgroundColor: 'rgba(148,163,184,0.09)', color: '#cbd5e1', dot: '#94a3b8' },
+}
+
+const STORY_LABELS = {
+  constrained: 'Constrained Pen',
+  watch: 'Watch-List Pen',
+  rested: 'Rested Pen',
+  balanced: 'Balanced Pen',
+  data_limited: 'Limited Read',
+}
+
+export const STORY_FRAMING_LINE =
+  'Context from current workload and availability signals — not a prediction.'
+
+const arms = (n) => `${n} arm${n === 1 ? '' : 's'}`
+// Verb agreement for count-driven sentences: one('is','are'), etc.
+const one = (n, singular, plural) => (n === 1 ? singular : plural)
+
+function boardCounts(board) {
+  const metrics = board?.context?.metrics || {}
+  const count = (key) => (typeof metrics[key] === 'number' ? metrics[key] : 0)
+  return {
+    total: count('total_relievers'),
+    ready: count('available'),
+    watch: count('monitor'),
+    // "Needing rest" is the workload-driven share (Limited + Avoid).
+    // Unavailable arms are roster- or data-driven and called out separately.
+    needRest: count('limited') + count('avoid'),
+    out: count('unavailable'),
+    pctAvailable: count('pct_available'),
+  }
+}
+
+// One deterministic family per board. The engine's own health state leads;
+// the count shapes settle anything the state leaves open.
+export function deriveStoryFamily(board) {
+  const { total, ready, watch, needRest, pctAvailable } = boardCounts(board)
+  const healthState = board?.context?.health?.state || 'no_data'
+
+  if (total === 0 || healthState === 'no_data') return 'data_limited'
+  if (healthState === 'constrained' || needRest >= 3 || (needRest >= 2 && needRest > watch)) {
+    return 'constrained'
+  }
+  if (
+    healthState === 'monitoring'
+    || healthState === 'elevated'
+    || watch >= 3
+    || (watch >= 2 && watch > needRest)
+  ) {
+    return 'watch'
+  }
+  if (needRest <= 1 && (ready >= 5 || pctAvailable >= 65)) return 'rested'
+  return 'balanced'
+}
+
+function workloadBullets(family, counts, confidence) {
+  const { total, ready, watch, needRest, out } = counts
+  const bullets = []
+
+  bullets.push(ready > 0
+    ? `${arms(ready)} of ${total} ${one(ready, 'comes', 'come')} in rested and ready.`
+    : 'No arm in this pen comes in fully rested.')
+  if (needRest > 0) {
+    bullets.push(`${arms(needRest)} ${one(needRest, 'is', 'are')} workload-restricted after ${one(needRest, 'its', 'their')} recent use.`)
+  }
+  if (watch > 0) {
+    bullets.push(`${arms(watch)} ${one(watch, 'carries', 'carry')} enough recent work to sit on the watch list.`)
+  }
+  if (out > 0) {
+    bullets.push(`${arms(out)} ${one(out, 'is', 'are')} unavailable for roster or data reasons rather than tonight's workload.`)
+  }
+  if (confidence === 'low') {
+    bullets.push('The workload read is thinner than usual today — take the counts with some caution.')
+  }
+  if (bullets.length < 2) {
+    bullets.push(`${arms(total)} tracked in this pen today.`)
+  }
+  return bullets.slice(0, 3)
+}
+
+function watchBullets(family, counts) {
+  const rosterBullet = 'Whether unavailable pitchers are roster moves rather than workload.'
+  switch (family) {
+    case 'constrained':
+      return [
+        'How many fully rested arms actually sit in the Available group.',
+        'Whether the same small group has been carrying the heaviest recent work.',
+        counts.out > 0
+          ? rosterBullet
+          : 'How much clean depth exists beyond the highest-trust arms.',
+      ]
+    case 'watch':
+      return [
+        'Whether the watch-list arms are the same names night after night.',
+        'How the Monitor group’s fatigue reads compare with the rested arms.',
+        'Whether rest is starting to show up for the busiest arms.',
+      ]
+    case 'rested':
+      return [
+        'How deep the Available group runs beyond the first few names.',
+        'Which rested arms have carried the lightest work this week.',
+        ...(counts.out > 0 ? [rosterBullet] : []),
+      ]
+    case 'data_limited':
+      return [
+        'Which arms have current workload reads and which are missing them.',
+        'Whether the picture fills in after the next completed games sync.',
+      ]
+    default:
+      return [
+        'Which arms sit closest to the watch line.',
+        'How the workload spreads across the middle of the pen.',
+        'Whether tonight’s work tips this pen toward stress or rest.',
+      ]
+  }
+}
+
+function storyHeadline(family, teamName, counts) {
+  const { total, ready, watch, needRest } = counts
+  switch (family) {
+    case 'constrained':
+      return {
+        headline: `The ${teamName} enter today with a thin late-inning margin`,
+        summary: needRest > 0
+          ? `${arms(needRest)} of ${total} ${one(needRest, 'comes', 'come')} in needing rest after recent work, and the clean options are thinner than they look. This bullpen has less margin than most today.`
+          : `Only ${arms(ready)} of ${total} ${one(ready, 'comes', 'come')} in fully rested, and the clean options are thinner than they look. This bullpen has less margin than most today.`,
+      }
+    case 'watch':
+      return {
+        headline: `The ${teamName} look calm on the surface — the workload underneath is worth watching`,
+        summary: `${arms(watch)} of ${total} ${one(watch, 'carries', 'carry')} enough recent work to land on the watch list${needRest === 0 ? ', even though nobody is workload-restricted yet' : ''}. The work is concentrated in a small group, and that concentration is the story.`,
+      }
+    case 'rested':
+      return {
+        headline: `The ${teamName} bring one of the cleanest availability pictures into today`,
+        summary: `${arms(ready)} of ${total} ${one(ready, 'comes', 'come')} in rested and ready. Rest is doing a lot of the work in this bullpen's story today.`,
+      }
+    case 'data_limited':
+      return {
+        headline: `Not enough fresh data for a strong read on the ${teamName} today`,
+        summary: 'The current workload picture is too thin to carry a confident story. The board below shows what the data does support.',
+      }
+    default:
+      return {
+        headline: `The ${teamName} come in steady — no extreme bullpen signal today`,
+        summary: `A bit of everything: ${ready} ready, ${watch} on watch, ${needRest} needing rest. Nothing here pushes the late innings into a corner today.`,
+      }
+  }
+}
+
+export function getTeamBullpenStoryView(board) {
+  if (!board) return { hasStory: false }
+
+  const teamName = board?.team?.team_name || board?.team?.team_abbreviation || 'selected club'
+  const counts = boardCounts(board)
+  const confidence = board?.context?.confidence || 'high'
+  const family = deriveStoryFamily(board)
+  const { headline, summary } = storyHeadline(family, teamName, counts)
+
+  return {
+    hasStory: true,
+    family,
+    label: STORY_LABELS[family],
+    tone: STORY_TONES[family],
+    teamName,
+    headline,
+    summary,
+    workloadBullets: workloadBullets(family, counts, confidence),
+    watchBullets: watchBullets(family, counts),
+    framing: STORY_FRAMING_LINE,
+  }
+}

--- a/frontend/tests/teamBullpenStoryPanel.test.mjs
+++ b/frontend/tests/teamBullpenStoryPanel.test.mjs
@@ -1,0 +1,188 @@
+import assert from 'node:assert/strict'
+import test, { after } from 'node:test'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import { createServer } from 'vite'
+
+const server = await createServer({
+  root: process.cwd(),
+  server: { middlewareMode: true },
+  appType: 'custom',
+  logLevel: 'silent',
+})
+
+after(async () => {
+  await server.close()
+})
+
+const { default: TeamBullpenStoryPanel } = await server.ssrLoadModule('/src/components/bullpen/board/TeamBullpenStoryPanel.jsx')
+const { default: BullpenBoardView } = await server.ssrLoadModule('/src/components/bullpen/board/BullpenBoardView.jsx')
+const { getTeamBullpenStoryView, deriveStoryFamily, STORY_FRAMING_LINE } =
+  await server.ssrLoadModule('/src/components/bullpen/board/teamBullpenStoryView.js')
+
+const escapeRegExp = (value) => String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+const htmlIncludes = (html, text) => new RegExp(escapeRegExp(text)).test(html)
+const render = (el) => renderToStaticMarkup(React.createElement(MemoryRouter, null, el))
+
+// Board payloads shaped like /api/bullpen/teams/:id/board.
+function makeBoard({ teamName, abbr, state, confidence = 'high', metrics }) {
+  return {
+    capability: 'team_bullpen_board',
+    team: { team_id: 1, team_name: teamName, team_abbreviation: abbr },
+    context: {
+      health: { state, label: 'label', reasons: [] },
+      metrics,
+      confidence,
+      limitations: [],
+    },
+    groups: [],
+    freshness: {},
+    roster_status: null,
+    stress: null,
+    total_pitchers: metrics.total_relievers,
+  }
+}
+
+const constrainedBoard = makeBoard({
+  teamName: 'Milwaukee Brewers', abbr: 'MIL', state: 'constrained',
+  metrics: { total_relievers: 8, available: 2, monitor: 2, limited: 0, avoid: 3, unavailable: 1, pct_available: 25, pct_restricted: 50 },
+})
+
+const watchBoard = makeBoard({
+  teamName: 'Toronto Blue Jays', abbr: 'TOR', state: 'manageable',
+  metrics: { total_relievers: 8, available: 4, monitor: 4, limited: 0, avoid: 0, unavailable: 0, pct_available: 50, pct_restricted: 0 },
+})
+
+const restedBoard = makeBoard({
+  teamName: 'Washington Nationals', abbr: 'WSH', state: 'manageable',
+  metrics: { total_relievers: 8, available: 6, monitor: 1, limited: 0, avoid: 1, unavailable: 0, pct_available: 75, pct_restricted: 12 },
+})
+
+const balancedBoard = makeBoard({
+  teamName: 'Chicago Cubs', abbr: 'CHC', state: 'manageable',
+  metrics: { total_relievers: 8, available: 4, monitor: 1, limited: 1, avoid: 0, unavailable: 2, pct_available: 50, pct_restricted: 37 },
+})
+
+const dataLimitedBoard = makeBoard({
+  teamName: 'Miami Marlins', abbr: 'MIA', state: 'no_data',
+  metrics: { total_relievers: 0, available: 0, monitor: 0, limited: 0, avoid: 0, unavailable: 0, pct_available: 0, pct_restricted: 0 },
+})
+
+// ── Story family derivation ────────────────────────────────────────────────
+
+test('each board shape lands in its story family', () => {
+  assert.equal(deriveStoryFamily(constrainedBoard), 'constrained')
+  assert.equal(deriveStoryFamily(watchBoard), 'watch')
+  assert.equal(deriveStoryFamily(restedBoard), 'rested')
+  assert.equal(deriveStoryFamily(balancedBoard), 'balanced')
+  assert.equal(deriveStoryFamily(dataLimitedBoard), 'data_limited')
+})
+
+test('a constrained club gets constrained story copy with real counts', () => {
+  const story = getTeamBullpenStoryView(constrainedBoard)
+  assert.equal(story.label, 'Constrained Pen')
+  assert.match(story.headline, /Milwaukee Brewers enter today with a thin late-inning margin/)
+  assert.match(story.summary, /3 arms of 8 come in needing rest|3 arms/)
+  assert.ok(story.workloadBullets.some(bullet => /2 arms of 8 come in rested and ready/.test(bullet)))
+  assert.ok(story.workloadBullets.some(bullet => /3 arms are workload-restricted/.test(bullet)))
+  assert.ok(story.watchBullets.length >= 2 && story.watchBullets.length <= 3)
+})
+
+test('a watch-list club reads calm surface, heavy workload', () => {
+  const story = getTeamBullpenStoryView(watchBoard)
+  assert.equal(story.label, 'Watch-List Pen')
+  assert.match(story.headline, /look calm on the surface/)
+  assert.match(story.summary, /4 arms of 8/)
+  assert.match(story.summary, /nobody is workload-restricted yet/)
+})
+
+test('a rested club reads as the cleanest availability picture', () => {
+  const story = getTeamBullpenStoryView(restedBoard)
+  assert.equal(story.label, 'Rested Pen')
+  assert.match(story.headline, /cleanest availability pictures into today/)
+  assert.match(story.summary, /6 arms of 8 come in rested and ready/)
+})
+
+test('single-arm counts read grammatically', () => {
+  const story = getTeamBullpenStoryView(restedBoard)
+  assert.ok(story.workloadBullets.some(bullet => bullet === '1 arm is workload-restricted after its recent use.'),
+    `got: ${story.workloadBullets.join(' | ')}`)
+  assert.ok(story.workloadBullets.some(bullet => bullet === '1 arm carries enough recent work to sit on the watch list.'),
+    `got: ${story.workloadBullets.join(' | ')}`)
+})
+
+test('a neutral club gets balanced story copy', () => {
+  const story = getTeamBullpenStoryView(balancedBoard)
+  assert.equal(story.label, 'Balanced Pen')
+  assert.match(story.headline, /come in steady — no extreme bullpen signal today/)
+})
+
+test('a thin dataset gets an honest limited read', () => {
+  const story = getTeamBullpenStoryView(dataLimitedBoard)
+  assert.equal(story.label, 'Limited Read')
+  assert.match(story.headline, /Not enough fresh data for a strong read/)
+  assert.ok(story.workloadBullets.length >= 1)
+})
+
+test('no board means no story', () => {
+  assert.equal(getTeamBullpenStoryView(null).hasStory, false)
+  assert.equal(render(React.createElement(TeamBullpenStoryPanel, { board: null })), '')
+})
+
+// ── Panel rendering & placement ────────────────────────────────────────────
+
+test('the panel renders headline, both bullet sections, and the framing line', () => {
+  const html = render(React.createElement(TeamBullpenStoryPanel, { board: constrainedBoard }))
+  assert.ok(htmlIncludes(html, 'Why BaseballOS Is Watching This Pen'))
+  assert.ok(htmlIncludes(html, 'What The Workload Shape Says'))
+  assert.ok(htmlIncludes(html, 'What To Watch On The Board'))
+  assert.ok(htmlIncludes(html, STORY_FRAMING_LINE))
+})
+
+test('the board view mounts the story panel above the board only when asked', () => {
+  const withPanel = render(React.createElement(BullpenBoardView, { board: constrainedBoard, showStoryPanel: true }))
+  assert.ok(htmlIncludes(withPanel, 'Why BaseballOS Is Watching This Pen'))
+  assert.ok(
+    withPanel.indexOf('Why BaseballOS Is Watching This Pen') < withPanel.indexOf('Bullpen Board'),
+    'story panel should sit above the board heading',
+  )
+
+  // Embedded uses (e.g. the side-by-side comparison) stay unchanged.
+  const withoutPanel = render(React.createElement(BullpenBoardView, { board: constrainedBoard }))
+  assert.ok(!htmlIncludes(withoutPanel, 'Why BaseballOS Is Watching This Pen'))
+})
+
+// ── Language guardrails ────────────────────────────────────────────────────
+
+const allBoards = [constrainedBoard, watchBoard, restedBoard, balancedBoard, dataLimitedBoard]
+
+test('the story panel never renders raw system phrasing', () => {
+  for (const board of allBoards) {
+    const html = render(React.createElement(TeamBullpenStoryPanel, { board })).toLowerCase()
+    for (const term of [
+      'availability inventory', 'readiness limitations', 'limitations are present',
+      'snapshot', 'governance', 'classification', 'algorithm', 'data state',
+      'contract', 'fail closed',
+    ]) {
+      assert.ok(!html.includes(term), `${board.team.team_abbreviation} leaked system phrasing: ${term}`)
+    }
+  }
+})
+
+test('the story panel avoids prediction, betting, injury, and recommendation language', () => {
+  for (const board of allBoards) {
+    // The required framing line ("— not a prediction.") is the one sanctioned
+    // use of the word; everything else must stay clean.
+    const html = render(React.createElement(TeamBullpenStoryPanel, { board }))
+      .replace(new RegExp(escapeRegExp(STORY_FRAMING_LINE), 'g'), '')
+      .toLowerCase()
+    for (const term of [
+      'will collapse', 'guaranteed', 'bet ', 'betting', 'odds', 'parlay',
+      'injury', 'prediction', 'predict', 'recommended', 'recommendation',
+      'should use', 'use this pitcher', 'manager should', 'best arm', 'best option',
+    ]) {
+      assert.ok(!html.includes(term), `${board.team.team_abbreviation} leaked: ${term}`)
+    }
+  }
+})


### PR DESCRIPTION
Adds a team story panel to Tonight's Board, sitting between the context strips and the availability groups. It answers the question a reader arrives with from the Today page: why BaseballOS is watching this pen, what the workload shape says, and what to look at on the board below.

The story derives entirely from the board payload the page already fetches — the team health state plus the five availability counts — and lands in one of five families: constrained, watch-list, rested, balanced, or an honest limited read when the data is thin. Copy stays in baseball language with a fixed framing line: context from current workload and availability signals, not a prediction.

The panel is opt-in per board render, so the side-by-side comparison and other embedded uses are unchanged. Tests cover family derivation, copy for each shape, singular/plural count grammar, placement above the board, and guardrails against system phrasing and prediction or recommendation language.