### PR TITLE
Add league-wide workload concentration baseline infrastructure

### DIFF
--- a/backend/api/bullpen.py
+++ b/backend/api/bullpen.py
@@ -106,8 +106,14 @@ from services.roster_status import (
     classify_roster_status,
 )
 from services.roster_status_audit import with_recent_inactive_roster_audit
+from services.baseline_distribution import build_baseline_payload
 from services.season_era import build_season_era_payload
-from services.workload_concentration import summarize_recent_relief_workload
+from services.workload_concentration import (
+    WORKLOAD_CONCENTRATION_BASELINE_FAMILY,
+    build_workload_concentration_baselines,
+    league_relief_workload_by_team,
+    summarize_recent_relief_workload,
+)
 from services.mlb_api import MlbApiFetchError, mlb_client
 from services import dashboard_snapshot as dashboard_snapshot_service
 from services import sync as sync_service
@@ -2378,6 +2384,24 @@ def build_bullpen_dashboard_payload(*, use_published_freshness=False):
         'scored_pitcher_inventory': inventory_summary,
     }
 
+    # League-wide baseline distributions (Baseline Intelligence infrastructure).
+    # Built from the league-wide records and relief logs already in hand; this is
+    # backend-only and is not consumed by any UI or story surface yet.
+    baseline_team_pitcher_ids = {}
+    for record in availability_records:
+        record_pitcher = record['pitcher']
+        record_team_id = getattr(record_pitcher, 'team_id', None)
+        if record_team_id is None:
+            continue
+        baseline_team_pitcher_ids.setdefault(int(record_team_id), []).append(record_pitcher.id)
+    baselines = build_baseline_payload({
+        WORKLOAD_CONCENTRATION_BASELINE_FAMILY: build_workload_concentration_baselines(
+            league_relief_workload_by_team(
+                baseline_team_pitcher_ids, logs_by_pitcher, reference_date,
+            )
+        ),
+    })
+
     payload = {
         'capability': 'bullpen_dashboard',
         'generated_at': datetime.now(timezone.utc).isoformat(),
@@ -2401,6 +2425,7 @@ def build_bullpen_dashboard_payload(*, use_published_freshness=False):
         'availability_summary': summary,
         'scored_pitcher_inventory': inventory_summary,
         'stats_overview': stats_overview,
+        'baselines': baselines,
     }
     # Prior dashboard snapshot — the comparison baseline for canonical story
     # continuity and the "what changed" surfaces. Fetched once and reused below.

--- a/backend/services/baseline_distribution.py
+++ b/backend/services/baseline_distribution.py
@@ -1,0 +1,126 @@
+"""League-wide baseline distribution infrastructure.
+
+Metric-agnostic statistical infrastructure: given per-team (or per-entity) values
+for a metric, it produces a league distribution summary — sample count, mean,
+median, and the p10/p25/p75/p90 percentile values of that league sample.
+
+It deliberately carries no interpretation, no per-team percentile rank, and no
+comparison language. A later baseline engine decides how a single team's value
+reads against these distributions; this module only describes the league.
+
+Future metrics plug in by supplying their own value extractors to
+``build_metric_distributions`` and registering a family via ``build_baseline_payload``.
+Nothing here is specific to one metric.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Callable, Iterable, Mapping
+
+
+CAPABILITY = 'baseline_distribution_v1'
+
+# The percentile cut points every distribution reports, as fractions of 1.
+DISTRIBUTION_PERCENTILES = {
+    'p10': 0.10,
+    'p25': 0.25,
+    'p75': 0.75,
+    'p90': 0.90,
+}
+
+
+def _is_real_number(value: Any) -> bool:
+    # Bools are ints in Python; exclude them. Reject NaN/inf and non-numerics.
+    if isinstance(value, bool):
+        return False
+    if not isinstance(value, (int, float)):
+        return False
+    return math.isfinite(float(value))
+
+
+def _percentile(sorted_values, fraction: float):
+    """Linear-interpolation percentile over an ascending list (numpy default)."""
+    count = len(sorted_values)
+    if count == 0:
+        return None
+    if count == 1:
+        return float(sorted_values[0])
+    rank = fraction * (count - 1)
+    lower = int(math.floor(rank))
+    upper = min(lower + 1, count - 1)
+    weight = rank - lower
+    return float(sorted_values[lower] + weight * (sorted_values[upper] - sorted_values[lower]))
+
+
+def build_distribution(values: Iterable[Any]) -> dict:
+    """Summarize a sample of numeric values into a league distribution.
+
+    Non-numeric, boolean, and non-finite entries are dropped. An empty sample
+    yields a defined shape with ``sample_count`` 0 and null statistics, so the
+    output contract is stable regardless of input.
+    """
+    clean = sorted(float(value) for value in (values or []) if _is_real_number(value))
+    count = len(clean)
+    distribution = {
+        'sample_count': count,
+        'mean': (sum(clean) / count) if count else None,
+        'median': _percentile(clean, 0.5),
+    }
+    for name, fraction in DISTRIBUTION_PERCENTILES.items():
+        distribution[name] = _percentile(clean, fraction)
+    return distribution
+
+
+def build_metric_distributions(
+    items: Iterable[Any],
+    metric_extractors: Mapping[str, Callable[[Any], Any]],
+) -> dict:
+    """Build one distribution per metric from a shared set of per-entity items.
+
+    ``metric_extractors`` maps a metric key to a callable that pulls that metric's
+    value out of one item. This is the reuse point: a new metric family only needs
+    to provide its own extractors and call this function. Items whose value cannot
+    be extracted are skipped for that metric, not for the whole family.
+    """
+    materialized = list(items or [])
+    distributions = {}
+    for metric_key, extractor in (metric_extractors or {}).items():
+        values = []
+        for item in materialized:
+            try:
+                values.append(extractor(item))
+            except (KeyError, TypeError, AttributeError, IndexError):
+                continue
+        distributions[metric_key] = build_distribution(values)
+    return distributions
+
+
+def field_extractor(field: str) -> Callable[[Any], Any]:
+    """Extractor for a plain dict field, used to register dict-shaped metrics."""
+    def _extract(item):
+        return item.get(field) if isinstance(item, dict) else None
+    return _extract
+
+
+def build_baseline_payload(families: Mapping[str, Any]) -> dict:
+    """Wrap one or more metric-family baseline blocks in the versioned container.
+
+    Each value in ``families`` is a family block produced by a metric module
+    (for example workload concentration). The container is the single backend
+    surface consumers read; adding a future family is a one-line addition here.
+    """
+    return {
+        'capability': CAPABILITY,
+        'families': dict(families or {}),
+    }
+
+
+__all__ = [
+    'CAPABILITY',
+    'DISTRIBUTION_PERCENTILES',
+    'build_distribution',
+    'build_metric_distributions',
+    'field_extractor',
+    'build_baseline_payload',
+]

--- a/backend/services/workload_concentration.py
+++ b/backend/services/workload_concentration.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from datetime import timedelta
 from typing import Any
 
+from services.baseline_distribution import build_metric_distributions, field_extractor
 from services.bullpen_context import BULLPEN_CONTEXT_WINDOW_DAYS
 from utils.games_started import is_relief
 
@@ -107,3 +108,58 @@ def summarize_recent_relief_workload(logs_by_pitcher, reference_date, pitcher_id
             pitcher_ids=pitcher_ids,
         )
     )
+
+
+# ── League-wide baseline aggregation (Baseline Intelligence C1B) ──────────────
+
+WORKLOAD_CONCENTRATION_BASELINE_FAMILY = 'workload_concentration'
+WORKLOAD_CONCENTRATION_BASELINE_METRIC_KEYS = ('top_share', 'top_one_share')
+
+
+def league_relief_workload_by_team(team_to_pitcher_ids, logs_by_pitcher, reference_date):
+    """Recent relief workload concentration for every team that has relief workload.
+
+    ``team_to_pitcher_ids`` maps team_id -> the team's bullpen pitcher ids. Returns
+    one summary per team that actually threw relief pitches in the window. Teams
+    with no relief workload are excluded: their concentration is undefined, not a
+    real ``top_share`` of 0, so including them would bias a league distribution low.
+    """
+    summaries = []
+    for team_id, pitcher_ids in (team_to_pitcher_ids or {}).items():
+        if team_id is None:
+            continue
+        summary = summarize_recent_relief_workload(
+            logs_by_pitcher,
+            reference_date,
+            pitcher_ids=pitcher_ids,
+        )
+        if summary['total_pitches'] <= 0:
+            continue
+        summaries.append({
+            'team_id': team_id,
+            'top_share': summary['top_share'],
+            'top_one_share': summary['top_one_share'],
+            'total_pitches': summary['total_pitches'],
+            'participant_count': summary['participant_count'],
+        })
+    return summaries
+
+
+def build_workload_concentration_baselines(per_team_concentration):
+    """League baseline distributions for the workload-concentration metrics.
+
+    Returns a metric-family block (sample count, window, and a distribution per
+    metric) suitable for registration in the baseline payload container. No
+    interpretation and no per-team ranking — only the league distribution.
+    """
+    items = [item for item in (per_team_concentration or []) if isinstance(item, dict)]
+    extractors = {
+        key: field_extractor(key)
+        for key in WORKLOAD_CONCENTRATION_BASELINE_METRIC_KEYS
+    }
+    return {
+        'metric_family': WORKLOAD_CONCENTRATION_BASELINE_FAMILY,
+        'window_days': RECENT_WORKLOAD_WINDOW_DAYS,
+        'sample_count': len(items),
+        'metrics': build_metric_distributions(items, extractors),
+    }

--- a/backend/tests/test_baseline_distribution.py
+++ b/backend/tests/test_baseline_distribution.py
@@ -1,0 +1,87 @@
+"""Unit tests for the metric-agnostic baseline distribution infrastructure."""
+
+from services.baseline_distribution import (
+    CAPABILITY,
+    build_baseline_payload,
+    build_distribution,
+    build_metric_distributions,
+    field_extractor,
+)
+
+
+def test_build_distribution_reports_known_statistics():
+    dist = build_distribution([10, 20, 30, 40, 50])
+    assert dist['sample_count'] == 5
+    assert dist['mean'] == 30.0
+    assert dist['median'] == 30.0
+    assert dist['p10'] == 14.0
+    assert dist['p25'] == 20.0
+    assert dist['p75'] == 40.0
+    assert dist['p90'] == 46.0
+
+
+def test_percentiles_interpolate_between_ranks():
+    dist = build_distribution([0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100])
+    assert dist['median'] == 50.0
+    assert dist['p25'] == 25.0
+    assert dist['p75'] == 75.0
+    assert dist['p10'] == 10.0
+    assert dist['p90'] == 90.0
+    # Order independence: shuffled input yields the same distribution.
+    assert build_distribution([50, 0, 100, 30, 20, 90, 10, 70, 40, 80, 60]) == dist
+
+
+def test_empty_sample_has_defined_null_shape():
+    dist = build_distribution([])
+    assert dist == {
+        'sample_count': 0, 'mean': None, 'median': None,
+        'p10': None, 'p25': None, 'p75': None, 'p90': None,
+    }
+    assert build_distribution(None)['sample_count'] == 0
+
+
+def test_single_value_collapses_every_statistic_to_that_value():
+    dist = build_distribution([42])
+    assert dist['sample_count'] == 1
+    for key in ('mean', 'median', 'p10', 'p25', 'p75', 'p90'):
+        assert dist[key] == 42.0
+
+
+def test_malformed_entries_are_dropped_not_fatal():
+    dist = build_distribution(
+        [10, None, 'x', True, False, float('nan'), float('inf'), {'a': 1}, [1], 20, 30]
+    )
+    # Only the three real, finite numbers survive (bools/NaN/inf/non-numerics dropped).
+    assert dist['sample_count'] == 3
+    assert dist['mean'] == 20.0
+    assert dist['median'] == 20.0
+
+
+def test_build_metric_distributions_registry_handles_missing_fields():
+    items = [
+        {'a': 1, 'b': 10},
+        {'a': 2, 'b': 20},
+        {'b': 30},  # missing 'a'
+    ]
+    extractors = {'a': field_extractor('a'), 'b': field_extractor('b')}
+    dists = build_metric_distributions(items, extractors)
+    # 'a' only has two defined values; 'b' has three.
+    assert dists['a']['sample_count'] == 2
+    assert dists['a']['mean'] == 1.5
+    assert dists['b']['sample_count'] == 3
+    assert dists['b']['mean'] == 20.0
+
+
+def test_build_metric_distributions_with_no_items():
+    dists = build_metric_distributions([], {'a': field_extractor('a')})
+    assert dists['a']['sample_count'] == 0
+    assert dists['a']['p90'] is None
+
+
+def test_build_baseline_payload_wraps_families_with_capability():
+    family = {'metric_family': 'workload_concentration', 'sample_count': 0, 'metrics': {}}
+    payload = build_baseline_payload({'workload_concentration': family})
+    assert payload['capability'] == CAPABILITY
+    assert payload['families']['workload_concentration'] is family
+    # Robust to empty / missing families.
+    assert build_baseline_payload(None) == {'capability': CAPABILITY, 'families': {}}

--- a/backend/tests/test_bullpen_dashboard.py
+++ b/backend/tests/test_bullpen_dashboard.py
@@ -420,6 +420,41 @@ class TestDashboardEndpoint:
         assert 'selection_made' not in body['context']
         assert body['availability_summary']['total_pitchers'] >= 0
 
+    def test_dashboard_attaches_league_workload_concentration_baselines(self, client):
+        # Teams with recent relief workload feed a league distribution sample.
+        # Baselines are backend infrastructure only — no UI or story consumes them.
+        with client.application.app_context():
+            for team_id, base in ((301, 30100), (302, 30200)):
+                for idx in range(4):
+                    _seed_pitcher(
+                        f'Reliever {team_id}-{idx}',
+                        team_id=team_id,
+                        mlb_id=base + idx,
+                        innings=1.0,
+                        days_ago=1,
+                        roster_status=STATUS_ACTIVE,
+                        games_started=0,
+                    )
+
+        body = client.get('/api/bullpen/dashboard').get_json()
+
+        baselines = body['baselines']
+        assert baselines['capability'] == 'baseline_distribution_v1'
+        family = baselines['families']['workload_concentration']
+        assert family['metric_family'] == 'workload_concentration'
+        assert family['window_days'] == 7
+        assert family['sample_count'] >= 1
+        for metric_key in ('top_share', 'top_one_share'):
+            dist = family['metrics'][metric_key]
+            assert dist['sample_count'] == family['sample_count']
+            assert dist['mean'] is not None
+            assert dist['median'] is not None
+            for percentile in ('p10', 'p25', 'p75', 'p90'):
+                assert percentile in dist
+        # Infrastructure only: the baseline block leaks no ranking/selection.
+        assert 'ranking_applied' not in baselines
+        assert 'selection_made' not in baselines
+
     def test_dashboard_counts_exclude_clear_starters_league_wide(self, client):
         with client.application.app_context():
             _seed_pitcher(

--- a/backend/tests/test_workload_concentration.py
+++ b/backend/tests/test_workload_concentration.py
@@ -1,0 +1,88 @@
+"""Tests for league-wide workload concentration aggregation + baseline outputs."""
+
+from datetime import date, timedelta
+from types import SimpleNamespace
+
+from services.workload_concentration import (
+    RECENT_WORKLOAD_WINDOW_DAYS,
+    build_workload_concentration_baselines,
+    league_relief_workload_by_team,
+)
+
+REF = date(2026, 6, 22)
+
+
+def _log(days_ago, pitches, games_started=0):
+    # Object-shaped log: is_relief() reads .games_started via getattr.
+    return SimpleNamespace(
+        game_date=REF - timedelta(days=days_ago),
+        pitches_thrown=pitches,
+        games_started=games_started,
+    )
+
+
+def test_league_relief_workload_by_team_computes_per_team_shares():
+    logs = {
+        1: [_log(1, 30)], 2: [_log(1, 10)], 3: [_log(1, 10)],   # Team 100: total 50
+        4: [_log(2, 20)], 5: [_log(2, 20)], 6: [_log(2, 10)],   # Team 200: total 50
+    }
+    result = league_relief_workload_by_team({100: [1, 2, 3], 200: [4, 5, 6]}, logs, REF)
+    by_team = {row['team_id']: row for row in result}
+
+    assert by_team[100]['total_pitches'] == 50
+    assert by_team[100]['participant_count'] == 3
+    assert by_team[100]['top_share'] == 1.0            # only three arms -> top-3 is everything
+    assert round(by_team[100]['top_one_share'], 4) == 0.6   # 30 / 50
+    assert round(by_team[200]['top_one_share'], 4) == 0.4   # 20 / 50
+
+
+def test_league_excludes_teams_without_relief_workload():
+    logs = {1: [_log(1, 30)], 2: []}
+    result = league_relief_workload_by_team({100: [1], 200: [2]}, logs, REF)
+    assert {row['team_id'] for row in result} == {100}
+
+
+def test_league_excludes_starts_from_relief_workload():
+    # A start (games_started=1) is not relief, so the team has no relief workload.
+    logs = {1: [_log(1, 30, games_started=1)]}
+    assert league_relief_workload_by_team({100: [1]}, logs, REF) == []
+
+
+def test_league_ignores_none_team_id():
+    logs = {1: [_log(1, 30)]}
+    result = league_relief_workload_by_team({None: [1], 100: [1]}, logs, REF)
+    assert {row['team_id'] for row in result} == {100}
+
+
+def test_build_workload_concentration_baselines_distributions():
+    per_team = [
+        {'team_id': 1, 'top_share': 0.4, 'top_one_share': 0.2},
+        {'team_id': 2, 'top_share': 0.6, 'top_one_share': 0.3},
+        {'team_id': 3, 'top_share': 0.8, 'top_one_share': 0.5},
+    ]
+    block = build_workload_concentration_baselines(per_team)
+
+    assert block['metric_family'] == 'workload_concentration'
+    assert block['window_days'] == RECENT_WORKLOAD_WINDOW_DAYS
+    assert block['sample_count'] == 3
+
+    top_share = block['metrics']['top_share']
+    assert top_share['sample_count'] == 3
+    assert round(top_share['mean'], 6) == 0.6
+    assert top_share['median'] == 0.6
+    for percentile in ('p10', 'p25', 'p75', 'p90'):
+        assert percentile in top_share
+
+    top_one = block['metrics']['top_one_share']
+    assert top_one['sample_count'] == 3
+    assert round(top_one['mean'], 6) == round((0.2 + 0.3 + 0.5) / 3, 6)
+
+
+def test_build_workload_concentration_baselines_empty_sample():
+    block = build_workload_concentration_baselines([])
+    assert block['sample_count'] == 0
+    for metric_key in ('top_share', 'top_one_share'):
+        dist = block['metrics'][metric_key]
+        assert dist['sample_count'] == 0
+        assert dist['mean'] is None
+        assert dist['p90'] is None


### PR DESCRIPTION
First Baseline Intelligence increment: compute league-wide distributions for workload concentration so a later engine can answer "compared to what?" without any presentation or wording yet.

- Add services/baseline_distribution.py: metric-agnostic infrastructure that turns a sample of per-team values into a league distribution (sample_count, mean, median, p10/p25/p75/p90), with a registry-style build_metric_distributions for future metrics and a versioned build_baseline_payload container.
- Add league_relief_workload_by_team and build_workload_concentration_ baselines to services/workload_concentration.py: aggregate top_share and top_one_share across every team that has recent relief workload, reusing the existing per-team concentration math. Teams with no relief workload are excluded so the distribution is not biased low.
- Attach the result to the dashboard payload as dashboard.baselines, built from the league-wide records and relief logs already in hand (no extra queries). It is backend-only; no UI, story, or copy consumes it.
- Tests cover distribution math, percentile interpolation, sample counts, empty/single/malformed input, the registry aggregator, the league aggregation (including relief-vs-start and no-workload exclusion), and the dashboard wiring.

No interpretation, percentile-rank, or ranking language is produced; those belong to the later baseline engine and story-integration phases.