### PR TITLE
vocabulary: introduce the BaseballOS reads

### DIFF
--- a/frontend/src/components/bullpen/board/TeamBullpenStoryPanel.jsx
+++ b/frontend/src/components/bullpen/board/TeamBullpenStoryPanel.jsx
@@ -1,4 +1,6 @@
 import { getTeamBullpenStoryView } from './teamBullpenStoryView'
+import { CONCEPT_DEFINITIONS } from '../../../utils/bullpenConcepts'
+import { homeTone } from '../../home/homeIntelligenceView'
 
 // Today's Bullpen Story — a compact analyst note that sits between the
 // context strips and the availability board. It answers why BaseballOS is
@@ -32,6 +34,8 @@ export default function TeamBullpenStoryPanel({ board }) {
 
       <p className="mt-2 max-w-3xl text-sm leading-relaxed text-chalk200">{story.summary}</p>
 
+      <BaseballOSReads reads={story.reads} />
+
       <div className="mt-4 grid gap-4 sm:grid-cols-2">
         <div>
           <div className="font-mono text-[10px] uppercase tracking-widest text-chalk400">
@@ -57,5 +61,55 @@ export default function TeamBullpenStoryPanel({ board }) {
 
       <p className="mt-3 border-t border-dirt/60 pt-2 text-[11px] text-chalk600">{story.framing}</p>
     </section>
+  )
+}
+
+// The BaseballOS Reads strip — the four named reads in a compact row. Each
+// chip explains itself on hover/focus, and the disclosure underneath spells
+// out what every read means in one line.
+function BaseballOSReads({ reads }) {
+  if (!Array.isArray(reads) || reads.length === 0) return null
+
+  return (
+    <div className="mt-4">
+      <div className="font-mono text-[10px] uppercase tracking-widest text-chalk400">
+        BaseballOS Reads
+      </div>
+      <dl className="mt-2 flex flex-wrap gap-2">
+        {reads.map(read => {
+          const tone = homeTone(read.tone)
+          return (
+            <div
+              key={read.key}
+              className="inline-flex items-center gap-2 rounded border border-dirt bg-field/60 px-2.5 py-1"
+              title={`${read.concept}: ${read.definition} ${read.detail}`}
+            >
+              <dt className="font-mono text-[10px] uppercase tracking-wider text-chalk400">
+                {read.concept}
+              </dt>
+              <dd
+                className="inline-flex items-center gap-1.5 font-mono text-[11px] font-semibold uppercase tracking-wide"
+                style={{ color: tone.color }}
+              >
+                <span className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: tone.dot }} aria-hidden="true" />
+                {read.label}
+              </dd>
+            </div>
+          )
+        })}
+      </dl>
+      <details className="mt-2">
+        <summary className="cursor-pointer font-mono text-[10px] uppercase tracking-widest text-chalk600 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber/60">
+          What these mean
+        </summary>
+        <ul className="mt-2 space-y-1">
+          {Object.values(CONCEPT_DEFINITIONS).map(concept => (
+            <li key={concept.name} className="text-xs leading-relaxed text-chalk400">
+              <span className="text-chalk200">{concept.name}</span> — {concept.definition}
+            </li>
+          ))}
+        </ul>
+      </details>
+    </div>
   )
 }

--- a/frontend/src/components/bullpen/board/teamBullpenStoryView.js
+++ b/frontend/src/components/bullpen/board/teamBullpenStoryView.js
@@ -4,6 +4,8 @@
 // Pure retelling in baseball language — descriptive only, no predictions,
 // no recommendations, no new signals.
 
+import { getBullpenReads } from '../../../utils/bullpenConcepts'
+
 const STORY_TONES = {
   constrained: { borderColor: '#ef444455', backgroundColor: '#ef444412', color: '#fca5a5', dot: '#ef4444' },
   watch: { borderColor: '#eab30855', backgroundColor: '#eab30812', color: '#fde047', dot: '#eab308' },
@@ -167,6 +169,9 @@ export function getTeamBullpenStoryView(board) {
   const confidence = board?.context?.confidence || 'high'
   const family = deriveStoryFamily(board)
   const { headline, summary } = storyHeadline(family, teamName, counts)
+  // The BaseballOS Reads strip — the named vocabulary derived from the same
+  // counts the story itself uses. A thin dataset reads as Limited across.
+  const { reads } = getBullpenReads({ ...counts, limitedRead: family === 'data_limited' })
 
   return {
     hasStory: true,
@@ -176,6 +181,7 @@ export function getTeamBullpenStoryView(board) {
     teamName,
     headline,
     summary,
+    reads,
     workloadBullets: workloadBullets(family, counts, confidence),
     watchBullets: watchBullets(family, counts),
     framing: STORY_FRAMING_LINE,

--- a/frontend/src/components/home/Home.jsx
+++ b/frontend/src/components/home/Home.jsx
@@ -122,13 +122,24 @@ function HeroStory({ hero }) {
     <div className="relative overflow-hidden rounded-xl border border-dirt bg-dugout bg-stadium-glow p-5 sm:p-7">
       <div className="absolute inset-0 bg-grid-lines opacity-100 pointer-events-none" />
       <div className="relative z-10">
-        <span
-          className="inline-flex items-center gap-1.5 rounded border px-2 py-0.5 font-mono text-[10px] uppercase tracking-widest"
-          style={{ borderColor: tone.borderColor, backgroundColor: tone.backgroundColor, color: tone.color }}
-        >
-          <span className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: tone.dot }} aria-hidden="true" />
-          {hero.kicker}
-        </span>
+        <div className="flex flex-wrap items-center gap-2">
+          <span
+            className="inline-flex items-center gap-1.5 rounded border px-2 py-0.5 font-mono text-[10px] uppercase tracking-widest"
+            style={{ borderColor: tone.borderColor, backgroundColor: tone.backgroundColor, color: tone.color }}
+          >
+            <span className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: tone.dot }} aria-hidden="true" />
+            {hero.kicker}
+          </span>
+          {hero.read && (
+            <span
+              className="inline-flex items-center gap-1.5 rounded border border-dirt bg-field/60 px-2 py-0.5 font-mono text-[10px] uppercase tracking-widest text-chalk200"
+              title={`${hero.read.concept}: ${hero.read.definition} ${hero.read.detail}`}
+            >
+              <span className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: homeTone(hero.read.tone).dot }} aria-hidden="true" />
+              {hero.read.display}
+            </span>
+          )}
+        </div>
 
         <h2 className="mt-3 max-w-4xl font-display text-4xl leading-none tracking-wide text-chalk100 sm:text-5xl">
           {hero.headline}

--- a/frontend/src/components/home/homeIntelligenceView.js
+++ b/frontend/src/components/home/homeIntelligenceView.js
@@ -1,4 +1,5 @@
 import { fmtDataDate } from '../dashboard/syncStatusView'
+import { getReadsForLandscapeEntry } from '../../utils/bullpenConcepts'
 
 // The Morning Bullpen Report — view-model for the story-led homepage.
 //
@@ -102,6 +103,7 @@ export function getHeroStory(dashboard, source = 'home-hero') {
       tone: 'stress',
       kicker: 'Workload Stress',
       team: stressed,
+      read: getReadsForLandscapeEntry(stressed).byKey.pressure,
       headline: `The ${stressed.teamName} have baseball's most constrained bullpen today`,
       observation: `${stressed.restricted} of the pen's ${stressed.total} relievers come in needing rest after the work they've carried lately. No club enters the day with less late-inning flexibility.`,
       whyItMatters: 'A short bullpen narrows the late innings. If the next few games stay close, the heaviest work is likely to stay on the arms that have already been carrying it.',
@@ -117,6 +119,7 @@ export function getHeroStory(dashboard, source = 'home-hero') {
       tone: 'watch',
       kicker: 'Workload Watch',
       team: watched,
+      read: getReadsForLandscapeEntry(watched).byKey.pressure,
       headline: `The ${watched.teamName} have baseball's most concentrated bullpen workload today`,
       observation: `${watched.monitor} of the pen's ${watched.total} relievers are carrying enough recent work to sit on the watch list — the longest list in baseball today, even with nobody down outright.`,
       whyItMatters: 'Concentrated work stacks up quietly. Heavy weeks tend to show up later as shorter outings and nights off the schedule didn’t plan for.',
@@ -132,6 +135,7 @@ export function getHeroStory(dashboard, source = 'home-hero') {
       tone: 'rest',
       kicker: 'Fresh Arms',
       team: rested,
+      read: getReadsForLandscapeEntry(rested).byKey.pressure,
       headline: `The ${rested.teamName} bring baseball's most rested bullpen into today`,
       observation: `${rested.available} of the pen's ${rested.total} relievers come in rested and ready — the cleanest availability picture in baseball today.`,
       whyItMatters: 'Rest is flexibility. A full pen lets a manager shape the late innings on his terms instead of his bullpen’s.',
@@ -145,6 +149,7 @@ export function getHeroStory(dashboard, source = 'home-hero') {
     tone: 'neutral',
     kicker: 'League Check-In',
     team: null,
+    read: null,
     headline: 'A quiet morning across baseball’s bullpens',
     observation: dashboard?.context?.health?.label
       || 'No club stands out for bullpen stress or heavy workload today. Around the league, the pens are in reasonable shape.',
@@ -336,6 +341,7 @@ export function getBullpenStories(dashboard, observations = null) {
       teamId: hidden.teamId,
       abbr: hidden.abbr,
       teamName: hidden.teamName,
+      read: getReadsForLandscapeEntry(hidden).byKey.concentration,
       kicker: 'Hidden Workload',
       tone: 'watch',
       title: `The ${hidden.teamName} box score looks calm. The bullpen does not.`,
@@ -351,6 +357,7 @@ export function getBullpenStories(dashboard, observations = null) {
       teamId: heaviest.teamId,
       abbr: heaviest.abbr,
       teamName: heaviest.teamName,
+      read: getReadsForLandscapeEntry(heaviest).byKey.concentration,
       kicker: 'Carrying The Load',
       tone: 'watch',
       title: `The ${heaviest.teamName} keep handing the ball to the same relievers`,
@@ -366,6 +373,7 @@ export function getBullpenStories(dashboard, observations = null) {
       teamId: tightening.teamId,
       abbr: tightening.abbr,
       teamName: tightening.teamName,
+      read: getReadsForLandscapeEntry(tightening).byKey.pressure,
       kicker: 'Pressure Point',
       tone: 'stress',
       title: `A thin late-inning margin is forming for the ${tightening.teamName}`,
@@ -381,6 +389,7 @@ export function getBullpenStories(dashboard, observations = null) {
       teamId: freshest.teamId,
       abbr: freshest.abbr,
       teamName: freshest.teamName,
+      read: getReadsForLandscapeEntry(freshest).byKey.recovery,
       kicker: 'Fresh And Ready',
       tone: 'rest',
       title: `Nobody brings a more rested pen into today than the ${freshest.teamName}`,
@@ -396,6 +405,7 @@ export function getBullpenStories(dashboard, observations = null) {
       teamId: steady.teamId,
       abbr: steady.abbr,
       teamName: steady.teamName,
+      read: getReadsForLandscapeEntry(steady).byKey.cleanOptions,
       kicker: 'Quiet Strength',
       tone: 'rest',
       title: `The ${steady.teamName} pen is in good shape`,

--- a/frontend/src/components/stories/Stories.jsx
+++ b/frontend/src/components/stories/Stories.jsx
@@ -208,6 +208,18 @@ function FeedStoryCard({ story }) {
         </span>
       </div>
 
+      {story.read && (
+        <div className="mt-2">
+          <span
+            className="inline-flex items-center gap-1.5 rounded border border-dirt bg-field/60 px-2 py-0.5 font-mono text-[10px] uppercase tracking-widest text-chalk200"
+            title={`${story.read.concept}: ${story.read.definition} ${story.read.detail}`}
+          >
+            <span className="h-1 w-1 rounded-full" style={{ backgroundColor: homeTone(story.read.tone).dot }} aria-hidden="true" />
+            {story.read.display}
+          </span>
+        </div>
+      )}
+
       <h3 className="mt-3 font-display text-2xl leading-tight tracking-wide text-chalk100 group-hover:text-amber transition-colors">
         {story.title}
       </h3>

--- a/frontend/src/utils/bullpenConcepts.js
+++ b/frontend/src/utils/bullpenConcepts.js
@@ -1,0 +1,249 @@
+// The BaseballOS vocabulary layer — four named reads that describe bullpen
+// state in plain baseball language: Bullpen Pressure, Recovery Window,
+// Workload Concentration, and Clean Options.
+//
+// These are descriptive product concepts, not metrics. Every label derives
+// from the same availability counts the rest of the frontend already shows
+// (rested / watch / needing-rest / total), with fixed, inspectable tiers —
+// no scoring, no model, nothing the page can't explain in a sentence.
+
+export const CONCEPT_DEFINITIONS = {
+  pressure: {
+    name: 'Bullpen Pressure',
+    definition: 'How much strain the bullpen appears to be carrying today based on recent workload and availability.',
+  },
+  recovery: {
+    name: 'Recovery Window',
+    definition: 'How much clean rest the bullpen appears to have available today. This describes workload rest, not health.',
+  },
+  concentration: {
+    name: 'Workload Concentration',
+    definition: 'Whether recent bullpen work appears spread across the group or clustered among fewer arms.',
+  },
+  cleanOptions: {
+    name: 'Clean Options',
+    definition: 'How many arms appear to enter today without significant recent workload restriction.',
+  },
+}
+
+export const LIMITED_READ_LABEL = 'Limited Read'
+
+const arms = (n) => `${n} arm${n === 1 ? '' : 's'}`
+
+function normalizeCounts(counts = {}) {
+  const num = (value) => (typeof value === 'number' && Number.isFinite(value) ? value : 0)
+  const total = num(counts.total)
+  return {
+    total,
+    ready: num(counts.ready),
+    watch: num(counts.watch),
+    needRest: num(counts.needRest),
+    limitedRead: Boolean(counts.limitedRead) || total === 0,
+  }
+}
+
+function limitedRead(key) {
+  return {
+    key,
+    concept: CONCEPT_DEFINITIONS[key].name,
+    definition: CONCEPT_DEFINITIONS[key].definition,
+    label: LIMITED_READ_LABEL,
+    display: LIMITED_READ_LABEL,
+    tone: 'neutral',
+    detail: 'Not enough current data for this read.',
+  }
+}
+
+function pressureRead({ total, watch, needRest }) {
+  const base = {
+    key: 'pressure',
+    concept: CONCEPT_DEFINITIONS.pressure.name,
+    definition: CONCEPT_DEFINITIONS.pressure.definition,
+  }
+  if (needRest >= 3 || needRest / total >= 0.4) {
+    return {
+      ...base,
+      label: 'High',
+      display: 'High Bullpen Pressure',
+      tone: 'stress',
+      detail: `${arms(needRest)} of ${total} need rest — recent workload is squeezing today's options.`,
+    }
+  }
+  if (needRest === 2 || (needRest >= 1 && watch >= 2)) {
+    return {
+      ...base,
+      label: 'Elevated',
+      display: 'Elevated Bullpen Pressure',
+      tone: 'watch',
+      detail: 'Enough recent workload here to tighten the late innings.',
+    }
+  }
+  if (needRest === 1 || watch >= 2) {
+    return {
+      ...base,
+      label: 'Manageable',
+      display: 'Manageable Bullpen Pressure',
+      tone: 'rest',
+      detail: 'Some recent work to manage, nothing squeezing the pen yet.',
+    }
+  }
+  return {
+    ...base,
+    label: 'Low',
+    display: 'Low Bullpen Pressure',
+    tone: 'rest',
+    detail: 'Little recent strain on this group.',
+  }
+}
+
+function recoveryRead({ total, ready }) {
+  const base = {
+    key: 'recovery',
+    concept: CONCEPT_DEFINITIONS.recovery.name,
+    definition: CONCEPT_DEFINITIONS.recovery.definition,
+  }
+  const share = ready / total
+  if (ready >= 6 || share >= 0.65) {
+    return {
+      ...base,
+      label: 'Wide',
+      display: 'Wide Recovery Window',
+      tone: 'rest',
+      detail: `${arms(ready)} of ${total} come in rested — plenty of clean rest to work with.`,
+    }
+  }
+  if (share >= 0.45) {
+    return {
+      ...base,
+      label: 'Stable',
+      display: 'Stable Recovery Window',
+      tone: 'rest',
+      detail: 'A workable amount of clean rest in the group.',
+    }
+  }
+  if (share >= 0.25) {
+    return {
+      ...base,
+      label: 'Narrow',
+      display: 'Narrow Recovery Window',
+      tone: 'watch',
+      detail: 'Clean rest is in shorter supply than usual here.',
+    }
+  }
+  return {
+    ...base,
+    label: 'Limited',
+    display: 'Limited Recovery Window',
+    tone: 'stress',
+    detail: 'Very little clean rest available in this group today.',
+  }
+}
+
+function concentrationRead({ watch, needRest }) {
+  const base = {
+    key: 'concentration',
+    concept: CONCEPT_DEFINITIONS.concentration.name,
+    definition: CONCEPT_DEFINITIONS.concentration.definition,
+  }
+  if (watch >= 3 || (watch >= 2 && needRest >= 2)) {
+    return {
+      ...base,
+      label: 'Concentrated',
+      display: 'Concentrated Workload',
+      tone: 'watch',
+      detail: `Recent work is clustering in a few arms — ${arms(watch)} on the watch list.`,
+    }
+  }
+  if (watch === 2 || (watch >= 1 && needRest >= 1)) {
+    return {
+      ...base,
+      label: 'Some Concentration',
+      display: 'Some Concentration',
+      tone: 'neutral',
+      detail: 'A few arms are carrying more than their share of recent work.',
+    }
+  }
+  return {
+    ...base,
+    label: 'Spread-Out',
+    display: 'Spread-Out Workload',
+    tone: 'rest',
+    detail: 'Recent work looks spread across the group.',
+  }
+}
+
+function cleanOptionsRead({ total, ready }) {
+  const base = {
+    key: 'cleanOptions',
+    concept: CONCEPT_DEFINITIONS.cleanOptions.name,
+    definition: CONCEPT_DEFINITIONS.cleanOptions.definition,
+  }
+  if (ready >= 6 || ready / total >= 0.7) {
+    return {
+      ...base,
+      label: 'Deep',
+      display: 'Deep Clean Options',
+      tone: 'rest',
+      detail: `${arms(ready)} enter today without significant recent restriction.`,
+    }
+  }
+  if (ready >= 4 || ready / total >= 0.5) {
+    return {
+      ...base,
+      label: 'Enough',
+      display: 'Enough Clean Options',
+      tone: 'rest',
+      detail: 'A workable group of unrestricted arms for today.',
+    }
+  }
+  if (ready >= 2) {
+    return {
+      ...base,
+      label: 'Thin',
+      display: 'Thin Clean Options',
+      tone: 'watch',
+      detail: 'Fewer unrestricted arms than a club would like today.',
+    }
+  }
+  return {
+    ...base,
+    label: 'Very Thin',
+    display: 'Very Thin Clean Options',
+    tone: 'stress',
+    detail: 'Almost no unrestricted arms in this pen today.',
+  }
+}
+
+// All four reads from one set of counts:
+// { total, ready, watch, needRest, limitedRead? }.
+export function getBullpenReads(counts) {
+  const normalized = normalizeCounts(counts)
+  const keys = ['pressure', 'recovery', 'concentration', 'cleanOptions']
+
+  if (normalized.limitedRead) {
+    const reads = keys.map(key => limitedRead(key))
+    return { reads, byKey: Object.fromEntries(reads.map(read => [read.key, read])) }
+  }
+
+  const reads = [
+    pressureRead(normalized),
+    recoveryRead(normalized),
+    concentrationRead(normalized),
+    cleanOptionsRead(normalized),
+  ]
+  return { reads, byKey: Object.fromEntries(reads.map(read => [read.key, read])) }
+}
+
+// Adapter for the landscape entry shape the homepage view-model uses
+// ({ available, monitor, restricted, total }). The landscape's restricted
+// bucket folds roster-unavailable arms in with workload restriction, which is
+// fine for a descriptive read.
+export function getReadsForLandscapeEntry(entry) {
+  if (!entry) return getBullpenReads({ total: 0 })
+  return getBullpenReads({
+    total: entry.total,
+    ready: entry.available,
+    watch: entry.monitor,
+    needRest: entry.restricted,
+  })
+}

--- a/frontend/tests/bullpenConcepts.test.mjs
+++ b/frontend/tests/bullpenConcepts.test.mjs
@@ -1,0 +1,196 @@
+import assert from 'node:assert/strict'
+import test, { after } from 'node:test'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import { createServer } from 'vite'
+
+const server = await createServer({
+  root: process.cwd(),
+  server: { middlewareMode: true },
+  appType: 'custom',
+  logLevel: 'silent',
+})
+
+after(async () => {
+  await server.close()
+})
+
+const { getBullpenReads, getReadsForLandscapeEntry, CONCEPT_DEFINITIONS, LIMITED_READ_LABEL } =
+  await server.ssrLoadModule('/src/utils/bullpenConcepts.js')
+const { default: TeamBullpenStoryPanel } =
+  await server.ssrLoadModule('/src/components/bullpen/board/TeamBullpenStoryPanel.jsx')
+const { HomeView } = await server.ssrLoadModule('/src/components/home/Home.jsx')
+const { StoriesView } = await server.ssrLoadModule('/src/components/stories/Stories.jsx')
+
+const escapeRegExp = (value) => String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+const htmlIncludes = (html, text) => new RegExp(escapeRegExp(text)).test(html)
+const render = (el) => renderToStaticMarkup(React.createElement(MemoryRouter, null, el))
+
+const labelOf = (counts, key) => getBullpenReads(counts).byKey[key].label
+
+// ── Tier derivations ────────────────────────────────────────────────────────
+
+test('bullpen pressure covers high, elevated, manageable, low, and limited read', () => {
+  assert.equal(labelOf({ total: 8, ready: 2, watch: 2, needRest: 3 }, 'pressure'), 'High')
+  assert.equal(labelOf({ total: 5, ready: 2, watch: 0, needRest: 2 }, 'pressure'), 'High') // 40% share
+  assert.equal(labelOf({ total: 8, ready: 4, watch: 1, needRest: 2 }, 'pressure'), 'Elevated')
+  assert.equal(labelOf({ total: 8, ready: 5, watch: 2, needRest: 1 }, 'pressure'), 'Elevated')
+  assert.equal(labelOf({ total: 8, ready: 6, watch: 1, needRest: 1 }, 'pressure'), 'Manageable')
+  assert.equal(labelOf({ total: 8, ready: 6, watch: 2, needRest: 0 }, 'pressure'), 'Manageable')
+  assert.equal(labelOf({ total: 8, ready: 7, watch: 1, needRest: 0 }, 'pressure'), 'Low')
+  assert.equal(labelOf({ total: 0, ready: 0, watch: 0, needRest: 0 }, 'pressure'), LIMITED_READ_LABEL)
+})
+
+test('recovery window covers wide, stable, narrow, limited, and limited read', () => {
+  assert.equal(labelOf({ total: 8, ready: 6, watch: 1, needRest: 1 }, 'recovery'), 'Wide')
+  assert.equal(labelOf({ total: 8, ready: 4, watch: 2, needRest: 2 }, 'recovery'), 'Stable')
+  assert.equal(labelOf({ total: 8, ready: 2, watch: 2, needRest: 4 }, 'recovery'), 'Narrow')
+  assert.equal(labelOf({ total: 8, ready: 1, watch: 3, needRest: 4 }, 'recovery'), 'Limited')
+  assert.equal(labelOf({ total: 0 }, 'recovery'), LIMITED_READ_LABEL)
+})
+
+test('workload concentration covers concentrated, some, spread-out, and limited read', () => {
+  assert.equal(labelOf({ total: 8, ready: 4, watch: 4, needRest: 0 }, 'concentration'), 'Concentrated')
+  assert.equal(labelOf({ total: 8, ready: 2, watch: 2, needRest: 3 }, 'concentration'), 'Concentrated')
+  assert.equal(labelOf({ total: 8, ready: 6, watch: 2, needRest: 0 }, 'concentration'), 'Some Concentration')
+  assert.equal(labelOf({ total: 8, ready: 6, watch: 1, needRest: 1 }, 'concentration'), 'Some Concentration')
+  assert.equal(labelOf({ total: 8, ready: 7, watch: 1, needRest: 0 }, 'concentration'), 'Spread-Out')
+  assert.equal(labelOf({ total: 0 }, 'concentration'), LIMITED_READ_LABEL)
+})
+
+test('clean options covers deep, enough, thin, very thin, and limited read', () => {
+  assert.equal(labelOf({ total: 8, ready: 6, watch: 1, needRest: 1 }, 'cleanOptions'), 'Deep')
+  assert.equal(labelOf({ total: 8, ready: 4, watch: 2, needRest: 2 }, 'cleanOptions'), 'Enough')
+  assert.equal(labelOf({ total: 8, ready: 2, watch: 2, needRest: 4 }, 'cleanOptions'), 'Thin')
+  assert.equal(labelOf({ total: 8, ready: 1, watch: 3, needRest: 4 }, 'cleanOptions'), 'Very Thin')
+  assert.equal(labelOf({ total: 0 }, 'cleanOptions'), LIMITED_READ_LABEL)
+})
+
+test('every concept ships a visible name and definition', () => {
+  for (const key of ['pressure', 'recovery', 'concentration', 'cleanOptions']) {
+    assert.ok(CONCEPT_DEFINITIONS[key].name.length > 0)
+    assert.ok(CONCEPT_DEFINITIONS[key].definition.length > 20)
+  }
+  const { reads } = getBullpenReads({ total: 8, ready: 4, watch: 2, needRest: 2 })
+  assert.equal(reads.length, 4)
+  for (const read of reads) {
+    assert.ok(read.definition.length > 0)
+    assert.ok(read.detail.length > 0)
+  }
+})
+
+test('the landscape adapter maps entry counts onto the reads', () => {
+  const entry = { total: 8, available: 2, monitor: 2, restricted: 4 }
+  const { byKey } = getReadsForLandscapeEntry(entry)
+  assert.equal(byKey.pressure.label, 'High')
+  assert.equal(byKey.cleanOptions.label, 'Thin')
+  assert.equal(getReadsForLandscapeEntry(null).byKey.pressure.label, LIMITED_READ_LABEL)
+})
+
+// ── Surfaces ────────────────────────────────────────────────────────────────
+
+function makeBoard(metrics, state = 'constrained') {
+  return {
+    team: { team_id: 1, team_name: 'Milwaukee Brewers', team_abbreviation: 'MIL' },
+    context: { health: { state, label: 'label', reasons: [] }, metrics, confidence: 'high', limitations: [] },
+    groups: [],
+    freshness: {},
+    total_pitchers: metrics.total_relievers,
+  }
+}
+
+const constrainedBoard = makeBoard({
+  total_relievers: 8, available: 2, monitor: 2, limited: 0, avoid: 3, unavailable: 1,
+  pct_available: 25, pct_restricted: 50,
+})
+
+test('the team story panel renders the BaseballOS Reads strip with definitions', () => {
+  const html = render(React.createElement(TeamBullpenStoryPanel, { board: constrainedBoard }))
+  assert.ok(htmlIncludes(html, 'BaseballOS Reads'))
+  // Milwaukee's counts: 3 needing rest, 2 on watch, 2 ready of 8.
+  assert.ok(htmlIncludes(html, 'Bullpen Pressure'))
+  assert.ok(htmlIncludes(html, 'High'))
+  assert.ok(htmlIncludes(html, 'Recovery Window'))
+  assert.ok(htmlIncludes(html, 'Narrow'))
+  assert.ok(htmlIncludes(html, 'Workload Concentration'))
+  assert.ok(htmlIncludes(html, 'Concentrated'))
+  assert.ok(htmlIncludes(html, 'Clean Options'))
+  assert.ok(htmlIncludes(html, 'Thin'))
+  // The definitions are one disclosure away.
+  assert.ok(htmlIncludes(html, 'What these mean'))
+  assert.ok(htmlIncludes(html, CONCEPT_DEFINITIONS.pressure.definition))
+  assert.ok(htmlIncludes(html, CONCEPT_DEFINITIONS.recovery.definition))
+})
+
+test('a thin dataset reads as Limited across the strip', () => {
+  const emptyBoard = makeBoard({
+    total_relievers: 0, available: 0, monitor: 0, limited: 0, avoid: 0, unavailable: 0,
+    pct_available: 0, pct_restricted: 0,
+  }, 'no_data')
+  const html = render(React.createElement(TeamBullpenStoryPanel, { board: emptyBoard }))
+  const limitedCount = (html.match(new RegExp(escapeRegExp(LIMITED_READ_LABEL), 'g')) || []).length
+  assert.ok(limitedCount >= 4, `expected all four reads limited, saw ${limitedCount}`)
+})
+
+const dashboard = {
+  context: {
+    health: { state: 'strained', label: 'label', reasons: [] },
+    metrics: { total_relievers: 64, available: 38, monitor: 14, restricted: 9, pct_available: 59, pct_restricted: 14 },
+    confidence: 'high',
+  },
+  landscape: {
+    reference_date: '2026-06-06',
+    teams_evaluated: 8,
+    games: { available: true, data_state: 'historical', today_count: 0, as_of_date: '2026-06-05', as_of_count: 6, is_today: false, message: null },
+    constrained_bullpens: [
+      { team_id: 158, team_name: 'Milwaukee Brewers', team_abbreviation: 'MIL', total_relievers: 8, available: 2, monitor: 2, restricted: 4, pct_available: 25, pct_restricted: 50 },
+      { team_id: 121, team_name: 'New York Mets', team_abbreviation: 'NYM', total_relievers: 8, available: 3, monitor: 2, restricted: 3, pct_available: 37, pct_restricted: 37 },
+    ],
+    available_bullpens: [
+      { team_id: 120, team_name: 'Washington Nationals', team_abbreviation: 'WSH', total_relievers: 8, available: 6, monitor: 1, restricted: 1, pct_available: 75, pct_restricted: 12 },
+    ],
+    monitoring_concentration: [
+      { team_id: 141, team_name: 'Toronto Blue Jays', team_abbreviation: 'TOR', total_relievers: 8, available: 4, monitor: 4, restricted: 0, pct_available: 50, pct_restricted: 0 },
+    ],
+    notes: [],
+  },
+  freshness: { data_through: '2026-06-05', last_successful_sync: '2026-06-06T08:00:00Z', is_current: true, sync_status: 'success' },
+}
+
+test('today stays light: exactly one concept chip, on the hero', () => {
+  const html = render(React.createElement(HomeView, { dashboard }))
+  const matches = (html.match(/High Bullpen Pressure/g) || []).length
+  assert.equal(matches, 1, 'the hero carries one pressure chip; story cards on Today stay untagged')
+})
+
+test('stories feed cards carry compact concept tags', () => {
+  const html = render(React.createElement(StoriesView, { dashboard }))
+  // Toronto's hidden-workload story is tagged with its concentration read.
+  assert.ok(htmlIncludes(html, 'Concentrated Workload'))
+  // Washington's rested story is tagged with its recovery read.
+  assert.ok(htmlIncludes(html, 'Wide Recovery Window'))
+})
+
+// ── Language guardrails ─────────────────────────────────────────────────────
+
+test('the vocabulary never reaches for prediction, betting, injury, or advice', () => {
+  const fixtures = [
+    { total: 8, ready: 2, watch: 2, needRest: 3 },
+    { total: 8, ready: 4, watch: 2, needRest: 2 },
+    { total: 8, ready: 6, watch: 1, needRest: 1 },
+    { total: 8, ready: 7, watch: 1, needRest: 0 },
+    { total: 8, ready: 1, watch: 3, needRest: 4 },
+    { total: 0 },
+  ]
+  for (const fixture of fixtures) {
+    const { reads } = getBullpenReads(fixture)
+    const text = reads.map(read => `${read.display} ${read.detail} ${read.definition}`).join(' ').toLowerCase()
+    for (const term of [
+      'will ', 'guarantee', 'collapse', 'injur', 'predict', 'bet ', 'betting',
+      'odds', 'should use', 'recommend', 'best arm', 'best option', 'projected',
+    ]) {
+      assert.ok(!text.includes(term), `leaked "${term}" for ${JSON.stringify(fixture)}`)
+    }
+  }
+})


### PR DESCRIPTION
First pass at BaseballOS-owned language: Bullpen Pressure, Recovery Window, Workload Concentration, and Clean Options. Four named reads that describe bullpen state in plain baseball terms — descriptive product concepts, not metrics. Every label derives from the same availability counts the pages already show, through fixed tiers anyone can inspect; thin data reads as Limited rather than guessing.

The team story panel gains a compact BaseballOS Reads strip with a one-click 'What these mean' disclosure carrying the definitions. Today stays light — a single pressure chip on the hero. Stories feed cards carry one concept tag each, matched to the story's angle. Every chip explains itself in a tooltip: definition plus the counts behind the read.

Tests pin every tier of all four reads, the Limited Read fallback, the panel strip with visible definitions, the one-chip budget on Today, the feed tags, and the language guardrails.