### PR TITLE
vocabulary: sharpen the BaseballOS reads

### DIFF
--- a/frontend/src/components/bullpen/board/TeamBullpenStoryPanel.jsx
+++ b/frontend/src/components/bullpen/board/TeamBullpenStoryPanel.jsx
@@ -64,45 +64,41 @@ export default function TeamBullpenStoryPanel({ board }) {
   )
 }
 
-// The BaseballOS Reads strip — the four named reads in a compact row. Each
-// chip explains itself on hover/focus, and the disclosure underneath spells
-// out what every read means in one line.
+// The BaseballOS Reads strip — the four named reads in one tight row. Each
+// chip pairs a muted concept name with its tone-colored value and explains
+// itself on hover/focus; the collapsed disclosure carries the plain-English
+// definitions so the chips themselves stay light.
 function BaseballOSReads({ reads }) {
   if (!Array.isArray(reads) || reads.length === 0) return null
 
   return (
     <div className="mt-4">
-      <div className="font-mono text-[10px] uppercase tracking-widest text-chalk400">
-        BaseballOS Reads
-      </div>
-      <dl className="mt-2 flex flex-wrap gap-2">
+      <dl className="flex flex-wrap items-center gap-x-1.5 gap-y-1.5">
+        <dt className="font-mono text-[10px] uppercase tracking-widest text-amber/70">
+          BaseballOS Reads
+        </dt>
         {reads.map(read => {
           const tone = homeTone(read.tone)
           return (
-            <div
+            <dd
               key={read.key}
-              className="inline-flex items-center gap-2 rounded border border-dirt bg-field/60 px-2.5 py-1"
-              title={`${read.concept}: ${read.definition} ${read.detail}`}
+              className="inline-flex items-center gap-1.5 rounded border border-dirt/70 bg-field/40 px-2 py-0.5"
+              title={`${read.display}: ${read.detail}`}
             >
-              <dt className="font-mono text-[10px] uppercase tracking-wider text-chalk400">
-                {read.concept}
-              </dt>
-              <dd
-                className="inline-flex items-center gap-1.5 font-mono text-[11px] font-semibold uppercase tracking-wide"
-                style={{ color: tone.color }}
-              >
-                <span className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: tone.dot }} aria-hidden="true" />
+              <span className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: tone.dot }} aria-hidden="true" />
+              <span className="font-mono text-[10px] uppercase tracking-wide text-chalk400">{read.concept}</span>
+              <span className="font-mono text-[10px] font-semibold uppercase tracking-wide" style={{ color: tone.color }}>
                 {read.label}
-              </dd>
-            </div>
+              </span>
+            </dd>
           )
         })}
       </dl>
-      <details className="mt-2">
+      <details className="mt-1.5">
         <summary className="cursor-pointer font-mono text-[10px] uppercase tracking-widest text-chalk600 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber/60">
           What these mean
         </summary>
-        <ul className="mt-2 space-y-1">
+        <ul className="mt-1.5 space-y-1">
           {Object.values(CONCEPT_DEFINITIONS).map(concept => (
             <li key={concept.name} className="text-xs leading-relaxed text-chalk400">
               <span className="text-chalk200">{concept.name}</span> — {concept.definition}

--- a/frontend/src/components/home/Home.jsx
+++ b/frontend/src/components/home/Home.jsx
@@ -133,7 +133,7 @@ function HeroStory({ hero }) {
           {hero.read && (
             <span
               className="inline-flex items-center gap-1.5 rounded border border-dirt bg-field/60 px-2 py-0.5 font-mono text-[10px] uppercase tracking-widest text-chalk200"
-              title={`${hero.read.concept}: ${hero.read.definition} ${hero.read.detail}`}
+              title={`${hero.read.display}: ${hero.read.detail}`}
             >
               <span className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: homeTone(hero.read.tone).dot }} aria-hidden="true" />
               {hero.read.display}

--- a/frontend/src/components/stories/Stories.jsx
+++ b/frontend/src/components/stories/Stories.jsx
@@ -209,14 +209,12 @@ function FeedStoryCard({ story }) {
       </div>
 
       {story.read && (
-        <div className="mt-2">
-          <span
-            className="inline-flex items-center gap-1.5 rounded border border-dirt bg-field/60 px-2 py-0.5 font-mono text-[10px] uppercase tracking-widest text-chalk200"
-            title={`${story.read.concept}: ${story.read.definition} ${story.read.detail}`}
-          >
-            <span className="h-1 w-1 rounded-full" style={{ backgroundColor: homeTone(story.read.tone).dot }} aria-hidden="true" />
-            {story.read.display}
-          </span>
+        <div
+          className="mt-1.5 inline-flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-widest text-chalk500"
+          title={`${story.read.display}: ${story.read.detail}`}
+        >
+          <span className="h-1 w-1 rounded-full" style={{ backgroundColor: homeTone(story.read.tone).dot }} aria-hidden="true" />
+          {story.read.display}
         </div>
       )}
 

--- a/frontend/src/utils/bullpenConcepts.js
+++ b/frontend/src/utils/bullpenConcepts.js
@@ -10,25 +10,33 @@
 export const CONCEPT_DEFINITIONS = {
   pressure: {
     name: 'Bullpen Pressure',
-    definition: 'How much strain the bullpen appears to be carrying today based on recent workload and availability.',
+    definition: 'How much workload strain the pen is carrying today.',
   },
   recovery: {
     name: 'Recovery Window',
-    definition: 'How much clean rest the bullpen appears to have available today. This describes workload rest, not health.',
+    definition: 'How much clean rest the bullpen has available.',
   },
   concentration: {
     name: 'Workload Concentration',
-    definition: 'Whether recent bullpen work appears spread across the group or clustered among fewer arms.',
+    definition: 'Whether recent work is spread around or clustered on fewer arms.',
   },
   cleanOptions: {
     name: 'Clean Options',
-    definition: 'How many arms appear to enter today without significant recent workload restriction.',
+    definition: 'How many arms enter today without major recent workload restriction.',
   },
 }
 
 export const LIMITED_READ_LABEL = 'Limited Read'
 
-const arms = (n) => `${n} arm${n === 1 ? '' : 's'}`
+// Count-led phrase helpers — every read's detail leads with the arms that
+// drive it, so a tooltip reads like "3 of 8 arms need rest; 2 more on watch."
+const needRestPhrase = (needRest, total) =>
+  `${needRest} of ${total} ${needRest === 1 ? 'arm needs' : 'arms need'} rest`
+const restedPhrase = (ready, total) =>
+  `${ready} of ${total} ${ready === 1 ? 'arm comes' : 'arms come'} in rested`
+const unrestrictedPhrase = (ready, total) =>
+  `${ready} of ${total} ${ready === 1 ? 'arm enters' : 'arms enter'} without restriction`
+const onWatchPhrase = (watch, total) => `${watch} of ${total} on the watch list`
 
 function normalizeCounts(counts = {}) {
   const num = (value) => (typeof value === 'number' && Number.isFinite(value) ? value : 0)
@@ -60,22 +68,18 @@ function pressureRead({ total, watch, needRest }) {
     concept: CONCEPT_DEFINITIONS.pressure.name,
     definition: CONCEPT_DEFINITIONS.pressure.definition,
   }
+  // Lead with arms needing rest, then add the watch tail when it applies.
+  const restAndWatch = watch > 0
+    ? `${needRestPhrase(needRest, total)}; ${watch} more on watch.`
+    : `${needRestPhrase(needRest, total)}.`
   if (needRest >= 3 || needRest / total >= 0.4) {
     return {
-      ...base,
-      label: 'High',
-      display: 'High Bullpen Pressure',
-      tone: 'stress',
-      detail: `${arms(needRest)} of ${total} need rest — recent workload is squeezing today's options.`,
+      ...base, label: 'High', display: 'High Bullpen Pressure', tone: 'stress', detail: restAndWatch,
     }
   }
   if (needRest === 2 || (needRest >= 1 && watch >= 2)) {
     return {
-      ...base,
-      label: 'Elevated',
-      display: 'Elevated Bullpen Pressure',
-      tone: 'watch',
-      detail: 'Enough recent workload here to tighten the late innings.',
+      ...base, label: 'Elevated', display: 'Elevated Bullpen Pressure', tone: 'watch', detail: restAndWatch,
     }
   }
   if (needRest === 1 || watch >= 2) {
@@ -84,7 +88,7 @@ function pressureRead({ total, watch, needRest }) {
       label: 'Manageable',
       display: 'Manageable Bullpen Pressure',
       tone: 'rest',
-      detail: 'Some recent work to manage, nothing squeezing the pen yet.',
+      detail: needRest === 1 ? `${needRestPhrase(needRest, total)}.` : `${onWatchPhrase(watch, total)}.`,
     }
   }
   return {
@@ -92,7 +96,7 @@ function pressureRead({ total, watch, needRest }) {
     label: 'Low',
     display: 'Low Bullpen Pressure',
     tone: 'rest',
-    detail: 'Little recent strain on this group.',
+    detail: watch > 0 ? `No arms need rest; ${watch} of ${total} on watch.` : 'No arms need rest today.',
   }
 }
 
@@ -103,43 +107,20 @@ function recoveryRead({ total, ready }) {
     definition: CONCEPT_DEFINITIONS.recovery.definition,
   }
   const share = ready / total
+  const detail = `${restedPhrase(ready, total)}.`
   if (ready >= 6 || share >= 0.65) {
-    return {
-      ...base,
-      label: 'Wide',
-      display: 'Wide Recovery Window',
-      tone: 'rest',
-      detail: `${arms(ready)} of ${total} come in rested — plenty of clean rest to work with.`,
-    }
+    return { ...base, label: 'Wide', display: 'Wide Recovery Window', tone: 'rest', detail }
   }
   if (share >= 0.45) {
-    return {
-      ...base,
-      label: 'Stable',
-      display: 'Stable Recovery Window',
-      tone: 'rest',
-      detail: 'A workable amount of clean rest in the group.',
-    }
+    return { ...base, label: 'Stable', display: 'Stable Recovery Window', tone: 'rest', detail }
   }
   if (share >= 0.25) {
-    return {
-      ...base,
-      label: 'Narrow',
-      display: 'Narrow Recovery Window',
-      tone: 'watch',
-      detail: 'Clean rest is in shorter supply than usual here.',
-    }
+    return { ...base, label: 'Narrow', display: 'Narrow Recovery Window', tone: 'watch', detail }
   }
-  return {
-    ...base,
-    label: 'Limited',
-    display: 'Limited Recovery Window',
-    tone: 'stress',
-    detail: 'Very little clean rest available in this group today.',
-  }
+  return { ...base, label: 'Limited', display: 'Limited Recovery Window', tone: 'stress', detail }
 }
 
-function concentrationRead({ watch, needRest }) {
+function concentrationRead({ total, watch, needRest }) {
   const base = {
     key: 'concentration',
     concept: CONCEPT_DEFINITIONS.concentration.name,
@@ -147,28 +128,19 @@ function concentrationRead({ watch, needRest }) {
   }
   if (watch >= 3 || (watch >= 2 && needRest >= 2)) {
     return {
-      ...base,
-      label: 'Concentrated',
-      display: 'Concentrated Workload',
-      tone: 'watch',
-      detail: `Recent work is clustering in a few arms — ${arms(watch)} on the watch list.`,
+      ...base, label: 'Concentrated', display: 'Concentrated Workload', tone: 'watch',
+      detail: `${onWatchPhrase(watch, total)} — work is clustering in a few arms.`,
     }
   }
   if (watch === 2 || (watch >= 1 && needRest >= 1)) {
     return {
-      ...base,
-      label: 'Some Concentration',
-      display: 'Some Concentration',
-      tone: 'neutral',
-      detail: 'A few arms are carrying more than their share of recent work.',
+      ...base, label: 'Some Concentration', display: 'Some Concentration', tone: 'neutral',
+      detail: `${onWatchPhrase(watch, total)} carrying more than their share.`,
     }
   }
   return {
-    ...base,
-    label: 'Spread-Out',
-    display: 'Spread-Out Workload',
-    tone: 'rest',
-    detail: 'Recent work looks spread across the group.',
+    ...base, label: 'Spread-Out', display: 'Spread-Out Workload', tone: 'rest',
+    detail: watch > 0 ? `Just ${watch} of ${total} on watch; work otherwise spread.` : 'No arms on the watch list.',
   }
 }
 
@@ -178,40 +150,17 @@ function cleanOptionsRead({ total, ready }) {
     concept: CONCEPT_DEFINITIONS.cleanOptions.name,
     definition: CONCEPT_DEFINITIONS.cleanOptions.definition,
   }
+  const detail = `${unrestrictedPhrase(ready, total)}.`
   if (ready >= 6 || ready / total >= 0.7) {
-    return {
-      ...base,
-      label: 'Deep',
-      display: 'Deep Clean Options',
-      tone: 'rest',
-      detail: `${arms(ready)} enter today without significant recent restriction.`,
-    }
+    return { ...base, label: 'Deep', display: 'Deep Clean Options', tone: 'rest', detail }
   }
   if (ready >= 4 || ready / total >= 0.5) {
-    return {
-      ...base,
-      label: 'Enough',
-      display: 'Enough Clean Options',
-      tone: 'rest',
-      detail: 'A workable group of unrestricted arms for today.',
-    }
+    return { ...base, label: 'Enough', display: 'Enough Clean Options', tone: 'rest', detail }
   }
   if (ready >= 2) {
-    return {
-      ...base,
-      label: 'Thin',
-      display: 'Thin Clean Options',
-      tone: 'watch',
-      detail: 'Fewer unrestricted arms than a club would like today.',
-    }
+    return { ...base, label: 'Thin', display: 'Thin Clean Options', tone: 'watch', detail }
   }
-  return {
-    ...base,
-    label: 'Very Thin',
-    display: 'Very Thin Clean Options',
-    tone: 'stress',
-    detail: 'Almost no unrestricted arms in this pen today.',
-  }
+  return { ...base, label: 'Very Thin', display: 'Very Thin Clean Options', tone: 'stress', detail }
 }
 
 // All four reads from one set of counts:

--- a/frontend/tests/bullpenConcepts.test.mjs
+++ b/frontend/tests/bullpenConcepts.test.mjs
@@ -160,8 +160,11 @@ const dashboard = {
 
 test('today stays light: exactly one concept chip, on the hero', () => {
   const html = render(React.createElement(HomeView, { dashboard }))
-  const matches = (html.match(/High Bullpen Pressure/g) || []).length
-  assert.equal(matches, 1, 'the hero carries one pressure chip; story cards on Today stay untagged')
+  // Count chips by their unique tooltip marker so the visible label and its
+  // own title attribute are not double-counted.
+  const chips = (html.match(/title="High Bullpen Pressure:/g) || []).length
+  assert.equal(chips, 1, 'the hero carries one pressure chip; story cards on Today stay untagged')
+  assert.ok(htmlIncludes(html, 'High Bullpen Pressure'))
 })
 
 test('stories feed cards carry compact concept tags', () => {
@@ -170,6 +173,50 @@ test('stories feed cards carry compact concept tags', () => {
   assert.ok(htmlIncludes(html, 'Concentrated Workload'))
   // Washington's rested story is tagged with its recovery read.
   assert.ok(htmlIncludes(html, 'Wide Recovery Window'))
+})
+
+// ── Definition polish ───────────────────────────────────────────────────────
+
+test('definitions stay short and plain', () => {
+  for (const key of ['pressure', 'recovery', 'concentration', 'cleanOptions']) {
+    const { definition } = CONCEPT_DEFINITIONS[key]
+    assert.ok(definition.length > 20, `${key} definition too short`)
+    assert.ok(definition.length <= 80, `${key} definition should stay a single plain sentence`)
+    assert.ok(definition.split('.').filter(Boolean).length === 1, `${key} definition should be one sentence`)
+  }
+})
+
+test('the concept set stays at four — no new concepts were added', () => {
+  assert.equal(Object.keys(CONCEPT_DEFINITIONS).length, 4)
+  const { reads } = getBullpenReads({ total: 8, ready: 4, watch: 2, needRest: 2 })
+  assert.equal(reads.length, 4)
+})
+
+test('Clean Options keeps its name and avoids health-tinted alternatives', () => {
+  assert.equal(CONCEPT_DEFINITIONS.cleanOptions.name, 'Clean Options')
+  // No display label anywhere should drift to a fresh/health-flavored term.
+  const tiers = [
+    { total: 8, ready: 6, watch: 1, needRest: 1 },
+    { total: 8, ready: 4, watch: 2, needRest: 2 },
+    { total: 8, ready: 2, watch: 2, needRest: 4 },
+    { total: 8, ready: 1, watch: 3, needRest: 4 },
+  ]
+  for (const counts of tiers) {
+    const display = getBullpenReads(counts).byKey.cleanOptions.display
+    assert.ok(/Clean Options$/.test(display), `unexpected clean-options display: ${display}`)
+    assert.ok(!/Fresh|Clean Arms/.test(display))
+  }
+})
+
+test('read detail leads with the counts that drive it', () => {
+  const { byKey } = getBullpenReads({ total: 8, ready: 2, watch: 2, needRest: 3 })
+  assert.match(byKey.pressure.detail, /^3 of 8 arms need rest/)
+  assert.match(byKey.recovery.detail, /^2 of 8 arms come in rested/)
+  assert.match(byKey.concentration.detail, /^2 of 8 on the watch list/)
+  assert.match(byKey.cleanOptions.detail, /^2 of 8 arms enter without restriction/)
+  // Singular counts read grammatically.
+  const single = getBullpenReads({ total: 8, ready: 1, watch: 1, needRest: 1 })
+  assert.match(single.byKey.recovery.detail, /^1 of 8 arm comes in rested/)
 })
 
 // ── Language guardrails ─────────────────────────────────────────────────────


### PR DESCRIPTION
Polish pass on the concept layer — no new concepts, no new logic.

Definitions are now one plain sentence each ("How much workload strain the pen is carrying today.") instead of the longer formal versions. Tooltips lead with the counts that drive each read, so a hover reads "High Bullpen Pressure: 3 of 8 arms need rest; 2 more on watch" — what it means and what's behind it, in one line.

The team story panel's Reads strip is lighter: the four reads sit on one tight inline row beside their label, with the definitions tucked in a compact "What these mean" disclosure. On Stories the concept tag drops its boxed pill for muted dot-and-text so the story kicker and headline clearly lead. Today keeps its single hero chip.

Kept the term "Clean Options" — "fresh" reads as physical readiness and "clean arms" attaches the descriptor to the body; "clean options" stays about late-inning choices, not health. Derivation thresholds are untouched; only labels, definitions, and presentation changed.

Tests pin the shorter definitions, the four-concept ceiling, the retained name, count-led details, the single hero chip, and the guardrails.