### PR TITLE
language: translate bullpen signals into baseball voice across story surfaces

### DIFF
--- a/docs/product/LANGUAGE_ENGINE_V1.md
+++ b/docs/product/LANGUAGE_ENGINE_V1.md
@@ -1,0 +1,323 @@
+# BaseballOS Language Engine V1
+
+> Companion to [STORYTELLING_SURFACES.md](STORYTELLING_SURFACES.md).
+> Central problem: **the intelligence platform works, but BaseballOS stories
+> sound like BaseballOS talking about BaseballOS.** This document is the audit
+> of that language, the specification of the translation layer that fixes it,
+> and the record of what V1 changed.
+
+The test: when a baseball person reads the homepage, they should think
+*"yeah, that's how we'd talk about it"* — not *"that's how a model would talk
+about it."*
+
+---
+
+## 1. Architecture
+
+The ontology is untouched. The fix is a translation layer between the
+internal reads and the words on the page.
+
+```
+Internal Layer                       Language Layer                User-Facing Story
+─────────────────                    ──────────────                ─────────────────
+Recovery Window        = Wide    →   "fresh pen",              →  "The White Sox bring one of
+Workload Concentration = High    →   "leaning on the               the freshest bullpens
+Bullpen Pressure       = High    →    same arms",                  into today"
+Clean Options          = Thin    →   "room to breathe",
+(bullpenConcepts.js,                 (bullpenLanguage.js +         (homeIntelligenceView.js,
+ teamBullpenScoring.js,               this spec)                    storiesFeedView.js,
+ landscape counts)                                                  teamBullpenStoryView.js)
+```
+
+**Where each layer is allowed to speak:**
+
+| Slot | Voice | Example |
+| --- | --- | --- |
+| Headlines, prose, bullets, "Why It Matters" | Baseball | "The Mets keep handing the ball to the same relievers" |
+| Read chips, stat labels, fact labels, the Today's Bullpen Shape strip | Ontology (evidence) | `High Bullpen Pressure`, `Clean Options: 6 of 8` |
+| Tooltips / explanations behind a chip | Counts | "3 of 8 arms need rest; 2 more on watch." |
+
+Two rules govern every sentence the platform writes:
+
+1. **Concepts never act.** "Workload Concentration stacks up quietly" is model
+   voice — a concept doing a verb. "Heavy use on the same few arms stacks up
+   quietly" is baseball. Concepts appear as *labels on evidence*, not as the
+   subject of prose.
+2. **No system verbs in prose.** Arms never "register as" anything, never
+   "carry a signal," and are never "workload-restricted." They come in fresh,
+   need a day, sit on the watch list, get the call.
+
+Code home of the layer: `frontend/src/utils/bullpenLanguage.js`
+(`SIGNAL_HEADLINES` — one headline pool per signal, keyed by the slot that
+uses it, so a signal sounds like itself everywhere without repeating one
+sentence verbatim).
+
+---
+
+## 2. Language Audit
+
+Every phrase that read as mechanical, model-driven, internal, or unnatural,
+grouped by surface. ❌ = replaced in V1, ⏳ = left for a later pass (see §6),
+✅ = kept deliberately.
+
+### 2.1 Homepage (`homeIntelligenceView.js`, `Home.jsx`)
+
+| Phrase (before) | Problem | Status |
+| --- | --- | --- |
+| "The Brewers **have baseball's most constrained bullpen** today" | "Constrained" is engine-state vocabulary in a flagship headline | ❌ |
+| "The Blue Jays have baseball's **most concentrated bullpen workload** today" | A measurement, not a sentence anyone would say | ❌ |
+| "The Nationals bring baseball's **widest Recovery Window** into today" | Ontology term as headline subject | ❌ |
+| "relievers come in **with a limited Recovery Window**" | Concept used as a substance arms carry | ❌ |
+| "relievers **register as Clean Options**" | System verb; arms don't "register" | ❌ |
+| "**the cleanest availability context** in baseball" | Nobody in a clubhouse says "availability context" | ❌ |
+| "**High Bullpen Pressure** narrows the late innings" (Why It Matters) | Concept as the actor of the sentence | ❌ |
+| "**Workload Concentration** stacks up quietly" (Why It Matters) | Concept as the actor of the sentence | ❌ |
+| Hero count chips labeled `Clean Options` / `Workload Concentration` / `Recovery Window` | Concept names pasted onto raw counts — and mislabeled (the "Recovery Window" chip counted *restricted* arms) | ❌ |
+| "giving Stories another **Bullpen Pressure thread to unpack**" | Product talking about its own UI, concept as object | ❌ |
+| "arms are **carrying Workload Concentration**" | The single worst offender — a concept as cargo | ❌ |
+| "Recovery Window **is the counterweight to today's pressure**" | Concept-on-concept algebra | ❌ |
+| "The watch list is not all at the top of the page" | Refers to the page layout, not baseball | ❌ |
+| "Clean Options **still frame the league context**" | Concept as actor + "context" | ❌ |
+| "so Workload Concentration **is not limited to the flagship club**" | Concept as a spreading condition | ❌ |
+| League card: "More arms have a **limited Recovery Window** here than anywhere else" | Concept in prose slot | ❌ |
+| League card title "Workload Concentration" over a team abbreviation | Reads as a grade stamped on a club | ❌ |
+| "Depth Safety **is carrying more of the load** than usual today" | Concept as actor | ❌ |
+| "managing **Recovery Window** as carefully as they manage innings" | Concept where "rest" belongs | ❌ |
+| "The league **availability picture** moved overnight" | Internal noun phrase | ❌ |
+| "Why It Matters", "What BaseballOS Sees Today", "Three Things To Watch" | Strong editorial framing | ✅ kept |
+| "Built from completed games through Jun 5" (masthead) | Honest, plain | ✅ kept |
+
+### 2.2 Stories Feed (`storiesFeedView.js`, `Stories.jsx`, story candidates)
+
+| Phrase (before) | Problem | Status |
+| --- | --- | --- |
+| "Nobody brings a **wider Recovery Window** into today than the Nationals" | Ontology as headline subject | ❌ |
+| "**Clean Options are stacked a little deeper** for the Giants" | Concept-led headline | ❌ |
+| "**Coverage Safety is still part of today's league picture**" | Pure model voice, concept as subject | ❌ |
+| "no standout **Workload Concentration signal** today" | "Signal" is engine vocabulary | ❌ |
+| "**Depth Safety** is part of this pen's story" | Concept as character in the story | ❌ |
+| "**Stories is watching** where **Bullpen Pressure** is obvious" | Product self-reference + concept as subject | ❌ |
+| "it **gives the feed context** on both sides of the bullpen ledger" | Product talking about its feed | ❌ |
+| "the heaviest **concentration of recent bullpen work**" | Measurement language in a body line | ❌ |
+| Filter: "bullpens **carrying elevated workload strain**" | Clinical | ❌ |
+| Filter: "bullpens entering the day with **cleaner availability**" | System noun | ❌ |
+| Filter: "**workload patterns** are worth monitoring" | Model voice | ❌ |
+| "N **active bullpen observations** across team, trend, and league **lanes**" | Internal taxonomy shown to the reader | ❌ |
+| "The Blue Jays box score looks calm. The bullpen does not." | — | ✅ kept (the voice target) |
+| "The Mets keep handing the ball to the same relievers" | — | ✅ kept |
+| "A thin late-inning margin is forming for the Mets" | — | ✅ kept |
+| "Observations, not predictions." (header chip) | Honest framing | ✅ kept |
+
+### 2.3 Team Intelligence Panels (`teamBullpenStoryView.js`, `TeamBullpenStoryPanel.jsx`)
+
+| Phrase (before) | Problem | Status |
+| --- | --- | --- |
+| Label chip "**Constrained Pen**" | Engine health-state word | ❌ → "Short-Handed Pen" |
+| "The X bring one of the **cleanest availability pictures** into today" | System noun phrase in the headline | ❌ |
+| "Rest **is doing a lot of the work in this bullpen's story** today" | Story talking about itself | ❌ |
+| "3 arms are **workload-restricted** after their recent use" | Hyphenated system status as a verb | ❌ |
+| "nobody is **workload-restricted** yet" | Same | ❌ |
+| "no extreme **bullpen signal** today" | Engine vocabulary | ❌ |
+| "unavailable for roster or **data reasons**" | Half-system phrasing | ❌ |
+| "How the **Monitor group's fatigue reads** compare with the rested arms" | Board taxonomy + engine noun in a watch bullet | ❌ |
+| "**The work is concentrated** in a small group, and **that concentration is the story**" | Measurement restated as drama | ❌ |
+| Section header "**What The Workload Shape Says**" | "Workload shape" is internal geometry | ❌ → "What The Recent Work Says" |
+| Framing "Context from current workload and availability **signals**" | Engine noun | ❌ |
+| "Why BaseballOS Is Watching This Pen" | Brand voice, works | ✅ kept |
+| "Today's Bullpen Shape" strip with `High Bullpen Pressure` / `Thin Clean Options` etc. | This **is** the evidence layer | ✅ kept |
+| "Not enough fresh data for a strong read on the X today" | Honest limitation, plain words | ✅ kept |
+
+### 2.4 Bullpen Pages (board, availability surfaces — audit only, see §6)
+
+| Phrase | Problem | Status |
+| --- | --- | --- |
+| "Workload **signals are inside normal public-data use ranges**" (availability tone line) | Pure engine voice | ⏳ |
+| "Public workload **signals show meaningful recent-use risk**" | Same | ⏳ |
+| "No arms are **workload-restricted** tonight" (board empty state) | System status as adjective | ⏳ |
+| "**Workload-only signal before roster-status adjustment**" (pitcher summary) | Pipeline language on a player card | ⏳ |
+| "Roster and workload **signals behind this final status**" | Same | ⏳ |
+| "Chicago Cubs **appears to have the most constrained bullpen** tonight" (dashboard storyline) | "Constrained" again; hedge verb | ⏳ |
+| Governed observation cards (trust/dashboard): "Availability inventory is constrained." | Intentionally system-voiced on governance surfaces; translated before reaching story surfaces | ✅ by design |
+
+---
+
+## 3. Translation Layer Specification
+
+One entry per internal signal. **Internal vocabulary never changes** — these
+are presentation pools. "In code" marks the variants V1 shipped
+(`SIGNAL_HEADLINES` plus surface copy); the rest are approved alternates for
+future rotation. `{Team}` = full club name.
+
+### Recovery Window — Wide / deep Clean Options
+
+*The pen is rested; most arms come in without restriction.*
+
+| Slot | Headline |
+| --- | --- |
+| In code — hero | "The {Team} bring baseball's freshest bullpen into today" |
+| In code — feed | "Nobody brings a fresher bullpen into today than the {Team}" |
+| In code — feed depth | "The {Team} have fresh arms to spare today" |
+| In code — team panel | "The {Team} bring one of the freshest bullpens into today" |
+| Alternate | "The {Team} have room to breathe tonight" |
+| Alternate | "Plenty of coverage tonight for the {Team}" |
+| Alternate | "A full pen and a free hand for the {Team}" |
+
+Inline phrases: *fresh pen · room to breathe · arms to spare · rested and
+ready · the kind of depth that lets the late innings breathe.*
+
+### Recovery Window — Narrow/Limited / High Bullpen Pressure
+
+*The pen is short on rested arms after recent workload.*
+
+| Slot | Headline |
+| --- | --- |
+| In code — hero | "The {Team} bullpen is stretched thinner than any in baseball today" |
+| In code — feed | "A thin late-inning margin is forming for the {Team}" |
+| In code — team panel | "The {Team} enter today with a thin late-inning margin" |
+| Alternate | "The {Team} are short in the pen tonight" |
+| Alternate | "Not many fresh arms left for the {Team}" |
+| Alternate | "The late innings are getting tight for the {Team}" |
+
+Inline phrases: *stretched thin · coming in short · needing rest / needing a
+day · less room in the late innings · less margin than most.*
+
+### Workload Concentration (and the reserved Leverage Concentration / Workload Accumulation)
+
+*Recent work is clustered on a few arms instead of spread around.*
+
+| Slot | Headline |
+| --- | --- |
+| In code — hero | "The {Team} are leaning on the same arms more than anyone in baseball today" |
+| In code — feed | "The {Team} keep handing the ball to the same relievers" |
+| In code — feed hidden | "The {Team} box score looks calm. The bullpen does not." |
+| In code — team panel | "The {Team} look calm on the surface — the workload underneath is worth watching" |
+| Alternate | "The {Team} keep leaning on the same arms" |
+| Alternate | "Heavy usage is falling on a small group" |
+| Alternate | "Late innings are running through the same relievers" |
+| Alternate | "The same names every night for the {Team}" |
+
+Inline phrases: *leaning on the same arms · the same arms keep getting the
+call · heavy work falling on a small group · carrying the heavy lifting ·
+stacks up quietly.*
+
+### Clean Options — Thin/Very Thin
+
+*Few arms enter without a workload flag.*
+
+| Slot | Headline |
+| --- | --- |
+| In code — observation card | "Fresh arms are harder to find in a few pens today" |
+| In code — observation card | "A few late-inning margins are getting thin" |
+| Alternate | "Fewer fresh arms than the {Team} would like" |
+| Alternate | "One long night from real trouble" |
+
+Inline phrases: *fewer fresh arms than they would like · almost nobody fresh ·
+the margin for a long night is thin.*
+
+### Bullpen Dependency (reserved — concept live in ontology, no surface yet)
+
+| Slot | Headline |
+| --- | --- |
+| Reserved | "This pen relies on its core arms" |
+| Reserved | "Few relievers carry most of the load" |
+| Reserved | "Take away two arms and this pen changes shape" |
+
+### Coverage Safety / Depth Safety
+
+*How much length and fallback the pen has behind its primary arms.*
+
+| Slot | Headline |
+| --- | --- |
+| In code — feed (league) | "Most of the league still has fresh arms to call on" |
+| Reserved | "Somebody has to cover the middle innings" |
+| Reserved | "The back of this pen is doing real work" |
+
+Inline phrases: *the back of the bullpen is carrying more of the load · fresh
+depth beyond the arms the club trusts most.* Labels (`Strong Coverage
+Safety`, `Thin Depth Safety`…) stay on the shape strip as evidence.
+
+### Bullpen State / Bullpen Identity / Bullpen Resilience (reserved)
+
+No live surfaces yet. When they arrive: State → "where this pen is today";
+Identity → "how this pen is built / how this club uses its pen"; Resilience →
+"how fast this pen bounces back". Same two rules apply.
+
+### Limited Read (trust tier)
+
+Honesty beats fluency — limitation copy stays plain and is **not** dressed
+up: "Not enough fresh data for a strong read on the {Team} today." The label
+`Limited Read` keeps its name everywhere.
+
+---
+
+## 4. Before / After (V1 as shipped)
+
+| Surface | Before | After |
+| --- | --- | --- |
+| Hero (stress) | "The Brewers have baseball's most constrained bullpen today" | "The Brewers bullpen is stretched thinner than any in baseball today" |
+| Hero (concentration) | "The Blue Jays have baseball's most concentrated bullpen workload today" | "The Blue Jays are leaning on the same arms more than anyone in baseball today" |
+| Hero (rest) | "The Nationals bring baseball's widest Recovery Window into today" | "The Nationals bring baseball's freshest bullpen into today" |
+| Hero observation | "…relievers register as Clean Options — the cleanest availability context in baseball today." | "…relievers come in rested and ready to go — no pen in baseball has more fresh arms to call on today." |
+| Why It Matters | "High Bullpen Pressure narrows the late innings." | "A stretched pen narrows the late innings." |
+| Why It Matters | "Workload Concentration stacks up quietly." | "Heavy use on the same few arms stacks up quietly." |
+| Watch item | "The watch list is not all at the top of the page" | "Another club keeps going to the same arms" |
+| Watch item | "Recovery Window is the counterweight to today's pressure" | "At least one pen comes in with room to breathe" |
+| Watch item body | "…are carrying Workload Concentration, a quieter signal worth a second look." | "…have been carrying the heavy work lately — quiet so far, worth a second look." |
+| League context | "9 tracked arms have a limited Recovery Window… and 38 register as Clean Options." | "Around the league, 9 tracked arms need rest after recent work… and 38 come in fresh." |
+| League card | "More arms have a limited Recovery Window here than anywhere else in baseball." | "More arms need a day here than anywhere else in baseball." |
+| Story card | "Nobody brings a wider Recovery Window into today than the Nationals" | "Nobody brings a fresher bullpen into today than the Nationals" |
+| Story card | "Clean Options are stacked a little deeper for the Giants" | "The Giants have fresh arms to spare today" |
+| Story card | "Coverage Safety is still part of today's league picture" | "Most of the league still has fresh arms to call on" |
+| Story body | "…Stories is watching where Bullpen Pressure is obvious and where it is still quiet." | "…Some of that work is obvious, some is still quiet — and the quiet kind is usually where the next story starts." |
+| Feed filter | "Stories involving bullpens carrying elevated workload strain." | "Pens that have been worked hard and are short on rest." |
+| Team panel (rested) | "The White Sox bring one of the cleanest availability pictures into today" | "The White Sox bring one of the freshest bullpens into today" |
+| Team panel summary | "Rest is doing a lot of the work in this bullpen's story today." | "This pen has room to breathe today." |
+| Team panel bullet | "3 arms are workload-restricted after their recent use." | "3 arms have earned a rest day after the work they have carried." |
+| Team panel summary | "The work is concentrated in a small group, and that concentration is the story." | "The heavy work keeps falling on the same small group, and that is the story." |
+| Panel section | "What The Workload Shape Says" | "What The Recent Work Says" |
+| Panel label | "Constrained Pen" | "Short-Handed Pen" |
+| Panel headline (balanced) | "…come in steady — no extreme bullpen signal today" | "…come in steady — nothing tilting the pen either way today" |
+
+Ontology untouched and still on the page: the hero read chip
+(`High Bullpen Pressure` + count tooltip), feed card read tags
+(`Concentrated Workload`, `Wide Recovery Window`), League Context fact labels
+(`Bullpen Pressure` / `Workload Concentration` / `Clean Options`), the full
+Today's Bullpen Shape strip (`Trust Arm Availability`, `Clean Options`,
+`Bullpen Pressure`, `Coverage Safety`, `Depth Safety`), and every label tier
+in `teamBullpenScoring.js` and `bullpenConcepts.js`.
+
+---
+
+## 5. Enforcement
+
+- `tests/homeIntelligence.test.mjs`, `tests/storiesFeed.test.mjs`,
+  `tests/teamBullpenStoryPanel.test.mjs` pin the new copy and now also ban
+  the mechanical patterns in prose: `register as`, `workload-restricted`,
+  `availability context`, `availability picture`, `limited recovery window`,
+  `carrying workload concentration`.
+- Existing guardrails (no predictions, no rankings, no advice, no betting/
+  injury language, no raw governance vocabulary) all still hold.
+
+## 6. Remaining Areas That Still Feel Mechanical
+
+Out of V1 scope (V1 = homepage, stories, team intelligence). Next passes, in
+rough priority order:
+
+1. **Availability tone lines** (`availabilityView.js`, also surfaced on
+   pitcher cards and the board legend): "Workload signals are inside normal
+   public-data use ranges." → e.g. "Normal recent workload — nothing holding
+   this arm back."
+2. **Tonight's Bullpen Board empty states** (`tonightsBullpenBoardView.js`):
+   "No arms are workload-restricted tonight."
+3. **Pitcher availability summary** (`AvailabilitySummary.jsx`):
+   "Workload-only signal before roster-status adjustment." is pipeline
+   language on a player card.
+4. **Dashboard storylines** (`bullpenLandscapeView.js`): "appears to have the
+   most constrained bullpen tonight", "shows the highest concentration of
+   Monitor arms."
+5. **Comparison view** (`teamBullpenComparisonView.js`): carries little prose
+   of its own but inherits the availability badge/tone lines, so fixing (1)
+   fixes it.
+6. **Governed observation surfaces** (trust page, dashboard intelligence
+   panel): deliberately system-voiced today; decide whether deeper surfaces
+   ever adopt the language layer or stay raw as the audit trail.

--- a/frontend/src/components/bullpen/board/TeamBullpenStoryPanel.jsx
+++ b/frontend/src/components/bullpen/board/TeamBullpenStoryPanel.jsx
@@ -4,7 +4,7 @@ import { homeTone } from '../../home/homeIntelligenceView'
 
 // Today's Bullpen Story — a compact analyst note that sits between the
 // context strips and the availability board. It answers why BaseballOS is
-// watching this pen, what the workload shape says, and what to look at on
+// watching this pen, what the recent work says, and what to look at on
 // the board below. Additive context only; the board remains the detail.
 export default function TeamBullpenStoryPanel({ board }) {
   const story = getTeamBullpenStoryView(board)
@@ -41,7 +41,7 @@ export default function TeamBullpenStoryPanel({ board }) {
       <div className="mt-4 grid gap-4 sm:grid-cols-2">
         <div>
           <div className="font-mono text-[10px] uppercase tracking-widest text-chalk400">
-            What The Workload Shape Says
+            What The Recent Work Says
           </div>
           <ul className="mt-2 space-y-1.5">
             {story.workloadBullets.map((bullet, index) => (

--- a/frontend/src/components/bullpen/board/teamBullpenStoryView.js
+++ b/frontend/src/components/bullpen/board/teamBullpenStoryView.js
@@ -5,6 +5,7 @@
 // no recommendations, no new signals.
 
 import { getBullpenReads } from '../../../utils/bullpenConcepts'
+import { SIGNAL_HEADLINES } from '../../../utils/bullpenLanguage'
 import { getTeamBullpenShape } from '../../../utils/teamBullpenScoring'
 
 const STORY_TONES = {
@@ -16,7 +17,7 @@ const STORY_TONES = {
 }
 
 const STORY_LABELS = {
-  constrained: 'Constrained Pen',
+  constrained: 'Short-Handed Pen',
   watch: 'Watch-List Pen',
   rested: 'Rested Pen',
   balanced: 'Balanced Pen',
@@ -24,7 +25,7 @@ const STORY_LABELS = {
 }
 
 export const STORY_FRAMING_LINE =
-  'Context from current workload and availability signals — not a prediction.'
+  'Drawn from current workload and availability — a read on today, not a prediction.'
 
 const SHAPE_READ_ORDER = [
   { key: 'trustAvailability', concept: 'Trust Arm Availability' },
@@ -91,13 +92,13 @@ function workloadBullets(family, counts, confidence) {
     ? `${arms(ready)} of ${total} ${one(ready, 'comes', 'come')} in rested and ready.`
     : 'No arm in this pen comes in fully rested.')
   if (needRest > 0) {
-    bullets.push(`${arms(needRest)} ${one(needRest, 'is', 'are')} workload-restricted after ${one(needRest, 'its', 'their')} recent use.`)
+    bullets.push(`${arms(needRest)} ${one(needRest, 'has', 'have')} earned a rest day after the work ${one(needRest, 'it has', 'they have')} carried.`)
   }
   if (watch > 0) {
     bullets.push(`${arms(watch)} ${one(watch, 'carries', 'carry')} enough recent work to sit on the watch list.`)
   }
   if (out > 0) {
-    bullets.push(`${arms(out)} ${one(out, 'is', 'are')} unavailable for roster or data reasons rather than tonight's workload.`)
+    bullets.push(`${arms(out)} ${one(out, 'is', 'are')} out for roster reasons or missing data, not tonight's workload.`)
   }
   if (confidence === 'low') {
     bullets.push('The workload read is thinner than usual today — take the counts with some caution.')
@@ -122,7 +123,7 @@ function watchBullets(family, counts) {
     case 'watch':
       return [
         'Whether the watch-list arms are the same names night after night.',
-        'How the Monitor group’s fatigue reads compare with the rested arms.',
+        'How the busiest arms look next to the rested ones.',
         'Whether rest is starting to show up for the busiest arms.',
       ]
     case 'rested':
@@ -150,20 +151,20 @@ function storyHeadline(family, teamName, counts) {
   switch (family) {
     case 'constrained':
       return {
-        headline: `The ${teamName} enter today with a thin late-inning margin`,
+        headline: SIGNAL_HEADLINES.stretchedPen.team(teamName),
         summary: needRest > 0
           ? `${arms(needRest)} of ${total} ${one(needRest, 'comes', 'come')} in needing rest after recent work, and the clean options are thinner than they look. This bullpen has less margin than most today.`
           : `Only ${arms(ready)} of ${total} ${one(ready, 'comes', 'come')} in fully rested, and the clean options are thinner than they look. This bullpen has less margin than most today.`,
       }
     case 'watch':
       return {
-        headline: `The ${teamName} look calm on the surface — the workload underneath is worth watching`,
-        summary: `${arms(watch)} of ${total} ${one(watch, 'carries', 'carry')} enough recent work to land on the watch list${needRest === 0 ? ', even though nobody is workload-restricted yet' : ''}. The work is concentrated in a small group, and that concentration is the story.`,
+        headline: SIGNAL_HEADLINES.sameArms.team(teamName),
+        summary: `${arms(watch)} of ${total} ${one(watch, 'carries', 'carry')} enough recent work to land on the watch list${needRest === 0 ? ', even though nobody is down outright yet' : ''}. The heavy work keeps falling on the same small group, and that is the story.`,
       }
     case 'rested':
       return {
-        headline: `The ${teamName} bring one of the cleanest availability pictures into today`,
-        summary: `${arms(ready)} of ${total} ${one(ready, 'comes', 'come')} in rested and ready. Rest is doing a lot of the work in this bullpen's story today.`,
+        headline: SIGNAL_HEADLINES.freshPen.team(teamName),
+        summary: `${arms(ready)} of ${total} ${one(ready, 'comes', 'come')} in rested and ready. This pen has room to breathe today.`,
       }
     case 'data_limited':
       return {
@@ -172,7 +173,7 @@ function storyHeadline(family, teamName, counts) {
       }
     default:
       return {
-        headline: `The ${teamName} come in steady — no extreme bullpen signal today`,
+        headline: `The ${teamName} come in steady — nothing tilting the pen either way today`,
         summary: `A bit of everything: ${ready} ready, ${watch} on watch, ${needRest} needing rest. Nothing here pushes the late innings into a corner today.`,
       }
   }

--- a/frontend/src/components/home/homeIntelligenceView.js
+++ b/frontend/src/components/home/homeIntelligenceView.js
@@ -1,13 +1,16 @@
 import { fmtDataDate } from '../dashboard/syncStatusView'
 import { getReadsForLandscapeEntry } from '../../utils/bullpenConcepts'
+import { SIGNAL_HEADLINES } from '../../utils/bullpenLanguage'
 
 // The Morning Bullpen Report — view-model for the story-led homepage.
 //
 // Everything on the homepage is derived from outputs the platform already
 // publishes: the league dashboard payload (availability counts, team context,
 // landscape) and the governed observation feed. This module only retells those
-// signals in plain baseball language. Descriptive only — nothing here ranks
-// pitchers, selects arms, recommends usage, or predicts outcomes.
+// signals in plain baseball language: ontology vocabulary stays on the
+// evidence slots (read chips, stat labels, fact labels) while headlines and
+// prose talk baseball. Descriptive only — nothing here ranks pitchers,
+// selects arms, recommends usage, or predicts outcomes.
 
 const COUNT_WORDS = ['zero', 'one', 'two', 'three', 'four', 'five', 'six',
                      'seven', 'eight', 'nine', 'ten', 'eleven', 'twelve']
@@ -80,10 +83,12 @@ function leagueMetrics(dashboard) {
   }
 }
 
+// Count chips state plainly what each number counts; the concept vocabulary
+// rides the hero's read chip, where it explains itself on hover.
 const heroChips = (team) => [
-  { key: 'clean', label: 'Clean Options', value: team.available, tone: 'rest' },
-  { key: 'concentration', label: 'Workload Concentration', value: team.monitor, tone: 'watch' },
-  { key: 'recovery', label: 'Recovery Window', value: team.restricted, tone: 'stress' },
+  { key: 'clean', label: 'Fresh', value: team.available, tone: 'rest' },
+  { key: 'concentration', label: 'On Watch', value: team.monitor, tone: 'watch' },
+  { key: 'recovery', label: 'Needing Rest', value: team.restricted, tone: 'stress' },
   { key: 'total', label: 'Relievers', value: team.total, tone: 'neutral' },
 ]
 
@@ -101,12 +106,12 @@ export function getHeroStory(dashboard, source = 'home-hero') {
       hasStory: true,
       angle: 'stress',
       tone: 'stress',
-      kicker: 'Workload Stress',
+      kicker: 'Stretched Thin',
       team: stressed,
       read: getReadsForLandscapeEntry(stressed).byKey.pressure,
-      headline: `The ${stressed.teamName} have baseball's most constrained bullpen today`,
-      observation: `${stressed.restricted} of the pen's ${stressed.total} relievers come in with a limited Recovery Window after the work they've carried lately. No club enters the day with less late-inning flexibility.`,
-      whyItMatters: 'High Bullpen Pressure narrows the late innings. If the next few games stay close, the heaviest work is likely to stay on the arms that have already been carrying it.',
+      headline: SIGNAL_HEADLINES.stretchedPen.hero(stressed.teamName),
+      observation: `${stressed.restricted} of the pen's ${stressed.total} relievers come in needing rest after the work they've carried lately. No club enters the day with less room in the late innings.`,
+      whyItMatters: 'A stretched pen narrows the late innings. If the next few games stay close, the heaviest work keeps falling on the arms that have already been carrying it.',
       chips: heroChips(stressed),
     }
   }
@@ -120,9 +125,9 @@ export function getHeroStory(dashboard, source = 'home-hero') {
       kicker: 'Workload Watch',
       team: watched,
       read: getReadsForLandscapeEntry(watched).byKey.concentration,
-      headline: `The ${watched.teamName} have baseball's most concentrated bullpen workload today`,
+      headline: SIGNAL_HEADLINES.sameArms.hero(watched.teamName),
       observation: `${watched.monitor} of the pen's ${watched.total} relievers are carrying enough recent work to sit on the watch list — the longest list in baseball today, even with nobody down outright.`,
-      whyItMatters: 'Workload Concentration stacks up quietly. Heavy weeks tend to show up later as shorter outings and nights off the schedule did not plan for.',
+      whyItMatters: 'Heavy use on the same few arms stacks up quietly. It tends to show up later as shorter outings and nights off the schedule did not plan for.',
       chips: heroChips(watched),
     }
   }
@@ -133,12 +138,12 @@ export function getHeroStory(dashboard, source = 'home-hero') {
       hasStory: true,
       angle: 'rest',
       tone: 'rest',
-      kicker: 'Recovery Window',
+      kicker: 'Fresh Pen',
       team: rested,
       read: getReadsForLandscapeEntry(rested).byKey.recovery,
-      headline: `The ${rested.teamName} bring baseball's widest Recovery Window into today`,
-      observation: `${rested.available} of the pen's ${rested.total} relievers register as Clean Options — the cleanest availability context in baseball today.`,
-      whyItMatters: 'A wide Recovery Window is flexibility. A full pen lets a manager shape the late innings on his terms instead of his bullpen’s.',
+      headline: SIGNAL_HEADLINES.freshPen.hero(rested.teamName),
+      observation: `${rested.available} of the pen's ${rested.total} relievers come in rested and ready to go — no pen in baseball has more fresh arms to call on today.`,
+      whyItMatters: 'A fresh pen is flexibility. A full slate of rested arms lets a manager shape the late innings on his terms instead of his bullpen’s.',
       chips: heroChips(rested),
     }
   }
@@ -195,29 +200,31 @@ export function getLeagueCards(dashboard) {
     }
   }
 
+  // Card titles talk baseball; the stat labels underneath keep the counts and
+  // concept vocabulary as evidence.
   return [
     {
       key: 'most-stressed',
-      title: 'Highest Bullpen Pressure',
+      title: 'The Most Stretched Pen',
       tone: 'stress',
       team: stressLeader,
       stat: stressLeader ? `${stressLeader.restricted} of ${stressLeader.total}` : null,
-      statLabel: stressLeader ? 'arms with limited Recovery Window' : null,
+      statLabel: stressLeader ? 'arms needing rest' : null,
       line: stressLeader
-        ? 'More arms have a limited Recovery Window here than anywhere else in baseball.'
+        ? 'More arms need a day here than anywhere else in baseball.'
         : 'No pen is carrying outsized stress today — a clean league-wide picture.',
       href: stressLeader?.href || '/bullpen',
       cta: stressLeader ? 'Step inside this pen' : 'Browse every bullpen',
     },
     {
       key: 'most-rested',
-      title: 'Widest Recovery Window',
+      title: 'The Freshest Pen',
       tone: 'rest',
       team: restLeader,
       stat: restLeader ? `${restLeader.available} of ${restLeader.total}` : null,
       statLabel: restLeader ? 'Clean Options' : null,
       line: restLeader
-        ? 'This group brings the cleanest availability context into today.'
+        ? 'No pen brings more rested arms into today.'
         : 'No pen stands out for rest today.',
       href: restLeader?.href || '/bullpen',
       cta: restLeader ? 'Step inside this pen' : 'Browse every bullpen',
@@ -235,13 +242,13 @@ export function getLeagueCards(dashboard) {
     },
     {
       key: 'bullpen-to-watch',
-      title: 'Workload Concentration',
+      title: 'Leaning On The Same Arms',
       tone: 'watch',
       team: watchLeader,
       stat: watchLeader ? `${watchLeader.monitor} of ${watchLeader.total}` : null,
       statLabel: watchLeader ? 'arms on the watch list' : null,
       line: watchLeader
-        ? 'The surface is not alarming yet, but the recent workload is worth watching.'
+        ? 'Nothing is flashing red yet, but the same arms keep getting the call.'
         : 'No watch list stands out today.',
       href: watchLeader?.href || '/bullpen',
       cta: watchLeader ? 'Step inside this pen' : 'Browse every bullpen',
@@ -279,7 +286,7 @@ export function getTodayWatchItems(dashboard) {
       kicker: 'Pressure Watch',
       tone: 'stress',
       title: 'One more pen is working with a shorter late-inning margin',
-      body: `The ${pressure.teamName} also carry ${pressure.restricted} ${pressure.restricted === 1 ? 'reliever' : 'relievers'} with a limited Recovery Window, giving Stories another Bullpen Pressure thread to unpack.`,
+      body: `The ${pressure.teamName} also have ${pressure.restricted} ${pressure.restricted === 1 ? 'reliever' : 'relievers'} needing rest after recent work — another pen coming in short today.`,
       href: pressure.href,
       cta: 'Open the team board',
     })
@@ -291,8 +298,8 @@ export function getTodayWatchItems(dashboard) {
       teamId: workload.teamId,
       kicker: 'Workload Watch',
       tone: 'watch',
-      title: 'The watch list is not all at the top of the page',
-      body: `${workload.monitor} ${workload.monitor === 1 ? 'arm' : 'arms'} in the ${workload.teamName} pen are carrying Workload Concentration, a quieter signal worth a second look.`,
+      title: 'Another club keeps going to the same arms',
+      body: `${workload.monitor} ${workload.monitor === 1 ? 'arm' : 'arms'} in the ${workload.teamName} pen ${workload.monitor === 1 ? 'has' : 'have'} been carrying the heavy work lately — quiet so far, worth a second look.`,
       href: workload.href,
       cta: 'Open the team board',
     })
@@ -302,10 +309,10 @@ export function getTodayWatchItems(dashboard) {
   if (recovery) {
     addItem(recovery, {
       teamId: recovery.teamId,
-      kicker: 'Recovery Window',
+      kicker: 'Fresh Arms',
       tone: 'rest',
-      title: 'Recovery Window is the counterweight to today’s pressure',
-      body: `${recovery.available} ${recovery.available === 1 ? 'reliever registers' : 'relievers register'} as Clean Options for the ${recovery.teamName}, giving the day a second side beyond the stress story.`,
+      title: 'At least one pen comes in with room to breathe',
+      body: `The ${recovery.teamName} have ${recovery.available} ${recovery.available === 1 ? 'reliever' : 'relievers'} coming in fresh — the other side of today’s workload story.`,
       href: recovery.href,
       cta: 'Open the team board',
     })
@@ -317,8 +324,8 @@ export function getTodayWatchItems(dashboard) {
       teamId: null,
       kicker: 'League Watch',
       tone: 'watch',
-      title: 'The workload underneath is worth watching',
-      body: `${metrics.monitor} tracked ${metrics.monitor === 1 ? 'arm sits' : 'arms sit'} on the watch list around the league, so Workload Concentration is not limited to the flagship club.`,
+      title: 'The heavy lifting is spread around the league',
+      body: `${metrics.monitor} tracked ${metrics.monitor === 1 ? 'arm sits' : 'arms sit'} on the watch list around the league — the heavy recent work is not limited to one club.`,
       href: '/stories',
       cta: 'Open Stories',
     })
@@ -327,10 +334,10 @@ export function getTodayWatchItems(dashboard) {
   if (items.length < 3 && metrics.available > 0) {
     items.push({
       teamId: null,
-      kicker: 'Coverage Safety',
+      kicker: 'Fresh Arms',
       tone: 'rest',
-      title: 'Clean Options still frame the league context',
-      body: `${metrics.available} tracked ${metrics.available === 1 ? 'reliever registers' : 'relievers register'} as Clean Options. The pressure points matter, but the league picture is not one-note.`,
+      title: 'There are still plenty of fresh arms out there',
+      body: `${metrics.available} tracked ${metrics.available === 1 ? 'reliever comes' : 'relievers come'} in fresh today. The pressure points matter, but the league picture is not one-note.`,
       href: '/stories',
       cta: 'Open Stories',
     })
@@ -345,9 +352,11 @@ export function getLeagueContext(dashboard) {
   const hasMetrics = metrics.total > 0
 
   const summary = hasMetrics
-    ? `${metrics.restricted} tracked ${metrics.restricted === 1 ? 'arm has' : 'arms have'} a limited Recovery Window, ${metrics.monitor} ${metrics.monitor === 1 ? 'sits' : 'sit'} on the watch list, and ${metrics.available} register as Clean Options. That is the league context behind today’s front-page story.`
+    ? `Around the league, ${metrics.restricted} tracked ${metrics.restricted === 1 ? 'arm needs' : 'arms need'} rest after recent work, ${metrics.monitor} ${metrics.monitor === 1 ? 'sits' : 'sit'} on the watch list, and ${metrics.available} ${metrics.available === 1 ? 'comes' : 'come'} in fresh. That is the backdrop behind today’s front-page story.`
     : 'The league context is waiting on a complete bullpen dashboard.'
 
+  // Fact labels keep the BaseballOS vocabulary; the values and details say
+  // what is actually being counted.
   return {
     summary,
     facts: [
@@ -356,7 +365,7 @@ export function getLeagueContext(dashboard) {
         label: 'Bullpen Pressure',
         tone: metrics.restricted > 0 ? 'stress' : 'neutral',
         value: hasMetrics ? String(metrics.restricted) : '0',
-        detail: 'arms with limited Recovery Window',
+        detail: 'arms needing rest after recent work',
       },
       {
         key: 'concentration',
@@ -370,7 +379,7 @@ export function getLeagueContext(dashboard) {
         label: 'Clean Options',
         tone: metrics.available > 0 ? 'rest' : 'neutral',
         value: hasMetrics ? `${metrics.pctAvailable}%` : '0%',
-        detail: 'of tracked arms available cleanly',
+        detail: 'of tracked arms fresh today',
       },
     ],
     href: '/stories',
@@ -405,15 +414,15 @@ export const STORY_TITLE_GUIDELINES = {
 const OBSERVATION_STORY_COPY = {
   inventory: {
     kicker: 'Depth Check',
-    title: 'Clean Options are thinner in a few places today',
-    body: 'Around the league, a few pens come in with fewer Clean Options than they would like. Depth Safety is carrying more of the load than usual today.',
+    title: 'Fresh arms are harder to find in a few pens today',
+    body: 'Around the league, a few pens come in with fewer rested arms than they would like, and the back of the bullpen is carrying more of the load than usual.',
     href: '/dashboard',
     cta: 'See the league view',
   },
   readiness: {
     kicker: 'Rest Watch',
     title: 'Rest is becoming part of the bullpen story',
-    body: 'Not every arm on a roster is a Clean Option today. A handful of pens are managing Recovery Window as carefully as they manage innings.',
+    body: 'Not every arm on a roster is ready for the ball today. A handful of pens are managing rest as carefully as they manage innings.',
     href: '/dashboard',
     cta: 'See the league view',
   },
@@ -427,7 +436,7 @@ const OBSERVATION_STORY_COPY = {
   constraint: {
     kicker: 'Tight Margins',
     title: 'A few late-inning margins are getting thin',
-    body: 'More than one club comes in with a shorter list of Clean Options than it would like. The margin for a long night is thin in places.',
+    body: 'More than one club comes in with fewer fresh arms than it would like. The margin for a long night is thin in places.',
     href: '/dashboard',
     cta: 'See the league view',
   },
@@ -447,8 +456,8 @@ const OBSERVATION_STORY_COPY = {
   },
   availability_movement: {
     kicker: 'Movement',
-    title: 'The league availability picture moved overnight',
-    body: 'Arms are rotating on and off rest around the league. Today’s availability picture is not yesterday’s.',
+    title: 'Who is rested changed overnight',
+    body: 'Arms are rotating on and off rest around the league. Today’s picture is not yesterday’s.',
     href: '/dashboard',
     cta: 'See the league view',
   },
@@ -486,7 +495,7 @@ export function getBullpenStories(dashboard, observations = null) {
       read: getReadsForLandscapeEntry(hidden).byKey.concentration,
       kicker: 'Hidden Workload',
       tone: 'watch',
-      title: `The ${hidden.teamName} box score looks calm. The bullpen does not.`,
+      title: SIGNAL_HEADLINES.sameArms.hidden(hidden.teamName),
       body: `Nobody in this pen is flashing red, but ${hidden.monitor} of ${hidden.total} arms are carrying heavy recent work. The quiet surface is doing a lot of hiding.`,
       href: hidden.href,
       cta: 'Step inside this pen',
@@ -502,8 +511,8 @@ export function getBullpenStories(dashboard, observations = null) {
       read: getReadsForLandscapeEntry(heaviest).byKey.concentration,
       kicker: 'Carrying The Load',
       tone: 'watch',
-      title: `The ${heaviest.teamName} keep handing the ball to the same relievers`,
-      body: `${heaviest.monitor} of ${heaviest.total} arms sit on the watch list — the heaviest concentration of recent bullpen work in baseball today.`,
+      title: SIGNAL_HEADLINES.sameArms.feed(heaviest.teamName),
+      body: `${heaviest.monitor} of ${heaviest.total} arms sit on the watch list — the most anywhere in baseball today.`,
       href: heaviest.href,
       cta: 'Step inside this pen',
     })
@@ -518,8 +527,8 @@ export function getBullpenStories(dashboard, observations = null) {
       read: getReadsForLandscapeEntry(tightening).byKey.pressure,
       kicker: 'Pressure Point',
       tone: 'stress',
-      title: `A thin late-inning margin is forming for the ${tightening.teamName}`,
-      body: `${tightening.restricted} of ${tightening.total} relievers ${tightening.restricted === 1 ? 'has' : 'have'} a limited Recovery Window today. One long night could leave this pen with very few Clean Options.`,
+      title: SIGNAL_HEADLINES.stretchedPen.feed(tightening.teamName),
+      body: `${tightening.restricted} of ${tightening.total} relievers ${tightening.restricted === 1 ? 'needs' : 'need'} rest after recent work. One long night could leave this pen with almost nobody fresh.`,
       href: tightening.href,
       cta: 'Step inside this pen',
     })
@@ -532,10 +541,10 @@ export function getBullpenStories(dashboard, observations = null) {
       abbr: widestWindow.abbr,
       teamName: widestWindow.teamName,
       read: getReadsForLandscapeEntry(widestWindow).byKey.recovery,
-      kicker: 'Recovery Window',
+      kicker: 'Fresh Pen',
       tone: 'rest',
-      title: `Nobody brings a wider Recovery Window into today than the ${widestWindow.teamName}`,
-      body: `${widestWindow.available} of ${widestWindow.total} relievers register as Clean Options — the kind of depth that lets the late innings breathe.`,
+      title: SIGNAL_HEADLINES.freshPen.feed(widestWindow.teamName),
+      body: `${widestWindow.available} of ${widestWindow.total} relievers come in rested — the kind of depth that lets the late innings breathe.`,
       href: widestWindow.href,
       cta: 'Step inside this pen',
     })
@@ -548,10 +557,10 @@ export function getBullpenStories(dashboard, observations = null) {
       abbr: steady.abbr,
       teamName: steady.teamName,
       read: getReadsForLandscapeEntry(steady).byKey.cleanOptions,
-      kicker: 'Depth Safety',
+      kicker: 'Arms To Spare',
       tone: 'rest',
-      title: `Clean Options are stacked a little deeper for the ${steady.teamName}`,
-      body: `${steady.available} of ${steady.total} arms register as Clean Options, with no standout Workload Concentration signal today. Depth Safety is part of this pen’s story.`,
+      title: SIGNAL_HEADLINES.freshPen.depth(steady.teamName),
+      body: `${steady.available} of ${steady.total} arms come in without a workload flag, and nobody is carrying too much of the recent load. Depth is part of this pen’s story today.`,
       href: steady.href,
       cta: 'Step inside this pen',
     })
@@ -564,7 +573,7 @@ export function getBullpenStories(dashboard, observations = null) {
       kicker: 'League Note',
       tone: metrics.restricted > metrics.monitor ? 'stress' : 'watch',
       title: 'Workload is collecting below the headline',
-      body: `${metrics.monitor} tracked ${metrics.monitor === 1 ? 'arm sits' : 'arms sit'} on the watch list and ${metrics.restricted} ${metrics.restricted === 1 ? 'has' : 'have'} a limited Recovery Window. Stories is watching where Bullpen Pressure is obvious and where it is still quiet.`,
+      body: `${metrics.monitor} tracked ${metrics.monitor === 1 ? 'arm sits' : 'arms sit'} on the watch list and ${metrics.restricted} ${metrics.restricted === 1 ? 'needs' : 'need'} rest. Some of that work is obvious, some is still quiet — and the quiet kind is usually where the next story starts.`,
       href: '/dashboard',
       cta: 'See the league view',
     })
@@ -573,10 +582,10 @@ export function getBullpenStories(dashboard, observations = null) {
   if (metrics.available > 0) {
     candidates.push({
       teamId: null,
-      kicker: 'Coverage Safety',
+      kicker: 'The Other Side',
       tone: 'rest',
-      title: 'Coverage Safety is still part of today’s league picture',
-      body: `${metrics.available} tracked ${metrics.available === 1 ? 'reliever registers' : 'relievers register'} as Clean Options. That does not erase the pressure points, but it gives the feed context on both sides of the bullpen ledger.`,
+      title: 'Most of the league still has fresh arms to call on',
+      body: `${metrics.available} tracked ${metrics.available === 1 ? 'reliever comes' : 'relievers come'} in fresh today. That does not erase the pressure points, but the league as a whole is not running on empty.`,
       href: '/dashboard',
       cta: 'See the league view',
     })
@@ -634,7 +643,7 @@ export function getRankingsPreview(dashboard) {
       {
         key: 'shape',
         title: 'Bullpen Shape Preview',
-        note: 'Availability context, not a ranking',
+        note: 'How each pen comes in, not a ranking',
         placeholder: true,
         placeholderCopy: 'Coming later after the preview is validated.',
         entries: [],
@@ -642,7 +651,7 @@ export function getRankingsPreview(dashboard) {
       {
         key: 'recovery',
         title: 'Recovery Window Preview',
-        note: 'Clean Options context, not a ranking',
+        note: 'Who comes in fresh, not a ranking',
         placeholder: true,
         placeholderCopy: 'Not yet validated for team ordering.',
         entries: [],
@@ -650,7 +659,7 @@ export function getRankingsPreview(dashboard) {
       {
         key: 'pressure',
         title: 'Bullpen Pressure Preview',
-        note: 'Workload context, not a ranking',
+        note: 'Who is carrying the load, not a ranking',
         placeholder: true,
         placeholderCopy: 'Preview only until the full release is ready.',
         entries: [],

--- a/frontend/src/components/stories/Stories.jsx
+++ b/frontend/src/components/stories/Stories.jsx
@@ -160,7 +160,7 @@ function FeedScope({ feed, counts }) {
           </h2>
           <p className="mt-2 max-w-3xl text-sm leading-relaxed text-chalk400">
             {feed.hasStories
-              ? `${feed.items.length} active bullpen observations across team, trend, and league lanes.`
+              ? `${feed.items.length} bullpen storylines in play today, from single pens to the league picture.`
               : feed.fallback}
           </p>
         </div>

--- a/frontend/src/components/stories/storiesFeedView.js
+++ b/frontend/src/components/stories/storiesFeedView.js
@@ -17,19 +17,19 @@ export const STORY_FILTERS = [
     key: 'stressed',
     label: 'Stressed',
     activeLabel: 'Stressed Stories',
-    description: 'Stories involving bullpens carrying elevated workload strain.',
+    description: 'Pens that have been worked hard and are short on rest.',
   },
   {
     key: 'rested',
     label: 'Rested',
     activeLabel: 'Rested Stories',
-    description: 'Stories involving bullpens entering the day with cleaner availability.',
+    description: 'Pens coming in fresh, with arms to spare.',
   },
   {
     key: 'watch',
     label: 'Watch List',
     activeLabel: 'Watch List Stories',
-    description: 'Stories where workload patterns are worth monitoring.',
+    description: 'Pens quietly leaning on the same arms.',
   },
   {
     key: 'league',

--- a/frontend/src/utils/bullpenConcepts.js
+++ b/frontend/src/utils/bullpenConcepts.js
@@ -129,7 +129,7 @@ function concentrationRead({ total, watch, needRest }) {
   if (watch >= 3 || (watch >= 2 && needRest >= 2)) {
     return {
       ...base, label: 'Concentrated', display: 'Concentrated Workload', tone: 'watch',
-      detail: `${onWatchPhrase(watch, total)} — work is clustering in a few arms.`,
+      detail: `${onWatchPhrase(watch, total)} — the heavy work is falling on a few arms.`,
     }
   }
   if (watch === 2 || (watch >= 1 && needRest >= 1)) {

--- a/frontend/src/utils/bullpenLanguage.js
+++ b/frontend/src/utils/bullpenLanguage.js
@@ -1,0 +1,56 @@
+// The BaseballOS language layer — where internal bullpen signals get
+// translated into the words a baseball person would actually say.
+//
+// Layering (see docs/product/LANGUAGE_ENGINE_V1.md for the full spec):
+//
+//   internal reads                       language layer        user-facing story
+//   (bullpenConcepts, teamBullpenScoring,  →  this module  →   (homepage, stories
+//    landscape counts, board counts)                            feed, team panels)
+//
+// The ontology itself is untouched: Recovery Window, Workload Concentration,
+// Bullpen Pressure, Clean Options, Coverage Safety, and Depth Safety keep
+// their names and keep riding every surface as evidence — read chips, stat
+// labels, the Today's Bullpen Shape strip. This module only owns how those
+// signals sound when they become a sentence. Two rules govern everything in
+// it: concepts never act as the subject of a sentence ("Workload
+// Concentration stacks up" is model voice; "heavy use on the same arms
+// stacks up" is baseball), and prose never uses system verbs ("register as",
+// "carrying a signal").
+//
+// Each signal maps to a small pool of headline builders keyed by the slot
+// that uses it, so a signal sounds like itself everywhere without repeating
+// one sentence verbatim across surfaces. Alternates considered for each pool
+// live in the spec doc. Everything stays descriptive and present-tense —
+// no forecasts, no verdicts, no advice.
+
+export const SIGNAL_HEADLINES = {
+  // ── Bullpen Pressure / narrow Recovery Window ─────────────────────────────
+  // Internal: the pen is short on rested arms after recent workload.
+  // Says: stretched thin, a short bench, less margin than most.
+  stretchedPen: {
+    hero: (team) => `The ${team} bullpen is stretched thinner than any in baseball today`,
+    feed: (team) => `A thin late-inning margin is forming for the ${team}`,
+    team: (team) => `The ${team} enter today with a thin late-inning margin`,
+  },
+
+  // ── Workload Concentration ────────────────────────────────────────────────
+  // Internal: recent work is clustered on a few arms instead of spread out.
+  // Says: leaning on the same arms, the same names every night, heavy work
+  // falling on a small group.
+  sameArms: {
+    hero: (team) => `The ${team} are leaning on the same arms more than anyone in baseball today`,
+    feed: (team) => `The ${team} keep handing the ball to the same relievers`,
+    hidden: (team) => `The ${team} box score looks calm. The bullpen does not.`,
+    team: (team) => `The ${team} look calm on the surface — the workload underneath is worth watching`,
+  },
+
+  // ── Wide Recovery Window / deep Clean Options ─────────────────────────────
+  // Internal: most of the pen comes in rested, with no workload restriction.
+  // Says: a fresh pen, room to breathe, arms to spare.
+  freshPen: {
+    hero: (team) => `The ${team} bring baseball's freshest bullpen into today`,
+    feed: (team) => `Nobody brings a fresher bullpen into today than the ${team}`,
+    depth: (team) => `The ${team} have fresh arms to spare today`,
+    team: (team) => `The ${team} bring one of the freshest bullpens into today`,
+  },
+}

--- a/frontend/tests/homeIntelligence.test.mjs
+++ b/frontend/tests/homeIntelligence.test.mjs
@@ -95,7 +95,7 @@ test('the hero leads with the most constrained bullpen', () => {
 
 test('the hero headline states what the data shows, not a forecast', () => {
   const hero = getHeroStory(dashboard)
-  assert.match(hero.headline, /have baseball's most constrained bullpen today/)
+  assert.match(hero.headline, /bullpen is stretched thinner than any in baseball today/)
   // No drama, no fortune-telling.
   for (const phrase of [/running out/i, /collapse/i, /will\s/i, /guarantee/i, /doomed/i]) {
     assert.ok(!phrase.test(hero.headline), `headline leaked: ${phrase}`)
@@ -110,7 +110,7 @@ test('the hero falls back to the heaviest watch list, then the most rested pen',
   const watchHero = getHeroStory(noStress)
   assert.equal(watchHero.angle, 'concentration')
   assert.equal(watchHero.team.teamName, 'Toronto Blue Jays')
-  assert.match(watchHero.headline, /most concentrated bullpen workload today/)
+  assert.match(watchHero.headline, /leaning on the same arms more than anyone in baseball today/)
 
   const restOnly = {
     ...dashboard,
@@ -119,7 +119,7 @@ test('the hero falls back to the heaviest watch list, then the most rested pen',
   const restHero = getHeroStory(restOnly)
   assert.equal(restHero.angle, 'rest')
   assert.equal(restHero.team.teamName, 'Washington Nationals')
-  assert.match(restHero.headline, /widest Recovery Window into today/)
+  assert.match(restHero.headline, /baseball's freshest bullpen into today/)
 })
 
 test('a quiet league day still produces a hero story', () => {
@@ -148,11 +148,11 @@ test('card copy reads like a hook, not a metric summary', () => {
   const cards = getLeagueCards(dashboard)
   const byKey = Object.fromEntries(cards.map(card => [card.key, card]))
   assert.equal(byKey['most-stressed'].line,
-    'More arms have a limited Recovery Window here than anywhere else in baseball.')
+    'More arms need a day here than anywhere else in baseball.')
   assert.equal(byKey['most-rested'].line,
-    'This group brings the cleanest availability context into today.')
+    'No pen brings more rested arms into today.')
   assert.equal(byKey['bullpen-to-watch'].line,
-    'The surface is not alarming yet, but the recent workload is worth watching.')
+    'Nothing is flashing red yet, but the same arms keep getting the call.')
 })
 
 test('cards degrade to quiet copy when the landscape is empty', () => {
@@ -177,16 +177,16 @@ test('today watch items are briefing-only and exclude the flagship club', () => 
     watchItems.items.map(item => item.title),
     [
       'One more pen is working with a shorter late-inning margin',
-      'The watch list is not all at the top of the page',
-      'Recovery Window is the counterweight to today’s pressure',
+      'Another club keeps going to the same arms',
+      'At least one pen comes in with room to breathe',
     ],
   )
 })
 
-test('today league context stays short and uses BaseballOS vocabulary', () => {
+test('today league context talks baseball and keeps the vocabulary on the fact labels', () => {
   const context = getLeagueContext(dashboard)
-  assert.match(context.summary, /limited Recovery Window/)
-  assert.match(context.summary, /Clean Options/)
+  assert.match(context.summary, /need rest after recent work/)
+  assert.match(context.summary, /come in fresh/)
   assert.equal(context.facts.length, 3)
   assert.deepEqual(context.facts.map(fact => fact.label), [
     'Bullpen Pressure',
@@ -258,7 +258,7 @@ test('story title guidelines prefer observations over conclusions', () => {
   for (const weak of ['pen is in good shape', 'bullpen is healthy', 'strong availability']) {
     assert.ok(!titles.includes(weak), `conclusion-driven title leaked: ${weak}`)
   }
-  assert.ok(titles.includes('clean options are stacked a little deeper'))
+  assert.ok(titles.includes('fresh arms to spare today'))
 })
 
 // ── Rankings preview ────────────────────────────────────────────────────────
@@ -324,12 +324,12 @@ test('today is curated: no team explorer, feedback CTA intact', () => {
 test('today shows three briefing watch items without repeating Stories titles', () => {
   const html = render(React.createElement(HomeView, { dashboard, observations }))
   assert.ok(htmlIncludes(html, 'One more pen is working with a shorter late-inning margin'))
-  assert.ok(htmlIncludes(html, 'The watch list is not all at the top of the page'))
-  assert.ok(htmlIncludes(html, 'Recovery Window is the counterweight to today’s pressure'))
+  assert.ok(htmlIncludes(html, 'Another club keeps going to the same arms'))
+  assert.ok(htmlIncludes(html, 'At least one pen comes in with room to breathe'))
   // Full-feed story titles stay in Stories, not on the briefing.
   assert.ok(!htmlIncludes(html, 'box score looks calm'))
   assert.ok(!htmlIncludes(html, 'A thin late-inning margin is forming'))
-  assert.ok(!htmlIncludes(html, 'Nobody brings a wider Recovery Window'))
+  assert.ok(!htmlIncludes(html, 'Nobody brings a fresher bullpen'))
   assert.ok(!htmlIncludes(html, 'The workload underneath is worth watching'))
 })
 
@@ -347,7 +347,7 @@ test('the hero renders the flagship observation with Why It Matters', () => {
   const html = render(React.createElement(HomeView, { dashboard, observations }))
   assert.ok(htmlIncludes(html, 'Why It Matters'))
   assert.ok(htmlIncludes(html, 'Milwaukee Brewers'))
-  assert.ok(htmlIncludes(html, 'most constrained bullpen today'))
+  assert.ok(htmlIncludes(html, 'stretched thinner than any in baseball today'))
   assert.ok(htmlIncludes(html, 'Step inside the MIL pen'))
 })
 
@@ -468,6 +468,9 @@ test('the homepage avoids raw system phrasing', () => {
     'availability inventory', 'readiness limitations', 'limitations are present',
     'trusted snapshot', 'snapshot', 'data state', 'data_state', 'contract',
     'fail closed', 'fail_closed', 'governance',
+    // Mechanical phrasing the language layer exists to prevent in prose.
+    'register as', 'limited recovery window', 'availability context',
+    'carrying workload concentration', 'workload-restricted',
   ]) {
     assert.ok(!html.includes(term), `leaked system phrasing: ${term}`)
   }

--- a/frontend/tests/storiesFeed.test.mjs
+++ b/frontend/tests/storiesFeed.test.mjs
@@ -164,9 +164,9 @@ test('the stories page renders as a feed-first surface beyond Today', () => {
   assert.ok(htmlIncludes(html, 'Observations, not predictions.'))
   assert.ok(htmlIncludes(html, 'Beyond Today'))
   assert.ok(htmlIncludes(html, 'What Else BaseballOS Is Seeing'))
-  assert.ok(htmlIncludes(html, 'active bullpen observations'))
+  assert.ok(htmlIncludes(html, 'bullpen storylines in play today'))
   assert.ok(!htmlIncludes(html, 'Top Story'))
-  assert.ok(!htmlIncludes(html, 'most constrained bullpen today'))
+  assert.ok(!htmlIncludes(html, 'stretched thinner than any in baseball today'))
   assert.ok(!htmlIncludes(html, 'Step inside the MIL pen'))
 })
 
@@ -322,6 +322,9 @@ test('the stories page stays in baseball language', () => {
     'snapshot', 'governance', 'data_state', 'fail closed',
     'recommended', 'recommendation', 'betting', 'parlay', 'injury',
     'will collapse', 'guaranteed',
+    // Mechanical phrasing the language layer exists to prevent.
+    'register as', 'workload-restricted', 'availability context',
+    'carrying workload concentration', 'limited recovery window',
   ]) {
     assert.ok(!html.includes(term), `leaked: ${term}`)
   }

--- a/frontend/tests/teamBullpenStoryPanel.test.mjs
+++ b/frontend/tests/teamBullpenStoryPanel.test.mjs
@@ -135,11 +135,11 @@ test('each board shape lands in its story family', () => {
 
 test('a constrained club gets constrained story copy with real counts', () => {
   const story = getTeamBullpenStoryView(constrainedBoard)
-  assert.equal(story.label, 'Constrained Pen')
+  assert.equal(story.label, 'Short-Handed Pen')
   assert.match(story.headline, /Milwaukee Brewers enter today with a thin late-inning margin/)
   assert.match(story.summary, /3 arms of 8 come in needing rest|3 arms/)
   assert.ok(story.workloadBullets.some(bullet => /2 arms of 8 come in rested and ready/.test(bullet)))
-  assert.ok(story.workloadBullets.some(bullet => /3 arms are workload-restricted/.test(bullet)))
+  assert.ok(story.workloadBullets.some(bullet => /3 arms have earned a rest day/.test(bullet)))
   assert.ok(story.watchBullets.length >= 2 && story.watchBullets.length <= 3)
 })
 
@@ -148,19 +148,20 @@ test('a watch-list club reads calm surface, heavy workload', () => {
   assert.equal(story.label, 'Watch-List Pen')
   assert.match(story.headline, /look calm on the surface/)
   assert.match(story.summary, /4 arms of 8/)
-  assert.match(story.summary, /nobody is workload-restricted yet/)
+  assert.match(story.summary, /nobody is down outright yet/)
 })
 
-test('a rested club reads as the cleanest availability picture', () => {
+test('a rested club reads as one of the freshest pens', () => {
   const story = getTeamBullpenStoryView(restedBoard)
   assert.equal(story.label, 'Rested Pen')
-  assert.match(story.headline, /cleanest availability pictures into today/)
+  assert.match(story.headline, /freshest bullpens into today/)
   assert.match(story.summary, /6 arms of 8 come in rested and ready/)
+  assert.match(story.summary, /room to breathe today/)
 })
 
 test('single-arm workload counts read grammatically after density trimming', () => {
   const story = getTeamBullpenStoryView(restedBoard)
-  assert.ok(story.workloadBullets.some(bullet => bullet === '1 arm is workload-restricted after its recent use.'),
+  assert.ok(story.workloadBullets.some(bullet => bullet === '1 arm has earned a rest day after the work it has carried.'),
     `got: ${story.workloadBullets.join(' | ')}`)
   assert.equal(story.workloadBullets.length, 2)
 })
@@ -168,7 +169,7 @@ test('single-arm workload counts read grammatically after density trimming', () 
 test('a neutral club gets balanced story copy', () => {
   const story = getTeamBullpenStoryView(balancedBoard)
   assert.equal(story.label, 'Balanced Pen')
-  assert.match(story.headline, /come in steady — no extreme bullpen signal today/)
+  assert.match(story.headline, /come in steady — nothing tilting the pen either way today/)
 })
 
 test('a thin dataset gets an honest limited read', () => {
@@ -188,7 +189,7 @@ test('no board means no story', () => {
 test('the panel renders headline, both bullet sections, and the framing line', () => {
   const html = render(React.createElement(TeamBullpenStoryPanel, { board: constrainedBoard }))
   assert.ok(htmlIncludes(html, 'Why BaseballOS Is Watching This Pen'))
-  assert.ok(htmlIncludes(html, 'What The Workload Shape Says'))
+  assert.ok(htmlIncludes(html, 'What The Recent Work Says'))
   assert.ok(htmlIncludes(html, 'What To Watch On The Board'))
   assert.ok(htmlIncludes(html, STORY_FRAMING_LINE))
 })
@@ -224,7 +225,7 @@ test('the panel renders Today’s Bullpen Shape in the required order with expla
 test('the shape section stays label-led and avoids score ranking or grade language', () => {
   const html = render(React.createElement(TeamBullpenStoryPanel, { board: constrainedBoard }))
   const start = html.indexOf('Today’s Bullpen Shape')
-  const end = html.indexOf('What The Workload Shape Says')
+  const end = html.indexOf('What The Recent Work Says')
   const shapeHtml = html.slice(start, end)
 
   for (const term of [
@@ -259,6 +260,8 @@ test('the story panel never renders raw system phrasing', () => {
       'availability inventory', 'readiness limitations', 'limitations are present',
       'snapshot', 'governance', 'classification', 'algorithm', 'data state',
       'contract', 'fail closed',
+      // Mechanical phrasing the language layer exists to prevent in prose.
+      'workload-restricted', 'register as', 'availability picture',
     ]) {
       assert.ok(!html.includes(term), `${board.team.team_abbreviation} leaked system phrasing: ${term}`)
     }


### PR DESCRIPTION
The intelligence layer was speaking for itself on the page: headlines led with ontology terms (most constrained bullpen, widest Recovery Window), prose used system verbs (register as Clean Options), and concepts acted as sentence subjects (Workload Concentration stacks up quietly).

Add a language layer (bullpenLanguage.js) that translates internal reads into baseball phrasing, and rewrite the homepage, stories feed, and team intelligence panel copy through it. The ontology is untouched and still rides every surface as evidence: read chips, stat labels, fact labels, and the Today's Bullpen Shape strip keep their vocabulary and tiers.

- Hero, watch items, league cards/context, and observation retellings now talk baseball (stretched thin, leaning on the same arms, fresh pen)
- Stories feed filters and league notes drop strain/lanes/feed jargon
- Team panel drops workload-restricted, availability pictures, and the workload-shape header; labels Short-Handed Pen instead of Constrained
- Tests pin the new copy and ban the mechanical patterns in prose
- docs/product/LANGUAGE_ENGINE_V1.md carries the audit, the translation spec with alternates, and the remaining mechanical surfaces