### PR TITLE
Add baseline interpretation engine for workload concentration

### DIFF
--- a/backend/services/baseline_engine.py
+++ b/backend/services/baseline_engine.py
@@ -1,0 +1,178 @@
+"""Baseline interpretation engine.
+
+Turns a single metric value into a structured, deterministic read against a
+league distribution produced by ``baseline_distribution`` (sample_count, mean,
+median, p10/p25/p75/p90). It emits structured fields only — never prose, never a
+recommendation, prediction, or per-team ranking. A later story/UI phase decides
+how to word these reads; this module just classifies.
+
+Scope (C1C): applied to workload concentration (``top_share`` / ``top_one_share``)
+via ``interpret_workload_concentration``. ``interpret_value`` itself is metric
+agnostic so future metrics can reuse it.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+
+CAPABILITY = 'baseline_engine_v1'
+
+# Minimum league sample before a value is interpreted at all (MVP guard).
+MIN_SAMPLE_COUNT = 10
+
+# Half-width of the "about typical" band around the mean, as a fraction of the
+# interquartile range. Keeps small deviations from over-labeling above/below.
+MEAN_TOLERANCE_IQR_RATIO = 0.15
+
+# Unavailable states (available = False).
+COMPARISON_UNAVAILABLE = 'unavailable'
+COMPARISON_INSUFFICIENT_SAMPLE = 'insufficient_sample'
+COMPARISON_MALFORMED = 'malformed_distribution'
+
+# Interpretation bands for higher-is-more-notable metrics (available = True).
+BELOW_AVERAGE = 'below_average'
+ABOUT_TYPICAL = 'about_typical'
+ABOVE_AVERAGE = 'above_average'
+WELL_ABOVE_AVERAGE = 'well_above_average'
+AMONG_HIGHEST = 'among_highest'
+
+# Metrics this phase is allowed to interpret.
+WORKLOAD_CONCENTRATION_METRICS = ('top_share', 'top_one_share')
+
+
+def _is_number(value: Any) -> bool:
+    if isinstance(value, bool):
+        return False
+    if not isinstance(value, (int, float)):
+        return False
+    return math.isfinite(float(value))
+
+
+def _mean_tolerance(p25, p75, mean) -> float:
+    """Symmetric tolerance around the mean defining the 'about typical' band."""
+    if _is_number(p25) and _is_number(p75) and p75 > p25:
+        return MEAN_TOLERANCE_IQR_RATIO * (float(p75) - float(p25))
+    # Degenerate/absent IQR: fall back to a small fraction of the mean magnitude.
+    return abs(float(mean)) * 0.02 if _is_number(mean) else 0.0
+
+
+def _classify(value, mean, p75, p90, tolerance):
+    """Return (band, comparison, direction, severity, nearest_threshold).
+
+    Evaluated from the highest cut point down so the outcome is unambiguous.
+    """
+    if value >= p90:
+        return ('at_or_above_p90', AMONG_HIGHEST, 'higher', 'high', 'p90')
+    if value >= p75:
+        return ('p75_to_p90', WELL_ABOVE_AVERAGE, 'higher', 'elevated', 'p75')
+    if value > mean + tolerance:
+        return ('mean_to_p75', ABOVE_AVERAGE, 'higher', 'notable', 'mean')
+    if value >= mean - tolerance:
+        return ('around_mean', ABOUT_TYPICAL, 'typical', 'typical', 'mean')
+    return ('below_mean', BELOW_AVERAGE, 'lower', 'low', 'mean')
+
+
+def _state(comparison, metric, value, sample_count, mean, median, reason):
+    """An unavailable read (insufficient / malformed / no value)."""
+    return {
+        'capability': CAPABILITY,
+        'available': False,
+        'metric': metric,
+        'value': float(value) if _is_number(value) else None,
+        'comparison': comparison,
+        'band': None,
+        'direction': None,
+        'severity': None,
+        'sample_count': int(sample_count) if _is_number(sample_count) else None,
+        'mean': float(mean) if _is_number(mean) else None,
+        'median': float(median) if _is_number(median) else None,
+        'nearest_threshold': None,
+        'reason': reason,
+    }
+
+
+def interpret_value(metric, value, distribution, *, sample_count=None, min_sample_count=MIN_SAMPLE_COUNT):
+    """Interpret ``value`` for ``metric`` against a league ``distribution``.
+
+    ``distribution`` is a ``baseline_distribution.build_distribution`` shape.
+    ``sample_count`` defaults to the distribution's own sample_count. Returns a
+    structured read; unavailable states carry available=False and a ``reason``.
+    """
+    dist = distribution if isinstance(distribution, dict) else {}
+    resolved_sample = sample_count if sample_count is not None else dist.get('sample_count')
+    mean = dist.get('mean')
+    median = dist.get('median')
+    p25 = dist.get('p25')
+    p75 = dist.get('p75')
+    p90 = dist.get('p90')
+
+    # Nothing to interpret.
+    if not _is_number(value):
+        return _state(COMPARISON_UNAVAILABLE, metric, None, resolved_sample, mean, median, 'no value to interpret')
+
+    # Too little league data (an empty distribution lands here: sample_count 0).
+    if _is_number(resolved_sample) and resolved_sample < min_sample_count:
+        return _state(
+            COMPARISON_INSUFFICIENT_SAMPLE, metric, value, resolved_sample, mean, median,
+            f'sample_count below minimum of {min_sample_count}',
+        )
+
+    # Distribution is unusable: missing sample_count or non-finite cut points.
+    if not _is_number(resolved_sample) or not all(_is_number(point) for point in (mean, p75, p90)):
+        return _state(
+            COMPARISON_MALFORMED, metric, value, resolved_sample, mean, median,
+            'distribution missing a finite sample_count, mean, p75, or p90',
+        )
+
+    value = float(value)
+    mean = float(mean)
+    tolerance = _mean_tolerance(p25, p75, mean)
+    band, comparison, direction, severity, nearest = _classify(value, mean, float(p75), float(p90), tolerance)
+    return {
+        'capability': CAPABILITY,
+        'available': True,
+        'metric': metric,
+        'value': value,
+        'comparison': comparison,
+        'band': band,
+        'direction': direction,
+        'severity': severity,
+        'sample_count': int(resolved_sample),
+        'mean': mean,
+        'median': float(median) if _is_number(median) else None,
+        'nearest_threshold': nearest,
+    }
+
+
+def interpret_workload_concentration(metric, value, family, *, min_sample_count=MIN_SAMPLE_COUNT):
+    """Interpret a team's workload-concentration value against the league family.
+
+    ``family`` is the ``workload_concentration`` block from ``dashboard.baselines``
+    (carrying a per-metric distribution under ``metrics``). Only ``top_share`` and
+    ``top_one_share`` are supported in this phase.
+    """
+    if metric not in WORKLOAD_CONCENTRATION_METRICS:
+        return _state(COMPARISON_UNAVAILABLE, metric, value, None, None, None, 'unsupported metric')
+    metrics = (family or {}).get('metrics') if isinstance(family, dict) else None
+    distribution = (metrics or {}).get(metric) if isinstance(metrics, dict) else None
+    return interpret_value(metric, value, distribution, min_sample_count=min_sample_count)
+
+
+__all__ = [
+    'CAPABILITY',
+    'MIN_SAMPLE_COUNT',
+    'MEAN_TOLERANCE_IQR_RATIO',
+    'COMPARISON_UNAVAILABLE',
+    'COMPARISON_INSUFFICIENT_SAMPLE',
+    'COMPARISON_MALFORMED',
+    'BELOW_AVERAGE',
+    'ABOUT_TYPICAL',
+    'ABOVE_AVERAGE',
+    'WELL_ABOVE_AVERAGE',
+    'AMONG_HIGHEST',
+    'WORKLOAD_CONCENTRATION_METRICS',
+    'interpret_value',
+    'interpret_workload_concentration',
+]

--- a/backend/tests/test_baseline_engine.py
+++ b/backend/tests/test_baseline_engine.py
@@ -1,0 +1,174 @@
+"""Tests for the baseline interpretation engine (workload concentration MVP)."""
+
+from services.baseline_distribution import build_distribution
+from services.baseline_engine import (
+    CAPABILITY,
+    interpret_value,
+    interpret_workload_concentration,
+)
+from services.workload_concentration import build_workload_concentration_baselines
+
+
+def _dist(sample_count=30, mean=0.48, median=0.50, p10=0.38, p25=0.42, p75=0.58, p90=0.66):
+    return {
+        'sample_count': sample_count, 'mean': mean, 'median': median,
+        'p10': p10, 'p25': p25, 'p75': p75, 'p90': p90,
+    }
+
+
+# ── Interpretation bands (higher-is-more-notable) ─────────────────────────────
+
+def test_value_at_or_above_p90_is_among_highest():
+    read = interpret_value('top_share', 0.70, _dist())
+    assert read['available'] is True
+    assert read['comparison'] == 'among_highest'
+    assert read['band'] == 'at_or_above_p90'
+    assert read['direction'] == 'higher'
+    assert read['nearest_threshold'] == 'p90'
+    assert read['metric'] == 'top_share'
+    assert read['value'] == 0.70
+    assert read['sample_count'] == 30
+    assert read['mean'] == 0.48
+
+
+def test_value_between_p75_and_p90_is_well_above_average():
+    read = interpret_value('top_share', 0.60, _dist())
+    assert read['comparison'] == 'well_above_average'
+    assert read['band'] == 'p75_to_p90'
+    assert read['nearest_threshold'] == 'p75'
+    assert read['direction'] == 'higher'
+
+
+def test_value_above_mean_below_p75_is_above_average():
+    read = interpret_value('top_share', 0.53, _dist())
+    assert read['comparison'] == 'above_average'
+    assert read['band'] == 'mean_to_p75'
+    assert read['direction'] == 'higher'
+
+
+def test_value_around_mean_is_about_typical():
+    read = interpret_value('top_share', 0.48, _dist())
+    assert read['comparison'] == 'about_typical'
+    assert read['band'] == 'around_mean'
+    assert read['direction'] == 'typical'
+    # A small deviation on either side of the mean stays typical (tolerance band).
+    assert interpret_value('top_share', 0.49, _dist())['comparison'] == 'about_typical'
+    assert interpret_value('top_share', 0.47, _dist())['comparison'] == 'about_typical'
+
+
+def test_value_below_mean_is_below_average():
+    read = interpret_value('top_share', 0.40, _dist())
+    assert read['comparison'] == 'below_average'
+    assert read['band'] == 'below_mean'
+    assert read['direction'] == 'lower'
+
+
+# ── Guards / unavailable states ───────────────────────────────────────────────
+
+def test_insufficient_sample_suppresses_interpretation():
+    read = interpret_value('top_share', 0.70, _dist(sample_count=5))
+    assert read['available'] is False
+    assert read['comparison'] == 'insufficient_sample'
+    assert read['band'] is None
+    assert read['value'] == 0.70
+    # An explicit higher minimum also suppresses an otherwise adequate sample.
+    stricter = interpret_value('top_share', 0.7, _dist(sample_count=12), min_sample_count=20)
+    assert stricter['comparison'] == 'insufficient_sample'
+
+
+def test_empty_distribution_is_insufficient_sample():
+    read = interpret_value('top_share', 0.70, build_distribution([]))
+    assert read['available'] is False
+    assert read['comparison'] == 'insufficient_sample'
+
+
+def test_malformed_distribution_is_flagged():
+    broken = {
+        'sample_count': 30, 'mean': None, 'median': None,
+        'p10': None, 'p25': None, 'p75': None, 'p90': None,
+    }
+    assert interpret_value('top_share', 0.70, broken)['comparison'] == 'malformed_distribution'
+    # Non-numeric statistic despite an adequate sample.
+    bad_stat = {'sample_count': 30, 'mean': 'x', 'p75': 0.5, 'p90': 0.6}
+    assert interpret_value('top_share', 0.70, bad_stat)['comparison'] == 'malformed_distribution'
+    # Not a dict at all.
+    assert interpret_value('top_share', 0.70, None)['comparison'] == 'malformed_distribution'
+
+
+def test_missing_or_nonnumeric_value_is_unavailable():
+    read = interpret_value('top_share', None, _dist())
+    assert read['available'] is False
+    assert read['comparison'] == 'unavailable'
+    assert read['value'] is None
+    assert interpret_value('top_share', 'x', _dist())['comparison'] == 'unavailable'
+    assert interpret_value('top_share', True, _dist())['comparison'] == 'unavailable'
+
+
+def test_output_is_structured_with_no_ranking_or_prediction_fields():
+    read = interpret_value('top_share', 0.70, _dist())
+    assert read['capability'] == CAPABILITY
+    # Structured fields only — no prose, ranking, recommendation, or prediction.
+    for forbidden in ('rank', 'ranking', 'recommendation', 'prediction', 'prose', 'text', 'narrative'):
+        assert forbidden not in read
+
+
+# ── Workload concentration wrapper (both supported metrics) ───────────────────
+
+def _family(sample_count=12):
+    return {
+        'metric_family': 'workload_concentration',
+        'window_days': 7,
+        'sample_count': sample_count,
+        'metrics': {
+            'top_share': _dist(sample_count=sample_count),
+            'top_one_share': _dist(
+                sample_count=sample_count, mean=0.25, median=0.24,
+                p10=0.18, p25=0.21, p75=0.30, p90=0.34,
+            ),
+        },
+    }
+
+
+def test_workload_concentration_supports_both_metrics():
+    family = _family()
+    top_share = interpret_workload_concentration('top_share', 0.70, family)
+    assert top_share['available'] is True
+    assert top_share['comparison'] == 'among_highest'
+    assert top_share['metric'] == 'top_share'
+
+    top_one = interpret_workload_concentration('top_one_share', 0.32, family)
+    assert top_one['available'] is True
+    assert top_one['comparison'] == 'well_above_average'
+    assert top_one['metric'] == 'top_one_share'
+
+
+def test_workload_concentration_rejects_unsupported_metric():
+    read = interpret_workload_concentration('coverage_depth', 0.5, _family())
+    assert read['available'] is False
+    assert read['comparison'] == 'unavailable'
+    assert read['reason'] == 'unsupported metric'
+
+
+def test_workload_concentration_insufficient_family_sample():
+    read = interpret_workload_concentration('top_share', 0.70, _family(sample_count=4))
+    assert read['comparison'] == 'insufficient_sample'
+
+
+def test_engine_consumes_a_real_c1b_baseline_block():
+    # End-to-end: C1B builds the league distribution, C1C interprets against it.
+    values = [0.40, 0.42, 0.44, 0.46, 0.48, 0.50, 0.52, 0.54, 0.58, 0.62, 0.66, 0.72]
+    per_team = [
+        {'team_id': idx, 'top_share': value, 'top_one_share': value / 2}
+        for idx, value in enumerate(values)
+    ]
+    family = build_workload_concentration_baselines(per_team)
+    assert family['metrics']['top_share']['sample_count'] == 12
+
+    high = interpret_workload_concentration('top_share', 0.72, family)
+    assert high['available'] is True
+    assert high['comparison'] in ('among_highest', 'well_above_average')
+    assert high['direction'] == 'higher'
+
+    low = interpret_workload_concentration('top_share', 0.40, family)
+    assert low['available'] is True
+    assert low['direction'] in ('lower', 'typical')


### PR DESCRIPTION
Second Baseline Intelligence increment: turn a workload concentration value into a structured, deterministic read against the league distribution built in the prior phase. Backend interpretation only — no UI, story, or copy consumes it, and the dashboard payload is unchanged.

- Add services/baseline_engine.py. interpret_value(metric, value, distribution) classifies a value against a baseline_distribution block into below_average / about_typical / above_average / well_above_average / among_highest, using the p75/p90 cut points and a tolerance band around the mean, and returns structured fields only (comparison, band, direction, severity, nearest_threshold, sample_count, mean, median).
- Guard states: insufficient_sample (sample_count below a minimum of 10, which also covers empty distributions), malformed_distribution (missing or non-finite stats), and unavailable (no value / unsupported metric).
- interpret_workload_concentration restricts this phase to top_share and top_one_share, reading the matching distribution from the dashboard.baselines workload_concentration family.
- No ranking, recommendation, or prediction is produced; the engine is exposed as an internal helper for later story integration and is not attached to any product payload (the least-risky option).
- Tests cover every band, the sample-size and malformed/missing-value guards, both supported metrics, and an end-to-end read against a distribution produced by the prior phase's aggregator.