### PR TITLE
Diversify the divergence closing stem and de-duplicate feed headlines

### DIFF
--- a/backend/services/four_beat_stories.py
+++ b/backend/services/four_beat_stories.py
@@ -19,7 +19,11 @@ from services.availability import (
     STATUS_UNAVAILABLE,
 )
 from services.pitcher_role_authority import author_role_read_labels
-from services.story_evidence import apply_story_evidence_framework, validate_story_evidence
+from services.story_evidence import (
+    apply_story_evidence_framework,
+    headline_opener_overlap,
+    validate_story_evidence,
+)
 from services.story_observation_discovery import select_feed_observations, story_template_dependency_audit
 from services.story_observation_voice import (
     build_observation_voice,
@@ -1876,6 +1880,91 @@ def diversify_adjacent_story_prose(stories: list[dict[str, Any]]) -> list[dict[s
     return diversified
 
 
+# Two cards on one page sharing a headline template is the most visible form of
+# reuse. Detect collisions with the scorer's normalized token-overlap heuristic
+# (after stripping team identity, so two teams on the same template still
+# collide) and rotate the later card to an alternate headline.
+HEADLINE_DEDUPE_OVERLAP_MIN = 0.6
+
+
+def _headline_identity_tokens(story: dict[str, Any]) -> set[str]:
+    tokens: set[str] = set()
+    for value in (story.get('team_name'), story.get('team_abbreviation')):
+        for word in str(value or '').lower().replace("'", ' ').split():
+            cleaned = ''.join(char for char in word if char.isalnum())
+            if cleaned:
+                tokens.add(cleaned)
+    return tokens
+
+
+def _headline_dedupe_signature(title: Any, story: dict[str, Any]) -> str:
+    team_tokens = _headline_identity_tokens(story)
+    words = []
+    for word in str(title or '').lower().replace("'", ' ').split():
+        cleaned = ''.join(char for char in word if char.isalnum())
+        if cleaned and cleaned not in team_tokens:
+            words.append(cleaned)
+    return ' '.join(words)
+
+
+def _headline_signature_collides(signature: str, assigned: list[str]) -> bool:
+    if not signature:
+        return False
+    return any(
+        headline_opener_overlap(signature, existing) >= HEADLINE_DEDUPE_OVERLAP_MIN
+        for existing in assigned
+        if existing
+    )
+
+
+def dedupe_feed_headlines(stories: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Ensure no two cards on one page share a headline.
+
+    Headlines are generated per story with no view of the rest of the feed, so
+    two teams on the same observation type and prose path render the same
+    template. Resolve at the feed layer: the first card in feed order keeps its
+    headline, and a later collision rotates to the next prose path whose headline
+    is free. Deterministic for a given team set.
+    """
+    assigned: list[str] = []
+    for story in stories:
+        signature = _headline_dedupe_signature(story.get('title'), story)
+        if not _headline_signature_collides(signature, assigned):
+            assigned.append(signature)
+            continue
+
+        original_title = story.get('title')
+        disallowed: set[str] = set()
+        current_path = (story.get('story_voice') or {}).get('prose_path')
+        if current_path:
+            disallowed.add(current_path)
+
+        resolved_signature = None
+        while True:
+            next_path = _next_prose_path(story, disallowed)
+            if not next_path or next_path in disallowed:
+                break
+            disallowed.add(next_path)
+            rebuilt = _rebuild_story_voice(story, next_path)
+            if not rebuilt:
+                continue
+            rebuilt_voice, rebuilt_facts = rebuilt
+            candidate_signature = _headline_dedupe_signature(rebuilt_voice.get('headline'), story)
+            if not _headline_signature_collides(candidate_signature, assigned):
+                _apply_story_voice(story, rebuilt_voice, facts_override=rebuilt_facts)
+                story['headline_dedupe'] = {
+                    'applied': True,
+                    'reason': 'feed_headline_collision',
+                    'original_title': original_title,
+                    'resolved_prose_path': next_path,
+                }
+                resolved_signature = candidate_signature
+                break
+
+        assigned.append(resolved_signature or signature)
+    return stories
+
+
 def assemble_story(
     rule_key,
     inputs,
@@ -2309,6 +2398,7 @@ def build_four_beat_story_feed(
     stories.sort(key=lambda story: (-story['strength'], story['team_name'] or '', story['rule_key']))
     stories, feed_order_diversification_count = diversify_feed_story_order(stories)
     stories = diversify_adjacent_story_prose(stories)
+    stories = dedupe_feed_headlines(stories)
     stories, evidence_suppressed = apply_story_evidence_framework(stories)
     assigned_family_counts = observation_differentiation.get('final_family_counts') or {}
     published_family_counts = _published_observation_family_counts(
@@ -2393,6 +2483,7 @@ __all__ = [
     'assemble_story',
     'build_four_beat_story_feed',
     'compute_team_story_inputs',
+    'dedupe_feed_headlines',
     'diversify_feed_story_order',
     'diversify_adjacent_story_prose',
     'evaluate_team_rules',

--- a/backend/services/story_observation_voice.py
+++ b/backend/services/story_observation_voice.py
@@ -271,6 +271,95 @@ def _variant(
     return options[index]
 
 
+# Divergence (strong surface stat, narrower workload underneath) consequence
+# stems. Every entry says the same thing; they differ in GRAMMAR so a feed of
+# divergence cards does not close on one repeated pivot. At most one semicolon
+# form and one ", but" form so a page cannot fill with either. None use
+# forecast/prediction language (no will/likely/expect/odds) — constraint
+# framing only, so each passes the forward-constraint banned lexicon.
+DIVERGENCE_SHAPE_WORKLOAD_LEAD = 'workload_lead'
+DIVERGENCE_SHAPE_SEMICOLON = 'semicolon'
+DIVERGENCE_SHAPE_CONDITIONAL = 'conditional'
+DIVERGENCE_SHAPE_BUT = 'but'
+DIVERGENCE_SHAPE_COMPARATIVE = 'comparative'
+DIVERGENCE_SHAPE_TWO_SENTENCE = 'two_sentence'
+
+DIVERGENCE_CONSEQUENCE_VARIANTS = (
+    (
+        DIVERGENCE_SHAPE_WORKLOAD_LEAD,
+        'The workload still runs through {short_subject}, even with the ERA where it is.',
+    ),
+    (
+        DIVERGENCE_SHAPE_SEMICOLON,
+        'The results hold up; the narrower part is who handles the high-leverage innings.',
+    ),
+    (
+        DIVERGENCE_SHAPE_CONDITIONAL,
+        'If the next game tightens, the strong results still have to come through {short_subject}.',
+    ),
+    (
+        DIVERGENCE_SHAPE_BUT,
+        'The run prevention is real, but the recent innings keep landing on {short_subject}.',
+    ),
+    (
+        DIVERGENCE_SHAPE_COMPARATIVE,
+        'Good results sit on top of a thinner workload pattern than the {era_text} ERA suggests.',
+    ),
+    (
+        DIVERGENCE_SHAPE_TWO_SENTENCE,
+        'The ERA holds the public read. The recent innings still lean on {short_subject}.',
+    ),
+)
+
+
+def _divergence_consequence_index(facts, selected, prose_path) -> int:
+    return _stable_index([
+        _team_name(facts),
+        (facts.get('team') or {}).get('team_id'),
+        selected.get('observation_type'),
+        selected.get('observation_id'),
+        prose_path,
+    ], len(DIVERGENCE_CONSEQUENCE_VARIANTS))
+
+
+def _divergence_consequence(facts, selected, prose_path, *, short_subject, era_text) -> str:
+    """Select a divergence closing stem deterministically per story.
+
+    Keyed off the same team/observation identity the rest of the engine uses, so
+    output is stable for a given card but varied across the feed.
+    """
+    _shape, template = DIVERGENCE_CONSEQUENCE_VARIANTS[
+        _divergence_consequence_index(facts, selected, prose_path)
+    ]
+    return template.format(short_subject=short_subject, era_text=era_text)
+
+
+def classify_divergence_consequence_shape(value: Any) -> str:
+    """Classify a divergence closing line by grammatical shape.
+
+    Used to confirm a feed of divergence cards does not collapse onto one
+    repeated pivot. Derives the shape from the rendered text so it works on any
+    closing line, not only ones built from the pool above.
+    """
+    text = _clean_text(value)
+    if not text:
+        return 'empty'
+    lower = text.lower()
+    if ';' in text:
+        return DIVERGENCE_SHAPE_SEMICOLON
+    if lower.startswith('if '):
+        return DIVERGENCE_SHAPE_CONDITIONAL
+    if ', but ' in lower:
+        return DIVERGENCE_SHAPE_BUT
+    # A second full sentence (internal sentence break) reads differently than a
+    # single clause, so treat it as its own shape before the comparative check.
+    if re.search(r'[.!?]\s+[A-Z]', text):
+        return DIVERGENCE_SHAPE_TWO_SENTENCE
+    if ' than ' in lower:
+        return DIVERGENCE_SHAPE_COMPARATIVE
+    return DIVERGENCE_SHAPE_WORKLOAD_LEAD
+
+
 def _team_inputs(facts: dict[str, Any]) -> dict[str, Any]:
     inputs = facts.get('story_inputs')
     return inputs if isinstance(inputs, dict) else {}
@@ -500,46 +589,26 @@ def polish_selected_observation(
             category = 'reduced_flexibility'
 
     elif subject and observation_type == OBSERVATION_RUN_PREVENTION_STRESS and era_text:
-        variants = {
-            PROSE_PATH_DEPENDENCY: (
+        evidence_variants = {
+            PROSE_PATH_DEPENDENCY:
                 f'{possessive} {era_text} bullpen ERA still leans heavily on {subject}, with recent usage at {per_arm} pitches per participating reliever.',
-                'heavier_workload_concentration',
-                f'The next tight inning still points back toward {short_subject} rather than a wider group.',
-            ),
-            PROSE_PATH_WORKLOAD: (
+            PROSE_PATH_WORKLOAD:
                 f'{team} {_team_has_verb(facts)} a {era_text} bullpen ERA, but {subject} remain tied to a {per_arm}-pitch recent workload per participating reliever.',
-                'heavier_workload_concentration',
-                _variant(facts, selected, prose_path, (
-                    'The bullpen remains effective, but fewer relievers are sharing the burden.',
-                    'The ERA says stable; the workload says the same arms are still doing more of the carrying.',
-                    'The run prevention is real, but the workload underneath is not as broad.',
-                )),
-            ),
-            PROSE_PATH_GAME_ROUTE: (
+            PROSE_PATH_GAME_ROUTE:
                 f'A {era_text} season ERA gives {team} results, but the recent route still runs through {subject} at {per_arm} pitches per participating reliever.',
-                'heavier_workload_concentration',
-                _variant(facts, selected, prose_path, (
-                    'A close game can still ask the same pocket of arms to carry the leverage.',
-                    'The results are strong, but the next leverage pocket may still return to the same arms.',
-                    'The ERA gives the staff cover, while the workload keeps the pressure on the front group.',
-                )),
-            ),
-            PROSE_PATH_ALTERNATIVES: (
+            PROSE_PATH_ALTERNATIVES:
                 f'{possessive} run prevention is strong at a {era_text} ERA, but recent usage still averages {per_arm} pitches per participating reliever around {subject}.',
-                'heavier_workload_concentration',
-                'The first read is good run prevention; the second is how much of it is concentrated in the same arms.',
-            ),
-            PROSE_PATH_RESULTS_MISMATCH: (
+            PROSE_PATH_RESULTS_MISMATCH:
                 f'{subject} have kept {possessive} run prevention strong with a {era_text} ERA, but the recent workload is still {per_arm} pitches per participating reliever.',
-                'heavier_workload_concentration',
-                _variant(facts, selected, prose_path, (
-                    'The results look stable, but the workload underneath is narrower than the ERA alone shows.',
-                    'The ERA is carrying a steadier public read than the recent workload shape deserves.',
-                    'The scoreboard result is clean; the bullpen structure underneath is tighter.',
-                )),
-            ),
         }
-        evidence, category, consequence = variants.get(prose_path, variants[PROSE_PATH_RESULTS_MISMATCH])
+        evidence = evidence_variants.get(prose_path, evidence_variants[PROSE_PATH_RESULTS_MISMATCH])
+        category = 'heavier_workload_concentration'
+        # Close on a structurally varied stem so a feed of divergence cards does
+        # not repeat one pivot. The evidence above keeps the prose-path framing;
+        # the stem is selected from the shared pool, deterministic per story.
+        consequence = _divergence_consequence(
+            facts, selected, prose_path, short_subject=short_subject, era_text=era_text,
+        )
 
     elif subject and observation_type == OBSERVATION_IDENTITY:
         summary = _identity_public_summary(facts)
@@ -1044,11 +1113,13 @@ def build_observation_voice(facts: dict[str, Any]) -> dict[str, Any]:
 __all__ = [
     'CAPABILITY',
     'VERSION',
+    'DIVERGENCE_CONSEQUENCE_VARIANTS',
     'GENERIC_FRAME_DENYLIST',
     'INTERNAL_PUBLIC_UNSAFE_TERMS',
     'PROSE_PATHS_BY_OBSERVATION',
     'THROAT_CLEARING_CLOSERS',
     'build_observation_voice',
+    'classify_divergence_consequence_shape',
     'observation_prose_paths',
     'polish_selected_observation',
     'select_observation_prose_path',

--- a/backend/tests/test_four_beat_stories.py
+++ b/backend/tests/test_four_beat_stories.py
@@ -1,5 +1,6 @@
 import inspect
 import re
+from collections import Counter
 from datetime import date, timedelta
 from types import SimpleNamespace
 
@@ -28,9 +29,12 @@ from services.four_beat_stories import (
     RULE_STRESS_TRANSFER,
     RULE_SUSTAINABILITY_QUESTION,
     TeamInputs,
+    _apply_story_voice,
+    _rebuild_story_voice,
     assemble_story,
     build_four_beat_story_feed,
     compute_team_story_inputs,
+    dedupe_feed_headlines,
     diversify_feed_story_order,
     evaluate_team_rules,
     four_beat_stories_enabled,
@@ -56,8 +60,10 @@ from services.story_observation_discovery import (
     story_template_dependency_audit,
 )
 from services.story_observation_voice import (
+    DIVERGENCE_CONSEQUENCE_VARIANTS,
     THROAT_CLEARING_CLOSERS,
     build_observation_voice,
+    classify_divergence_consequence_shape,
     observation_prose_paths,
     validate_observation_voice,
 )
@@ -2474,6 +2480,131 @@ def test_editorial_polish_diversifies_evidence_consequence_and_adjacent_families
     assert len(evidence_shapes) >= 4
     assert len(consequence_shapes) >= 4
     assert len(run_prevention_consequence_shapes) >= 2
+
+
+# Real divergence (strong surface stat, narrower workload underneath) teams.
+_DIVERGENCE_FEED_TEAMS = (
+    (116, 'Detroit Tigers', 'DET', 1.79),
+    (135, 'San Diego Padres', 'SD', 2.34),
+    (117, 'Houston Astros', 'HOU', 2.93),
+    (114, 'Cleveland Guardians', 'CLE', 2.51),
+    (146, 'Miami Marlins', 'MIA', 2.72),
+)
+
+# Forecast/prediction/betting words the divergence close must never use; it keeps
+# constraint framing ("if the next game tightens...") only.
+_FORECAST_LEXICON = (
+    'will', 'would', 'likely', 'expect', 'expects', 'expected', 'probably',
+    'odds', 'chance', 'chances', 'bet', 'bets', 'betting', 'going to',
+    'should', 'projected', 'projection', 'forecast', 'predict', 'predicts',
+    'may', 'might',
+)
+
+
+def _has_forecast_language(text):
+    lowered = (text or '').lower()
+    return [
+        word for word in _FORECAST_LEXICON
+        if re.search(rf'\b{re.escape(word)}\b', lowered)
+    ]
+
+
+def _run_prevention_stress_story(team_id, team_name, abbr, era, *, force_prose_path=None):
+    _pitchers, records, logs = _fixture_team(
+        team_id, team_name, abbr, [50, 42, 30, 6, 4],
+        available_count=4, high_risk_indices=(0, 1), trust_indices=(0, 1),
+    )
+    team_inputs = _team_inputs(
+        records, logs,
+        team={'team_id': team_id, 'team_name': team_name, 'team_abbreviation': abbr},
+        season_era_by_team=_ranked_era(team_id, era=era, rank=2, strong=True, solid=True),
+    )
+    inputs = compute_team_story_inputs(team_inputs)
+    discovery = discover_story_observations(RULE_SUSTAINABILITY_QUESTION, inputs)
+    candidate = next(
+        (item for item in discovery['candidates'] if item['observation_type'] == 'run_prevention_stress'),
+        None,
+    )
+    assert candidate is not None, team_name
+    story = assemble_story(
+        RULE_SUSTAINABILITY_QUESTION, inputs, selected_observation_override=candidate,
+    )
+    if force_prose_path:
+        rebuilt = _rebuild_story_voice(story, force_prose_path)
+        assert rebuilt is not None, (team_name, force_prose_path)
+        voice, facts = rebuilt
+        _apply_story_voice(story, voice, facts_override=facts)
+    return story
+
+
+def test_divergence_consequence_stems_vary_across_a_feed():
+    shapes = []
+    for team_id, team_name, abbr, era in _DIVERGENCE_FEED_TEAMS:
+        story = _run_prevention_stress_story(team_id, team_name, abbr, era)
+        assert (
+            story['story_observation']['selected_observation']['observation_type']
+            == 'run_prevention_stress'
+        )
+        shapes.append(
+            classify_divergence_consequence_shape(story['story_evidence']['consequence_statement'])
+        )
+
+    counts = Counter(shapes)
+    # The page cannot fill with one pivot: at most one semicolon and one ", but".
+    assert counts['semicolon'] <= 1
+    assert counts['but'] <= 1
+    # And the close varies its grammar across the feed.
+    assert len(set(shapes)) >= 3
+
+
+def test_divergence_consequence_pool_passes_forward_constraint_lexicon():
+    short_subject = 'Frame Arm and Bridge Arm'
+    for _shape, template in DIVERGENCE_CONSEQUENCE_VARIANTS:
+        rendered = template.format(short_subject=short_subject, era_text='2.41')
+        assert _has_forecast_language(rendered) == [], rendered
+
+    # Same guard on the lines the real feed teams actually render.
+    for team_id, team_name, abbr, era in _DIVERGENCE_FEED_TEAMS:
+        story = _run_prevention_stress_story(team_id, team_name, abbr, era)
+        consequence = story['story_evidence']['consequence_statement']
+        assert _has_forecast_language(consequence) == [], (team_name, consequence)
+
+
+def test_divergence_consequence_pool_has_at_most_one_semicolon_and_one_but():
+    shapes = [shape for shape, _template in DIVERGENCE_CONSEQUENCE_VARIANTS]
+    assert shapes.count('semicolon') <= 1
+    assert shapes.count('but') <= 1
+    assert len(set(shapes)) >= 5
+
+
+def test_feed_dedupes_identical_divergence_headlines():
+    detroit = _run_prevention_stress_story(116, 'Detroit Tigers', 'DET', 1.79, force_prose_path='game_route')
+    houston = _run_prevention_stress_story(117, 'Houston Astros', 'HOU', 2.93, force_prose_path='game_route')
+
+    # Both render the same "next tight inning" template before de-dup.
+    assert 'next tight inning may find the same relief pocket' in detroit['title'].lower()
+    assert 'next tight inning may find the same relief pocket' in houston['title'].lower()
+
+    feed = dedupe_feed_headlines([detroit, houston])
+
+    assert feed[0]['title'] != feed[1]['title']
+    # First in feed order keeps the primary; the later collision is rotated.
+    assert feed[0].get('headline_dedupe') is None
+    assert feed[1]['headline_dedupe']['applied'] is True
+    assert feed[1]['headline_dedupe']['reason'] == 'feed_headline_collision'
+    # De-duping the headline must not make it echo the body (prior-fix guard).
+    for story in feed:
+        assert validate_story_evidence(story)['headline_restates_opener'] is False
+
+
+def test_feed_headline_dedupe_is_deterministic():
+    def resolved_titles():
+        detroit = _run_prevention_stress_story(116, 'Detroit Tigers', 'DET', 1.79, force_prose_path='game_route')
+        houston = _run_prevention_stress_story(117, 'Houston Astros', 'HOU', 2.93, force_prose_path='game_route')
+        feed = dedupe_feed_headlines([detroit, houston])
+        return [story['title'] for story in feed]
+
+    assert resolved_titles() == resolved_titles()
 
 
 def test_feed_order_diversification_preserves_large_quality_gap():


### PR DESCRIPTION
Divergence cards (strong surface stat, narrower workload underneath) all closed on the same grammatical move, a two-clause "A; B" or "A, but B" pivot, so a page of them read as templated even though the content differed. Replace the run-prevention-stress closing pool with six structurally distinct stems (workload-lead, semicolon, conditional, but, comparative, two-sentence), with at most one semicolon form and one ", but" form, selected deterministically per story off the same team and observation key the engine already uses. All keep constraint framing and avoid forecast language.

Two teams on the same observation type and prose path also rendered the same headline, because headlines are generated per story with no view of the rest of the feed. Add a feed-assembly de-dup pass: detect collisions with the scorer's normalized token-overlap heuristic after stripping team identity, and rotate the later card to the next prose path whose headline is free. Deterministic for a given team set, and the headline-to-opener redundancy guard still reports no echo.