### PR TITLE
Add distribution-aware baseline context to the workload concentration…

### DIFF
--- a/backend/services/bullpen_concentration_context.py
+++ b/backend/services/bullpen_concentration_context.py
@@ -13,6 +13,8 @@ from datetime import date, datetime, timedelta
 from typing import Any
 
 from services.availability_reference_date import product_current_date
+from services.baseline_distribution import build_distribution
+from services.baseline_engine import interpret_value
 from services.workload_appearance import (
     is_pitch_count_workload_log,
     is_workload_appearance_log,
@@ -148,6 +150,7 @@ def _empty_context(ref, window_start, league_baseline=None):
             'league_top_three_workload_share_10d'
         ),
         'top_three_share_delta_vs_league': None,
+        'baseline_read': _baseline_read(None, league_baseline),
         'bullpen_workload_total_10d': 0,
         'concentration_band': CONCENTRATION_INSUFFICIENT_DATA,
         'top_three_relievers_10d': [],
@@ -194,6 +197,23 @@ def _league_baseline_value(league_baseline):
     if isinstance(league_baseline, dict):
         return league_baseline.get('league_top_three_workload_share_10d')
     return league_baseline
+
+
+def _league_baseline_distribution(league_baseline):
+    if isinstance(league_baseline, dict):
+        return league_baseline.get('top_three_workload_share_distribution_10d')
+    return None
+
+
+def _baseline_read(top_three_share, league_baseline):
+    # Distribution-aware league read for the top-three workload share. The shared
+    # baseline engine owns the interpretation; this only feeds it the team value
+    # and the 10-day league distribution, in the same percentage units.
+    return interpret_value(
+        'top_share',
+        top_three_share,
+        _league_baseline_distribution(league_baseline),
+    )
 
 
 def build_bullpen_concentration_context(
@@ -300,6 +320,7 @@ def build_bullpen_concentration_context(
         'top_three_workload_share_10d': top_three_share,
         'league_top_three_workload_share_10d': league_value,
         'top_three_share_delta_vs_league': _delta(top_three_share, league_value),
+        'baseline_read': _baseline_read(top_three_share, league_baseline),
         'bullpen_workload_total_10d': total_workload,
         'concentration_band': concentration_band(top_three_share),
         'top_three_relievers_10d': [
@@ -348,6 +369,7 @@ def build_league_bullpen_concentration_baseline(logs, *, reference_date=None):
     return {
         'league_top_three_workload_share_10d': league_share,
         'league_team_count_10d': len(shares),
+        'top_three_workload_share_distribution_10d': build_distribution(shares),
     }
 
 

--- a/backend/services/story_construction_engine.py
+++ b/backend/services/story_construction_engine.py
@@ -214,6 +214,7 @@ def _concentration_pressure_frame(team_context, observation):
         'league_top_three_workload_share_10d': concentration.get('league_top_three_workload_share_10d'),
         'top_three_share_delta_vs_league': concentration.get('top_three_share_delta_vs_league'),
         'league_team_count_10d': concentration.get('league_team_count_10d'),
+        'baseline_read': concentration.get('baseline_read'),
     }
     frame['cause_facts'] = {
         'rotation_avg_ip_7d': rotation.get('rotation_avg_ip_7d'),

--- a/backend/services/story_writer_v1.py
+++ b/backend/services/story_writer_v1.py
@@ -309,6 +309,32 @@ def _rotation_pressure(frame):
     )
 
 
+# Distribution-aware league phrasing for the workload concentration story's
+# baseline beat. Descriptive context only — no rank, recommendation, prediction,
+# or superlative-singular ("highest"/"most") language (governance C1E).
+_CONCENTRATION_BASELINE_SENTENCE = {
+    'among_highest': 'This bullpen has been among the more concentrated workloads in baseball recently',
+    'well_above_average': 'That concentration sits well above the league norm',
+    'above_average': 'That concentration sits above the league norm',
+    'about_typical': 'That concentration is around the league norm',
+    'below_average': 'That concentration is more spread out than a typical bullpen',
+}
+
+
+def _baseline_band(baseline):
+    """The supported comparison band, only when the baseline read is available."""
+    read = baseline.get('baseline_read') if isinstance(baseline, dict) else None
+    if not isinstance(read, dict) or read.get('available') is not True:
+        return None
+    comparison = read.get('comparison')
+    return comparison if comparison in _CONCENTRATION_BASELINE_SENTENCE else None
+
+
+def _concentration_baseline_sentence(baseline):
+    band = _baseline_band(baseline)
+    return _CONCENTRATION_BASELINE_SENTENCE.get(band) if band else None
+
+
 def _concentration_pressure(frame):
     team = _team(frame)
     headline = _facts(frame, 'headline_facts')
@@ -357,13 +383,17 @@ def _concentration_pressure(frame):
             ),
         ),
         baseline_paragraph=_paragraph(
+            # Distribution-aware league read when available; otherwise fall back to
+            # the existing league-average comparison (never both, to avoid stacking
+            # two "vs league" statements).
+            _concentration_baseline_sentence(baseline),
             (
                 f"The league comparison is {_fmt(league, suffix='%')} for top-three bullpen workload"
-                if _present(league) else None
+                if _present(league) and not _baseline_band(baseline) else None
             ),
             (
                 f"That puts this bullpen {_fmt(delta)} percentage points above that baseline"
-                if _present(delta) else None
+                if _present(delta) and not _baseline_band(baseline) else None
             ),
         ),
         cause_paragraph=_paragraph(

--- a/backend/tests/test_bullpen_concentration_context.py
+++ b/backend/tests/test_bullpen_concentration_context.py
@@ -160,15 +160,62 @@ def test_league_baseline_and_delta_are_calculated_from_team_shares():
         reference_date=REF,
     )
 
-    assert baseline == {
-        'league_top_three_workload_share_10d': 75.0,
-        'league_team_count_10d': 2,
-    }
+    assert baseline['league_top_three_workload_share_10d'] == 75.0
+    assert baseline['league_team_count_10d'] == 2
+    distribution = baseline['top_three_workload_share_distribution_10d']
+    assert distribution['sample_count'] == 2
+    assert round(distribution['mean'], 1) == 75.0
 
     result = context(team_two, league_baseline=baseline)
     assert result['top_three_workload_share_10d'] == 90.0
     assert result['league_top_three_workload_share_10d'] == 75.0
     assert result['top_three_share_delta_vs_league'] == 15.0
+
+
+_LEAGUE_DISTRIBUTION = {
+    'league_top_three_workload_share_10d': 48.0,
+    'league_team_count_10d': 28,
+    'top_three_workload_share_distribution_10d': {
+        'sample_count': 28, 'mean': 48.0, 'median': 50.0,
+        'p10': 38.0, 'p25': 42.0, 'p75': 58.0, 'p90': 66.0,
+    },
+}
+
+
+def test_baseline_read_interprets_team_value_against_league_distribution():
+    # Three arms carry nearly all the work -> top-three share at/above p90.
+    result = context(
+        [log(1, 1, 80), log(2, 1, 10), log(3, 1, 10), log(4, 2, 5)],
+        league_baseline=_LEAGUE_DISTRIBUTION,
+    )
+    read = result['baseline_read']
+    assert read['available'] is True
+    assert read['metric'] == 'top_share'
+    assert read['comparison'] == 'among_highest'
+    assert read['direction'] == 'higher'
+
+
+def test_baseline_read_guards_on_thin_league_sample():
+    thin = {
+        'league_top_three_workload_share_10d': 90.0,
+        'league_team_count_10d': 1,
+        'top_three_workload_share_distribution_10d': {
+            'sample_count': 1, 'mean': 90.0, 'median': 90.0,
+            'p10': 90.0, 'p25': 90.0, 'p75': 90.0, 'p90': 90.0,
+        },
+    }
+    result = context([log(1, 1, 80), log(2, 1, 10), log(3, 1, 10)], league_baseline=thin)
+    assert result['baseline_read']['available'] is False
+    assert result['baseline_read']['comparison'] == 'insufficient_sample'
+
+
+def test_baseline_read_without_distribution_degrades_gracefully():
+    # A legacy-shaped league baseline (no distribution) must not crash the context.
+    result = context(
+        [log(1, 1, 80), log(2, 1, 10), log(3, 1, 10)],
+        league_baseline={'league_top_three_workload_share_10d': 50.0},
+    )
+    assert result['baseline_read']['available'] is False
 
 
 def test_doubleheader_workload_aggregation_counts_distinct_appearances():

--- a/backend/tests/test_bullpen_context.py
+++ b/backend/tests/test_bullpen_context.py
@@ -78,6 +78,7 @@ BULLPEN_CONCENTRATION_CONTEXT_KEYS = {
     'top_three_workload_share_10d',
     'league_top_three_workload_share_10d',
     'top_three_share_delta_vs_league',
+    'baseline_read',
     'bullpen_workload_total_10d',
     'concentration_band',
     'top_three_relievers_10d',

--- a/backend/tests/test_story_writer_v1.py
+++ b/backend/tests/test_story_writer_v1.py
@@ -294,6 +294,70 @@ def test_writer_outputs_concentration_pressure_observation():
     assert_quality_sections(output)
 
 
+def test_writer_voices_distribution_aware_baseline_when_available():
+    frame = frame_for(team_context(concentration={
+        'concentration_band': 'narrow',
+        'top_three_workload_share_10d': 94.0,
+        'league_top_three_workload_share_10d': 58.0,
+        'top_three_share_delta_vs_league': 36.0,
+        'bullpen_workload_total_10d': 240,
+        'baseline_read': {'available': True, 'metric': 'top_share', 'comparison': 'among_highest'},
+    }), TYPE_CONCENTRATION_PRESSURE)
+
+    text = written_text(write_story_frame(frame))
+
+    assert 'among the more concentrated workloads in baseball recently' in text
+    # The distribution-aware read replaces the raw league-average line (no stacking).
+    assert 'The league comparison is' not in text
+    assert '36 percentage points' not in text
+
+
+def test_writer_voices_well_above_average_baseline():
+    frame = frame_for(team_context(concentration={
+        'concentration_band': 'concentrated',
+        'top_three_workload_share_10d': 65.0,
+        'league_top_three_workload_share_10d': 48.0,
+        'top_three_share_delta_vs_league': 17.0,
+        'bullpen_workload_total_10d': 200,
+        'baseline_read': {'available': True, 'metric': 'top_share', 'comparison': 'well_above_average'},
+    }), TYPE_CONCENTRATION_PRESSURE)
+
+    text = written_text(write_story_frame(frame))
+
+    assert 'well above the league norm' in text
+
+
+def test_writer_falls_back_to_league_average_when_baseline_guarded():
+    frame = frame_for(team_context(concentration={
+        'concentration_band': 'narrow',
+        'top_three_workload_share_10d': 94.0,
+        'league_top_three_workload_share_10d': 58.0,
+        'top_three_share_delta_vs_league': 36.0,
+        'bullpen_workload_total_10d': 240,
+        'baseline_read': {'available': False, 'comparison': 'insufficient_sample'},
+    }), TYPE_CONCENTRATION_PRESSURE)
+
+    text = written_text(write_story_frame(frame))
+
+    # Guarded read -> existing behavior preserved, no distribution-aware sentence.
+    assert '58%' in text
+    assert 'league norm' not in text
+    assert 'among the more concentrated' not in text
+
+
+def test_baseline_story_language_has_no_ranking_or_recommendation_terms():
+    from services.story_writer_v1 import _CONCENTRATION_BASELINE_SENTENCE
+
+    forbidden = (
+        'highest', '#1', 'top-ranked', 'league-leading', 'most concentrated',
+        'worst', 'best', 'rank', 'recommend', 'should', 'predict', 'will ',
+    )
+    for sentence in _CONCENTRATION_BASELINE_SENTENCE.values():
+        lowered = sentence.lower()
+        for term in forbidden:
+            assert term not in lowered, (sentence, term)
+
+
 def test_writer_outputs_optionality_strength_observation():
     frame = frame_for(team_context(optionality={
         'optionality_band': 'deep',


### PR DESCRIPTION
… story

Answer "compared to what?" in the canonical workload concentration story (concentration_pressure -> sustainability_question) by interpreting the team's top-three workload share against the league distribution, using the existing baseline infrastructure and engine. The story uses a 10-day concentration window, so this builds a 10-day-aligned distribution rather than reusing the 7-day dashboard.baselines.

- bullpen_concentration_context: build_league_bullpen_concentration_baseline now also returns a 10-day top-three-share distribution from the per-team shares it already collects; the per-team context attaches a baseline_read (baseline_engine.interpret_value) of its top-three share against that distribution.
- Story construction threads baseline_read into the concentration frame's baseline_facts; the writer voices the comparison band in the existing baseline beat with descriptive, governed phrasing, replacing the raw league-average line (never both, to avoid stacked "vs league" statements).
- Guarded reads (insufficient_sample, malformed, unavailable) and older snapshots without a distribution fall back to the existing behavior; the story always degrades gracefully.

Governance preserved: descriptive league context only — no rankings, selections, predictions, recommendations, or superlative-singular ("highest"/"most") language; ranking_applied and selection_made stay false and the canonical feed item shape is unchanged.

Tests cover the league distribution, the per-team baseline_read (band, thin-sample guard, missing-distribution fallback), the writer's band voicing and guarded fallback, and a language guard on the baseline copy.