### PR TITLE
bullpen: lift coverage safety floor on substitute bridge capacity

### DIFF
--- a/docs/COVERAGE_SAFETY_RECONCILIATION.md
+++ b/docs/COVERAGE_SAFETY_RECONCILIATION.md
@@ -1,0 +1,123 @@
+# Coverage Safety Reconciliation
+
+Targeted reconciliation of the read three review passes identified as answering
+a different question than users hear: **Coverage Safety**. The read was
+internally consistent but coverage-construction-led — a bullpen whose designated
+long man was degraded fell to the **Limited** floor even when several usable
+Bridge Arms could chain the innings. Live validation produced exactly this
+disagreement on three clubs (Brewers, Mets, Marlins) while agreeing everywhere
+construction and tonight-flexibility coincided. This branch adds a single
+substitute-coverage guardrail so the floor label is reserved for genuine innings
+emergencies. One read changed; the public labels are unchanged.
+
+## What Coverage Safety should answer
+
+> Can this bullpen absorb unexpected innings tonight?
+
+Designated Coverage Arms remain the most valuable coverage asset and the only
+path to Strong or Stable. But a pen with usable Bridge Arms behind a degraded
+long man is not in an innings emergency — it has substitute capacity, and the
+read should say so without overstating it.
+
+## Audit — prior behavior
+
+Tier gates (unchanged by this branch except the floor):
+
+- Strong — `≥2` Coverage Arms, `≥2` clean, none Rest-Restricted/Unavailable.
+- Stable — `≥2` Coverage Arms, `≥2` available (clean+watch), none Unavailable.
+- Thin — `≥1` Coverage Arm with `≥1` available.
+- Limited — otherwise, including every "no available designated coverage" case
+  regardless of the rest of the pen.
+
+League behavior (30-club construction archetypes × day-of states, via the
+impact-review harness): with one long man degraded, **24 of 30 clubs fell to
+Limited** — the red-toned floor — purely on that single arm's status. "Stable"
+was structurally unreachable at a rested baseline (0 of 30).
+
+## Logic change
+
+A single guardrail on the floor tier:
+
+- When the read would otherwise classify **Limited** and meaningful substitute
+  capacity exists — **at least one clean Bridge Arm, or two Bridge Arms on
+  watch** (a watched arm is half-usable, matching the established
+  read-usability semantics) — the read is **Thin** instead, with an explanation:
+  substitute capacity can chain emergency innings; it is not designated length.
+- The lift is one step only. Substitute capacity can never produce Stable or
+  Strong. Strong/Stable/Thin gates are untouched, so designated Coverage Arms
+  remain the only source of every tier above the floor.
+- Depth Arms earn nothing (no depth-credit expansion). Trust Arms earn nothing
+  (a clean closer adds no multi-inning coverage).
+- The sparse-data Limited Read gate is untouched and is never promoted.
+
+## Before vs after
+
+Labels from the live engine.
+
+| Bullpen | Before | After | Why |
+| --- | --- | --- | --- |
+| Mets-style — long man down, 4 clean Bridge Arms | Limited | **Thin** | Substitute capacity exists; not an emergency. |
+| Marlins-style — both long men down, 2 clean Bridge Arms | Limited | **Thin** | Same, with thinner margin honestly kept at Thin. |
+| Brewers-style — long man on watch, 3 clean Bridge Arms | Thin | Thin | Unchanged — a watched long man already reads Thin. |
+| Rockies archetype (Weak A) — 1 watched bridge only | Limited | Limited | One watched bridge is below the substitute bar. |
+| Athletics archetype (Weak B) — bridge Rest-Restricted | Limited | Limited | No usable substitute; clean depth earns nothing. |
+| Coverage-rich (Rays-style, 2-3 clean long men) | Strong | Strong | Untouched. |
+| Sparse data | Limited Read | Limited Read | Untouched gate. |
+
+League impact (same 30-club × 3-state harness): every change is
+**Limited → Thin**. Strong counts identical (6 rested / 1 watched / 0 down);
+Stable counts identical (0 / 5 / 1). At the "long man down" state the floor
+empties (24 → 0 Limited) into Thin — the precise failure mode the validation
+flagged, and nothing else moves.
+
+Two observation-harness profiles change with the rule, both because a clean
+Bridge Arm stands behind zero available designated coverage: Interesting A
+(trust-rich, depth-thin) and Interesting B (depth-rich, trust gassed) now read
+Thin rather than Limited. Weak A and Weak B remain Limited.
+
+## Validation scenarios
+
+- **A — no Coverage Arms, no substitute capacity:** Limited. ✓
+- **B — Coverage Arm down, meaningful substitutes:** Thin, explanation names the
+  bridge fallback. ✓
+- **C — Coverage Arm down, five clean bridges:** Thin, never Stable. ✓
+- **D — coverage-rich pen:** Strong, unchanged. ✓
+- **E — weak pen, no usable substitutes:** Limited, unchanged. ✓
+- **F/G — Mets-style and Marlins-style:** Limited → Thin. ✓
+- **H/I — Rockies-style and Athletics-style:** unchanged. ✓
+- Guardrail never fires when a designated Coverage Arm is available. ✓
+- Two watched bridges clear the bar; one does not. ✓
+
+## Explainability
+
+The read carries `cleanBridgeArms`, `watchBridgeArms`, and a
+`substituteCoverageApplied` flag in `supportingCounts`. A lifted read states
+plainly that Bridge Arms are covering emergency innings and that this is
+substitute capacity, not designated length; the bullpen-shape strip appends the
+same caveat. No score, weight value, or band is exposed.
+
+## Scope and constraints
+
+- Changed `coverageSafety` in `frontend/src/utils/teamBullpenScoring.js` and the
+  coverage line of `shortShapeExplanation` in
+  `frontend/src/components/bullpen/board/teamBullpenStoryView.js` (so a lifted
+  read explains itself).
+- Trust Arm Availability, Clean Options, Bullpen Pressure, and Depth Safety are
+  untouched (verified by their existing tests).
+- No backend, schema, sync, availability/fatigue engine, or page-structure
+  changes. Public labels and concept vocabulary preserved.
+- The broader flexibility models from the impact review (always-on bridge
+  credit, multi-inning capability weighting, depth fallback credit) are
+  intentionally **not** implemented. Capability-aware credit remains gated on a
+  per-arm multi-inning signal that does not exist yet.
+
+## Recommendation — was Coverage Safety flawed, or misread?
+
+**Misread, by design.** The read faithfully measured designated-long-man
+availability, but every surface around it (a strip titled "Today's Bullpen
+Shape," tonight-state sibling reads, game-state vocabulary) promised a day-of
+answer, so the Limited floor read as an innings emergency it did not mean. The
+guardrail reserves the floor for pens that genuinely have no usable length —
+designated or substitute — which is the only claim a baseball reader was ever
+going to take from it. Re-validate against live slates before any further
+flexibility evolution.

--- a/frontend/src/components/bullpen/board/teamBullpenStoryView.js
+++ b/frontend/src/components/bullpen/board/teamBullpenStoryView.js
@@ -222,12 +222,17 @@ function shortShapeExplanation(read) {
       break
     case 'coverageSafety':
       if (hasCounts(counts.availableCoverageArms, counts.coverageArms)) {
-        return `Coverage Arms: ${compactReadCounts([
+        const base = `Coverage Arms: ${compactReadCounts([
           { count: counts.cleanCoverageArms, label: 'Clean Option' },
           { count: counts.watchCoverageArms, label: 'Watch Arm' },
           { count: counts.restRestrictedCoverageArms, label: 'Rest-Restricted' },
           { count: counts.unavailableCoverageArms, label: 'Unavailable' },
         ], 'no Clean Options or Watch Arms.')}`
+        // A floor-lifted read must explain itself: the Thin label came from
+        // Bridge Arms covering emergency innings, not from designated length.
+        return counts.substituteCoverageApplied
+          ? `${base} Bridge Arms cover emergency innings.`
+          : base
       }
       break
     case 'depthSafety':

--- a/frontend/src/utils/teamBullpenScoring.js
+++ b/frontend/src/utils/teamBullpenScoring.js
@@ -428,6 +428,20 @@ function coverageSafety(summary) {
   const unavailableCoverageArms = coverageReads[READ_LABELS.unavailable]
   const limitedReadCoverageArms = coverageReads[READ_LABELS.limited]
   const availableCoverageArms = cleanCoverageArms + watchCoverageArms
+
+  // Substitute-coverage guardrail. Coverage Safety stays coverage-led: only
+  // designated Coverage Arms can earn Strong/Stable/Thin through the gates
+  // below. But a bullpen whose designated length is degraded or absent is not
+  // automatically in an innings emergency when usable Bridge Arms can chain
+  // emergency innings behind it. Meaningful substitute capacity is at least
+  // one clean Bridge Arm, or two on watch (a watched arm is half-usable, per
+  // the read-usability semantics). It lifts the floor only — Limited becomes
+  // Thin — and never raises any other tier, so designated Coverage Arms remain
+  // the only path to Strong or Stable and depth volume still earns nothing.
+  const cleanBridgeArms = summary.roleReadCounts.bridge[READ_LABELS.clean]
+  const watchBridgeArms = summary.roleReadCounts.bridge[READ_LABELS.watch]
+  const hasSubstituteCoverage = cleanBridgeArms >= 1 || watchBridgeArms >= 2
+
   const supportingCounts = {
     coverageArms,
     availableCoverageArms,
@@ -436,6 +450,9 @@ function coverageSafety(summary) {
     restRestrictedCoverageArms,
     unavailableCoverageArms,
     limitedReadCoverageArms,
+    cleanBridgeArms,
+    watchBridgeArms,
+    substituteCoverageApplied: false,
     roleKnownCount: summary.dataQuality.roleKnownCount,
     totalBullpenArms: summary.totalBullpenArms,
   }
@@ -457,6 +474,19 @@ function coverageSafety(summary) {
   }
   if (coverageArms >= 1 && availableCoverageArms >= 1) {
     return read('coverageSafety', 'Thin Coverage Safety', explanation, supportingCounts)
+  }
+  if (hasSubstituteCoverage) {
+    const bridgeFallback = [
+      cleanBridgeArms > 0 ? `${cleanBridgeArms} clean Bridge Arm${cleanBridgeArms === 1 ? '' : 's'}` : null,
+      watchBridgeArms > 0 ? `${watchBridgeArms} Bridge Arm${watchBridgeArms === 1 ? '' : 's'} on watch` : null,
+    ].filter(Boolean).join(' and ')
+    const liftedExplanation = `${explanation} No designated Coverage Arm is available, but ${bridgeFallback} can chain emergency innings, so coverage reads Thin rather than Limited — substitute capacity, not designated length.`
+    return read(
+      'coverageSafety',
+      'Thin Coverage Safety',
+      liftedExplanation,
+      { ...supportingCounts, substituteCoverageApplied: true },
+    )
   }
   return read('coverageSafety', 'Limited Coverage Safety', explanation, supportingCounts)
 }

--- a/frontend/tests/teamBullpenScoring.test.mjs
+++ b/frontend/tests/teamBullpenScoring.test.mjs
@@ -187,7 +187,7 @@ test('strong coverage safety scenario requires clean available Coverage Arms', (
 test('limited coverage safety scenario reflects unavailable coverage options', () => {
   const result = shape([
     pitcher('Trust Arm', 'Clean Option'),
-    pitcher('Bridge Arm', 'Clean Option'),
+    pitcher('Bridge Arm', 'Rest-Restricted'),
     pitcher('Coverage Arm', 'Rest-Restricted'),
     pitcher('Coverage Arm', 'Unavailable'),
     pitcher('Depth Arm', 'Clean Option'),
@@ -195,6 +195,173 @@ test('limited coverage safety scenario reflects unavailable coverage options', (
   ])
   assert.equal(result.coverageSafety.label, 'Limited Coverage Safety')
   assert.equal(result.coverageSafety.supportingCounts.availableCoverageArms, 0)
+  assert.equal(result.coverageSafety.supportingCounts.substituteCoverageApplied, false)
+})
+
+// ── Coverage Safety substitute-coverage guardrail (Limited → Thin only) ─────
+
+test('no coverage arms and no substitute capacity stays Limited', () => {
+  // Case A: one watched bridge is below the substitute bar; clean depth earns nothing.
+  const result = shape([
+    pitcher('Trust Arm', 'Clean Option'),
+    pitcher('Bridge Arm', 'Rest-Restricted'),
+    pitcher('Bridge Arm', 'Watch Arm'),
+    pitcher('Depth Arm', 'Clean Option'),
+    pitcher('Depth Arm', 'Clean Option'),
+    pitcher('Depth Arm', 'Clean Option'),
+    pitcher('Depth Arm', 'Clean Option'),
+  ])
+  assert.equal(result.coverageSafety.label, 'Limited Coverage Safety')
+  assert.equal(result.coverageSafety.supportingCounts.substituteCoverageApplied, false)
+})
+
+test('coverage arm down with meaningful substitute capacity lifts Limited to Thin', () => {
+  // Case B: the lift names the bridge fallback in its explanation.
+  const result = shape([
+    pitcher('Trust Arm', 'Clean Option'),
+    pitcher('Bridge Arm', 'Clean Option'),
+    pitcher('Bridge Arm', 'Clean Option'),
+    pitcher('Coverage Arm', 'Rest-Restricted'),
+    pitcher('Depth Arm', 'Clean Option'),
+    pitcher('Depth Arm', 'Clean Option'),
+  ])
+  assert.equal(result.coverageSafety.label, 'Thin Coverage Safety')
+  assert.equal(result.coverageSafety.supportingCounts.substituteCoverageApplied, true)
+  assert.ok(result.coverageSafety.explanation.includes('Bridge Arm'))
+  assert.ok(result.coverageSafety.explanation.includes('Thin rather than Limited'))
+})
+
+test('strong substitute capacity can never exceed Thin', () => {
+  // Case C: five clean bridges lift the floor one step only — never Stable.
+  const result = shape([
+    pitcher('Trust Arm', 'Clean Option'),
+    pitcher('Bridge Arm', 'Clean Option'),
+    pitcher('Bridge Arm', 'Clean Option'),
+    pitcher('Bridge Arm', 'Clean Option'),
+    pitcher('Bridge Arm', 'Clean Option'),
+    pitcher('Bridge Arm', 'Clean Option'),
+    pitcher('Coverage Arm', 'Unavailable'),
+    pitcher('Depth Arm', 'Clean Option'),
+  ])
+  assert.equal(result.coverageSafety.label, 'Thin Coverage Safety')
+  assert.equal(result.coverageSafety.supportingCounts.substituteCoverageApplied, true)
+})
+
+test('coverage-rich bullpen is unchanged by the substitute guardrail', () => {
+  // Case D: Strong still requires clean designated Coverage Arms and stays Strong.
+  const result = shape([
+    pitcher('Trust Arm', 'Clean Option'),
+    pitcher('Bridge Arm', 'Clean Option'),
+    pitcher('Bridge Arm', 'Clean Option'),
+    pitcher('Coverage Arm', 'Clean Option'),
+    pitcher('Coverage Arm', 'Clean Option'),
+    pitcher('Depth Arm', 'Clean Option'),
+  ])
+  assert.equal(result.coverageSafety.label, 'Strong Coverage Safety')
+  assert.equal(result.coverageSafety.supportingCounts.substituteCoverageApplied, false)
+})
+
+test('weak bullpen with no usable substitutes stays Limited', () => {
+  // Case E: degraded everywhere — depth bodies alone never lift the floor.
+  const result = shape([
+    pitcher('Trust Arm', 'Rest-Restricted'),
+    pitcher('Bridge Arm', 'Unavailable'),
+    pitcher('Coverage Arm', 'Rest-Restricted'),
+    pitcher('Depth Arm', 'Clean Option'),
+    pitcher('Depth Arm', 'Clean Option'),
+    pitcher('Depth Arm', 'Clean Option'),
+    pitcher('Depth Arm', 'Clean Option'),
+  ])
+  assert.equal(result.coverageSafety.label, 'Limited Coverage Safety')
+  assert.equal(result.coverageSafety.supportingCounts.substituteCoverageApplied, false)
+})
+
+test('mets-style scenario lifts Limited to Thin on bridge capacity', () => {
+  // Case F: long man down, four clean bridges, a clean trust arm.
+  const result = shape([
+    pitcher('Trust Arm', 'Clean Option'),
+    pitcher('Bridge Arm', 'Clean Option'),
+    pitcher('Bridge Arm', 'Clean Option'),
+    pitcher('Bridge Arm', 'Clean Option'),
+    pitcher('Bridge Arm', 'Clean Option'),
+    pitcher('Coverage Arm', 'Rest-Restricted'),
+    pitcher('Depth Arm', 'Clean Option'),
+    pitcher('Depth Arm', 'Clean Option'),
+  ])
+  assert.equal(result.coverageSafety.label, 'Thin Coverage Safety')
+  assert.equal(result.coverageSafety.supportingCounts.substituteCoverageApplied, true)
+})
+
+test('marlins-style scenario lifts Limited to Thin on bridge capacity', () => {
+  // Case G: both long men down, two clean bridges, watch-list depth.
+  const result = shape([
+    pitcher('Trust Arm', 'Clean Option'),
+    pitcher('Bridge Arm', 'Clean Option'),
+    pitcher('Bridge Arm', 'Clean Option'),
+    pitcher('Coverage Arm', 'Rest-Restricted'),
+    pitcher('Coverage Arm', 'Unavailable'),
+    pitcher('Depth Arm', 'Watch Arm'),
+    pitcher('Depth Arm', 'Watch Arm'),
+  ])
+  assert.equal(result.coverageSafety.label, 'Thin Coverage Safety')
+  assert.equal(result.coverageSafety.supportingCounts.substituteCoverageApplied, true)
+})
+
+test('rockies-style rested construction is unchanged', () => {
+  // Case H: a clean long man already reads Thin through the normal gate.
+  const result = shape([
+    pitcher('Trust Arm', 'Clean Option'),
+    pitcher('Bridge Arm', 'Clean Option'),
+    pitcher('Coverage Arm', 'Clean Option'),
+    pitcher('Depth Arm', 'Clean Option'),
+    pitcher('Depth Arm', 'Clean Option'),
+    pitcher('Depth Arm', 'Clean Option'),
+    pitcher('Depth Arm', 'Clean Option'),
+    pitcher('Depth Arm', 'Clean Option'),
+  ])
+  assert.equal(result.coverageSafety.label, 'Thin Coverage Safety')
+  assert.equal(result.coverageSafety.supportingCounts.substituteCoverageApplied, false)
+})
+
+test('athletics-style archetype with degraded pen stays Limited', () => {
+  // Case I: mirrors the observation-harness Weak B profile — no usable bridge.
+  const result = shape([
+    pitcher('Trust Arm', 'Unavailable'),
+    pitcher('Bridge Arm', 'Rest-Restricted'),
+    pitcher('Depth Arm', 'Clean Option'),
+    pitcher('Depth Arm', 'Clean Option'),
+    pitcher('Depth Arm', 'Clean Option'),
+    pitcher('Depth Arm', 'Clean Option'),
+    pitcher('Depth Arm', 'Unavailable'),
+  ])
+  assert.equal(result.coverageSafety.label, 'Limited Coverage Safety')
+  assert.equal(result.coverageSafety.supportingCounts.substituteCoverageApplied, false)
+})
+
+test('substitute guardrail never fires when a designated coverage arm is available', () => {
+  const result = shape([
+    pitcher('Trust Arm', 'Clean Option'),
+    pitcher('Bridge Arm', 'Clean Option'),
+    pitcher('Bridge Arm', 'Clean Option'),
+    pitcher('Coverage Arm', 'Watch Arm'),
+    pitcher('Depth Arm', 'Clean Option'),
+    pitcher('Depth Arm', 'Clean Option'),
+  ])
+  assert.equal(result.coverageSafety.label, 'Thin Coverage Safety')
+  assert.equal(result.coverageSafety.supportingCounts.substituteCoverageApplied, false)
+})
+
+test('two watched bridges clear the substitute bar when no coverage exists', () => {
+  const result = shape([
+    pitcher('Trust Arm', 'Clean Option'),
+    pitcher('Bridge Arm', 'Watch Arm'),
+    pitcher('Bridge Arm', 'Watch Arm'),
+    pitcher('Coverage Arm', 'Unavailable'),
+    pitcher('Depth Arm', 'Clean Option'),
+    pitcher('Depth Arm', 'Clean Option'),
+  ])
+  assert.equal(result.coverageSafety.label, 'Thin Coverage Safety')
+  assert.equal(result.coverageSafety.supportingCounts.substituteCoverageApplied, true)
 })
 
 test('strong depth safety scenario requires enough available fallback depth', () => {


### PR DESCRIPTION
Coverage Safety stays coverage-led: designated Coverage Arms remain the only path to Strong, Stable, and gate-earned Thin. But a pen whose designated length is degraded or absent is not automatically in an innings emergency when usable Bridge Arms can chain the innings behind it. When the read would land on the Limited floor and meaningful substitute capacity exists (one clean Bridge Arm, or two on watch), the read now lifts one step to Thin and says why - substitute capacity, not designated length.

The lift is floor-only by design: no Stable or Strong inflation, no depth or trust credit, sparse-data Limited Read untouched. League check across 30 construction archetypes x 3 day-of states: every movement is Limited to Thin; Strong and Stable counts are identical before and after. Mets/Marlins-style validation states improve for league-generic reasons; Rockies/Athletics-class pens with no usable substitutes stay Limited.