### PR TITLE
split the jobs: Today briefs, Stories streams

### DIFF
--- a/frontend/src/components/home/BullpenStories.jsx
+++ b/frontend/src/components/home/BullpenStories.jsx
@@ -1,26 +1,40 @@
 import { Link } from 'react-router-dom'
 import { homeTone } from './homeIntelligenceView'
 
-// Section 3 — Today's Bullpen Stories. Observation-led story cards in plain
-// baseball language: what the workload data shows, never what anyone should
-// do about it.
+// Section 3 — Today's Short List. The briefing cut: only the few stories that
+// matter most this morning, in plain baseball language — what the workload
+// data shows, never what anyone should do about it. The full feed lives on
+// the Stories page.
+export const SHORT_LIST_LIMIT = 3
+
 export default function BullpenStories({ stories }) {
+  const shortList = (Array.isArray(stories?.items) ? stories.items : []).slice(0, SHORT_LIST_LIMIT)
+
   return (
-    <section className="mb-8" aria-label="Today's bullpen stories">
+    <section className="mb-8" aria-label="Today's short list">
       <SectionHeading
-        title="Today’s Bullpen Stories"
-        subtitle="What the workload data is saying around the league — observations, not verdicts."
+        title="Today’s Short List"
+        subtitle="The bullpen stories that matter most this morning."
       />
 
       {!stories?.hasStories ? (
         <div className="card p-5 text-sm text-chalk400">{stories?.fallback}</div>
       ) : (
         <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-3">
-          {stories.items.map((story, index) => (
+          {shortList.map((story, index) => (
             <StoryCard key={`${story.kicker}-${index}`} story={story} />
           ))}
         </div>
       )}
+
+      <div className="mt-3 text-right">
+        <Link
+          to="/stories"
+          className="inline-flex items-center rounded border border-dirt bg-dugout px-3 py-1.5 font-mono text-[11px] uppercase tracking-widest text-chalk200 transition-colors hover:border-amber/40 hover:text-amber"
+        >
+          Open the full story feed →
+        </Link>
+      </div>
     </section>
   )
 }

--- a/frontend/src/components/home/Home.jsx
+++ b/frontend/src/components/home/Home.jsx
@@ -114,8 +114,8 @@ function Masthead({ masthead }) {
 }
 
 // The flagship observation, told the way a baseball writer would lead a
-// column. Shared with the Stories page, where it runs as the featured story.
-export function HeroStory({ hero }) {
+// column. The Stories page runs the same story as a compact lede instead.
+function HeroStory({ hero }) {
   const tone = homeTone(hero.tone)
 
   return (

--- a/frontend/src/components/stories/Stories.jsx
+++ b/frontend/src/components/stories/Stories.jsx
@@ -3,7 +3,6 @@ import { Link } from 'react-router-dom'
 import { useFetch } from '../../hooks/useFetch'
 import { getBullpenDashboard, getBullpenObservations } from '../../utils/api'
 import { LoadingPane, ErrorState } from '../UI'
-import { HeroStory } from '../home/Home'
 import LeagueIntelligenceCards from '../home/LeagueIntelligenceCards'
 import { SectionHeading } from '../home/BullpenStories'
 import {
@@ -20,10 +19,10 @@ import {
   getStoryFeed,
 } from './storiesFeedView'
 
-// BaseballOS Stories — the browseable bullpen intelligence feed. Today stays
-// curated; this page collects every storyline BaseballOS is carrying right
-// now into one place, with simple lanes to browse by. Same derivations, same
-// destinations, no new signals.
+// BaseballOS Stories — the browseable bullpen intelligence feed. Today is the
+// curated morning briefing; this page is the stream: a compact top story,
+// filters up front, and every storyline BaseballOS is carrying right now.
+// Same derivations, same destinations, no new signals.
 export default function Stories() {
   const dash = useFetch(getBullpenDashboard)
   const observations = useFetch(getBullpenObservations)
@@ -49,7 +48,7 @@ export function StoriesView({
 }) {
   const [filter, setFilter] = useState(initialFilter)
   const masthead = getMastheadView(dashboard)
-  const hero = getHeroStory(dashboard, 'stories-hero')
+  const hero = getHeroStory(dashboard, 'stories-top')
   const cards = getLeagueCards(dashboard)
   const feed = getStoryFeed(dashboard, observations)
   const counts = getFilterCounts(feed.items)
@@ -57,7 +56,7 @@ export function StoriesView({
 
   return (
     <div className="p-4 sm:p-5 lg:p-6 max-w-7xl mx-auto">
-      <header className="mb-6 border-b border-dirt pb-4 animate-fade-up opacity-0" style={{ animationFillMode: 'forwards' }}>
+      <header className="mb-5 border-b border-dirt pb-4 animate-fade-up opacity-0" style={{ animationFillMode: 'forwards' }}>
         <div className="flex flex-wrap items-end justify-between gap-3">
           <div>
             <div className="font-mono text-[10px] uppercase tracking-widest text-amber/70">
@@ -86,20 +85,7 @@ export function StoriesView({
         <ErrorState message={error} onRetry={onRetry} />
       ) : (
         <>
-          <section className="mb-8" aria-label="Featured story">
-            <div className="mb-3 font-mono text-xs uppercase tracking-widest text-chalk400">
-              The Story Today
-            </div>
-            <HeroStory hero={hero} />
-          </section>
-
-          <section className="mb-8" aria-label="Around the league">
-            <SectionHeading
-              title="Around The League"
-              subtitle="The four bullpen situations that frame the day."
-            />
-            <LeagueIntelligenceCards cards={cards} />
-          </section>
+          <TopStoryCard hero={hero} />
 
           <section className="mb-8" aria-label="Story feed">
             <SectionHeading
@@ -138,9 +124,66 @@ export function StoriesView({
               </div>
             )}
           </section>
+
+          <section className="mb-8" aria-label="Around the league">
+            <SectionHeading
+              title="Around The League"
+              subtitle="The four situations framing the day — the same cards the morning briefing leads with."
+            />
+            <LeagueIntelligenceCards cards={cards} />
+          </section>
         </>
       )}
     </div>
+  )
+}
+
+// The feed's lede: the same flagship story Today leads with, in a compact cut
+// that hands the page to the feed instead of repeating the homepage hero.
+function TopStoryCard({ hero }) {
+  const tone = homeTone(hero.tone)
+  const href = hero.team?.href || null
+
+  const inner = (
+    <>
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="font-mono text-[10px] uppercase tracking-widest text-amber/70">Top Story</span>
+        <span
+          className="inline-flex items-center gap-1.5 rounded border px-2 py-0.5 font-mono text-[10px] uppercase tracking-widest"
+          style={{ borderColor: tone.borderColor, backgroundColor: tone.backgroundColor, color: tone.color }}
+        >
+          <span className="h-1 w-1 rounded-full" style={{ backgroundColor: tone.dot }} aria-hidden="true" />
+          {hero.kicker}
+        </span>
+      </div>
+
+      <h2 className="mt-2 max-w-4xl font-display text-2xl leading-tight tracking-wide text-chalk100 sm:text-3xl group-hover:text-amber transition-colors">
+        {hero.headline}
+      </h2>
+
+      <p className="mt-2 max-w-3xl text-sm leading-relaxed text-chalk400">{hero.observation}</p>
+
+      {href && (
+        <div className="mt-3 font-mono text-[10px] uppercase tracking-widest text-chalk600 group-hover:text-amber transition-colors">
+          Step inside the {hero.team.abbr || hero.team.teamName} pen →
+        </div>
+      )}
+    </>
+  )
+
+  return (
+    <section className="mb-6" aria-label="Top story">
+      {href ? (
+        <Link
+          to={href}
+          className="card group block p-4 sm:p-5 transition-all duration-200 hover:border-amber/40 hover:bg-amber/5"
+        >
+          {inner}
+        </Link>
+      ) : (
+        <article className="card p-4 sm:p-5">{inner}</article>
+      )}
+    </section>
   )
 }
 

--- a/frontend/tests/homeIntelligence.test.mjs
+++ b/frontend/tests/homeIntelligence.test.mjs
@@ -254,7 +254,7 @@ test('the homepage renders all five sections in story-first order', () => {
   const sections = [
     'What BaseballOS Sees Today',
     'Most Stressed Bullpen',
-    'Bullpen Stories',
+    'Short List',
     'Bullpen Rankings',
   ]
   let lastIndex = -1
@@ -271,6 +271,20 @@ test('today is curated: no team explorer, feedback CTA intact', () => {
   assert.ok(!htmlIncludes(html, 'Explore Every Bullpen'))
   assert.ok(!htmlIncludes(html, 'arms tracked'))
   assert.ok(htmlIncludes(html, 'Help shape BaseballOS'))
+})
+
+test('today shows only the top three stories and hands off to the feed', () => {
+  const html = render(React.createElement(HomeView, { dashboard, observations }))
+  // With this fixture the story order is Toronto, the Mets, then Washington.
+  assert.ok(htmlIncludes(html, 'box score looks calm'))
+  assert.ok(htmlIncludes(html, 'thin late-inning margin is forming'))
+  assert.ok(htmlIncludes(html, 'more rested pen into today'))
+  // Stories four and beyond stay off the briefing.
+  assert.ok(!htmlIncludes(html, 'Quiet Strength'))
+  assert.ok(!htmlIncludes(html, 'Bullpen work is running heavy around the league'))
+  // The short list hands off to the full feed.
+  assert.ok(htmlIncludes(html, 'href="/stories"'))
+  assert.ok(htmlIncludes(html, 'Open the full story feed'))
 })
 
 test('the hero renders the flagship observation with Why It Matters', () => {
@@ -350,8 +364,10 @@ test('a story without a destination renders as plain copy, not a pretend link', 
     },
   }))
   assert.ok(htmlIncludes(html, 'No destination here'))
-  assert.ok(!html.includes('</a>'), 'no anchor should render without a destination')
-  assert.ok(!html.includes('→'), 'no CTA arrow should render without a destination')
+  // The only anchor in the section is the standing hand-off to the feed.
+  assert.equal((html.match(/<a /g) || []).length, 1)
+  assert.ok(htmlIncludes(html, 'href="/stories"'))
+  assert.ok(!htmlIncludes(html, 'Open the full picture'), 'no card CTA should render without a destination')
 })
 
 test('live ranking rows link to team boards; coming-soon boards render no links', () => {

--- a/frontend/tests/storiesFeed.test.mjs
+++ b/frontend/tests/storiesFeed.test.mjs
@@ -107,20 +107,37 @@ test('every feed story keeps a valid existing destination', () => {
 
 // ── Page rendering ──────────────────────────────────────────────────────────
 
-test('the stories page renders header, framing, featured story, and league cards', () => {
+test('the stories page renders header, framing, compact top story, and league cards', () => {
   const html = render(React.createElement(StoriesView, { dashboard, observations }))
   assert.ok(htmlIncludes(html, 'STORIES'))
   assert.ok(htmlIncludes(html, 'The bullpen stories BaseballOS is watching today'))
   assert.ok(htmlIncludes(html, 'Observations, not predictions.'))
-  // Featured story = the Today flagship, with Why It Matters and its CTA.
-  assert.ok(htmlIncludes(html, 'The Story Today'))
+  // The lede is a compact Top Story module carrying the Today flagship.
+  assert.ok(htmlIncludes(html, 'Top Story'))
   assert.ok(htmlIncludes(html, 'most constrained bullpen today'))
-  assert.ok(htmlIncludes(html, 'Why It Matters'))
   assert.ok(htmlIncludes(html, 'Step inside the MIL pen'))
-  // League intelligence cards, linking as they do from Today.
+  // League intelligence cards remain, linking as they do from Today.
   for (const title of ['Most Stressed Bullpen', 'Most Rested Bullpen', 'Biggest Trend', 'Bullpen To Watch']) {
     assert.ok(htmlIncludes(html, title), `missing card: ${title}`)
   }
+})
+
+test('stories is the feed, not a second homepage', () => {
+  const html = render(React.createElement(StoriesView, { dashboard, observations }))
+  // No giant Today hero: no Why It Matters box, no hero chips, no hero CTAs.
+  assert.ok(!htmlIncludes(html, 'Why It Matters'))
+  assert.ok(!htmlIncludes(html, 'Rested &amp; Ready'))
+  assert.ok(!htmlIncludes(html, 'Browse every bullpen'))
+  // No rankings on the feed.
+  assert.ok(!htmlIncludes(html, 'Bullpen Rankings'))
+  assert.ok(!htmlIncludes(html, 'Top Bullpen Health'))
+  // Filters sit with the feed, ahead of the demoted league strip.
+  const filterIndex = html.indexOf('Story filters')
+  const feedCardIndex = html.indexOf('box score looks calm')
+  const leagueStripIndex = html.indexOf('Around The League')
+  assert.ok(filterIndex >= 0 && feedCardIndex >= 0 && leagueStripIndex >= 0)
+  assert.ok(filterIndex < feedCardIndex, 'filters should come before the feed cards')
+  assert.ok(feedCardIndex < leagueStripIndex, 'the feed should come before the league strip')
 })
 
 test('the feed renders story cards with club identity and filter pills with counts', () => {


### PR DESCRIPTION
Today and Stories had drifted into the same page wearing different headers. This pass gives each a clear job.

Today is the morning briefing now: hero, league cards, a Short List of only the top three stories, and the rankings preview. The short list hands off to the full feed with a single CTA instead of duplicating it.

Stories is the intelligence stream: a compact Top Story lede instead of the homepage hero, the filter bar moved up beside the feed so the page's identity is obvious at a glance, the full story list as the main content, and the league cards demoted to a secondary strip below the feed. No rankings on the feed.

Same derivations and destinations on both pages; the difference is editorial cut and density, not data. Tests pin the top-three cap, the feed hand-off, the compact lede, the filter placement, and that the giant hero and rankings stay off Stories.