### PR TITLE
Add clean-options league baseline context to the trust-lane story

### DIFF
--- a/backend/services/bullpen_context.py
+++ b/backend/services/bullpen_context.py
@@ -5,6 +5,7 @@ Internal diagnostic evidence only. This module does not render product copy,
 select stories, rank teams, alter observations, or infer causality.
 """
 
+from collections import defaultdict
 from datetime import date, timedelta
 
 from models.game_log import GameLog
@@ -29,6 +30,7 @@ from services.availability_population import current_availability_records
 from services.availability_snapshot import latest_fatigue_rows
 from services.bullpen_optionality_context import (
     build_bullpen_optionality_context,
+    build_league_clean_options_baseline,
     empty_bullpen_optionality_context,
 )
 from services.bullpen_population import usage_logs_by_pitcher
@@ -384,6 +386,32 @@ def _optionality_records(team_id, reference_date):
     return current_availability_records(rows, reference_date=reference_date)
 
 
+def _league_clean_options_baseline(reference_date):
+    records = current_availability_records(
+        latest_fatigue_rows(),
+        reference_date=reference_date,
+    )
+    records_by_team = defaultdict(list)
+    pitcher_ids = []
+    for record in records:
+        pitcher = record.get('pitcher')
+        if pitcher is None or pitcher.team_id is None:
+            continue
+        records_by_team[pitcher.team_id].append(record)
+        pitcher_ids.append(pitcher.id)
+    logs_by_pitcher = usage_logs_by_pitcher(
+        pitcher_ids,
+        days=ACTIVE_WINDOW_DAYS,
+        include_stale=False,
+        reference_date=reference_date,
+    )
+    return build_league_clean_options_baseline(
+        records_by_team,
+        logs_by_pitcher=logs_by_pitcher,
+        reference_date=reference_date,
+    )
+
+
 def _bullpen_optionality_context(team_id, reference_date):
     records = _optionality_records(team_id, reference_date)
     pitcher_ids = [
@@ -397,10 +425,12 @@ def _bullpen_optionality_context(team_id, reference_date):
         include_stale=False,
         reference_date=reference_date,
     )
+    league_baseline = _league_clean_options_baseline(reference_date)
     return build_bullpen_optionality_context(
         records,
         logs_by_pitcher=logs_by_pitcher,
         reference_date=reference_date,
+        league_baseline=league_baseline,
     )
 
 

--- a/backend/services/bullpen_optionality_context.py
+++ b/backend/services/bullpen_optionality_context.py
@@ -20,6 +20,8 @@ from services.availability import (
     STATUS_UNAVAILABLE,
 )
 from services.availability_reference_date import product_current_date
+from services.baseline_distribution import build_distribution
+from services.baseline_engine import interpret_value
 from services.workload_appearance import workload_appearance_logs
 
 
@@ -247,7 +249,27 @@ def _sort_options(options):
     )
 
 
-def _empty_context(reference_date=None):
+CLEAN_OPTIONS_BASELINE_METRIC = 'clean_trusted_options'
+
+
+def _league_clean_options_distribution(league_baseline):
+    if isinstance(league_baseline, dict):
+        return league_baseline.get('clean_workload_options_distribution')
+    return None
+
+
+def _clean_options_baseline_read(clean_count, league_baseline):
+    # Distribution-aware league read for the current clean-options count. The
+    # shared baseline engine owns the interpretation; this only feeds it the team
+    # value and the current-snapshot league distribution (higher is deeper).
+    return interpret_value(
+        CLEAN_OPTIONS_BASELINE_METRIC,
+        clean_count,
+        _league_clean_options_distribution(league_baseline),
+    )
+
+
+def _empty_context(reference_date=None, league_baseline=None):
     ref = _date_value(reference_date)
     return {
         'capability': CAPABILITY,
@@ -263,6 +285,7 @@ def _empty_context(reference_date=None):
         'unavailable_arms_count': 0,
         'unknown_status_count': 0,
         'clean_workload_options': [],
+        'baseline_read': _clean_options_baseline_read(None, league_baseline),
         'secondary_options': [],
         'practical_close_game_paths_count': 0,
         'optionality_band': OPTIONALITY_INSUFFICIENT_DATA,
@@ -283,11 +306,12 @@ def build_bullpen_optionality_context(
     *,
     logs_by_pitcher=None,
     reference_date=None,
+    league_baseline=None,
 ):
     """Build Bullpen Optionality Context Layer 3 from availability records."""
     rows = list(records or [])
     if not rows:
-        return _empty_context(reference_date=reference_date)
+        return _empty_context(reference_date=reference_date, league_baseline=league_baseline)
 
     ref = _reference_date(rows, reference_date=reference_date)
     logs_by_pitcher = logs_by_pitcher or {}
@@ -349,6 +373,7 @@ def build_bullpen_optionality_context(
         'unavailable_arms_count': counts[STATUS_UNAVAILABLE],
         'unknown_status_count': unknown_status_count,
         'clean_workload_options': _sort_options(clean_options),
+        'baseline_read': _clean_options_baseline_read(len(clean_options), league_baseline),
         'secondary_options': _sort_options(secondary_options),
         'practical_close_game_paths_count': practical_paths,
         'optionality_band': band,
@@ -361,6 +386,32 @@ def build_bullpen_optionality_context(
             'band': band,
         },
         'limitations': limitations,
+    }
+
+
+def build_league_clean_options_baseline(records_by_team, *, logs_by_pitcher=None, reference_date=None):
+    """Current-snapshot league distribution of clean_workload_options_count.
+
+    ``records_by_team`` maps team_id -> that team's current availability records.
+    Every team with usable availability data contributes its clean-options count
+    (including 0, which is a real thin value, not missing data), so the league
+    distribution describes exactly the count the trust-lane story narrates. This
+    is a current snapshot, not a rolling window, and is independent of the 7-day
+    dashboard.baselines and the 10-day workload concentration distribution.
+    """
+    counts = []
+    for team_records in (records_by_team or {}).values():
+        context = build_bullpen_optionality_context(
+            team_records,
+            logs_by_pitcher=logs_by_pitcher,
+            reference_date=reference_date,
+        )
+        if context.get('context_available') is not True:
+            continue
+        counts.append(context['optionality_summary_inputs']['clean_count'])
+    return {
+        'clean_workload_options_distribution': build_distribution(counts),
+        'league_team_count': len(counts),
     }
 
 

--- a/backend/services/story_construction_engine.py
+++ b/backend/services/story_construction_engine.py
@@ -473,6 +473,7 @@ def _trust_lane_pressure_frame(team_context, observation):
         'available_arms_count': optionality.get('available_arms_count'),
         'monitor_arms_count': optionality.get('monitor_arms_count'),
         'restricted_arms_count': optionality.get('restricted_arms_count'),
+        'baseline_read': optionality.get('baseline_read'),
     }
     frame['cause_facts'] = {
         'clean_workload_options': clean,

--- a/backend/services/story_writer_v1.py
+++ b/backend/services/story_writer_v1.py
@@ -718,6 +718,35 @@ def _depth_pressure(frame):
     )
 
 
+# Distribution-aware league phrasing for the trust-lane story's baseline beat.
+# Clean options is better-is-higher, so the engine's value-neutral position bands
+# read as lane depth: a below-average clean-options count is a thinner trusted
+# lane, an above-average one is deeper. Descriptive context only — no rank,
+# recommendation, prediction, or superlative-singular ("deepest"/"most") language
+# (governance C1H). Kept separate from the concentration phrasing on purpose.
+_CLEAN_OPTIONS_BASELINE_SENTENCE = {
+    'below_average': 'That trusted group is thinner than the league norm',
+    'about_typical': 'That trusted group is about as deep as the league norm',
+    'above_average': 'That trusted group is deeper than the league norm',
+    'well_above_average': 'That trusted group sits well above the league norm',
+    'among_highest': 'That trusted group is among the deeper clean-options groups in baseball',
+}
+
+
+def _clean_options_band(baseline):
+    """The supported comparison band, only when the baseline read is available."""
+    read = baseline.get('baseline_read') if isinstance(baseline, dict) else None
+    if not isinstance(read, dict) or read.get('available') is not True:
+        return None
+    comparison = read.get('comparison')
+    return comparison if comparison in _CLEAN_OPTIONS_BASELINE_SENTENCE else None
+
+
+def _clean_options_baseline_sentence(baseline):
+    band = _clean_options_band(baseline)
+    return _CLEAN_OPTIONS_BASELINE_SENTENCE.get(band) if band else None
+
+
 def _trust_lane_pressure(frame):
     team = _team(frame)
     headline = _facts(frame, 'headline_facts')
@@ -761,9 +790,13 @@ def _trust_lane_pressure(frame):
             ),
         ),
         baseline_paragraph=_paragraph(
+            # Distribution-aware league read of the clean-options count when
+            # available; otherwise fall back to the board-vs-lane comparison
+            # (never both, to avoid stacking two competing "comparison" lines).
+            _clean_options_baseline_sentence(baseline),
             (
                 f"The comparison point is the {_fmt(available)}-arm available board set against a thinner trusted late-inning lane"
-                if _present(available) else None
+                if _present(available) and not _clean_options_band(baseline) else None
             ),
             (
                 f"Set against that board, the workload-flagged group numbers {_fmt(secondary_count)}"

--- a/backend/tests/test_bullpen_context.py
+++ b/backend/tests/test_bullpen_context.py
@@ -108,6 +108,7 @@ BULLPEN_OPTIONALITY_CONTEXT_KEYS = {
     'unavailable_arms_count',
     'unknown_status_count',
     'clean_workload_options',
+    'baseline_read',
     'secondary_options',
     'practical_close_game_paths_count',
     'optionality_band',

--- a/backend/tests/test_bullpen_optionality_context.py
+++ b/backend/tests/test_bullpen_optionality_context.py
@@ -12,6 +12,7 @@ from services.bullpen_optionality_context import (
     CAPABILITY,
     NO_OPTIONALITY_DATA_LIMITATION,
     build_bullpen_optionality_context,
+    build_league_clean_options_baseline,
 )
 
 
@@ -235,3 +236,111 @@ def test_doubleheader_workload_inputs_do_not_duplicate_bullpen_paths():
     assert result['secondary_options'][0]['player_id'] == 1
     assert result['practical_close_game_paths_count'] == 1
     assert result['optionality_band'] == 'thin'
+
+
+# Current-snapshot league distribution of the clean-options count: teams typically
+# carry three clean arms, so one is below the norm and five is among the deepest.
+_LEAGUE_CLEAN_OPTIONS = {
+    'clean_workload_options_distribution': {
+        'sample_count': 28, 'mean': 3.0, 'median': 3.0,
+        'p10': 1.0, 'p25': 2.0, 'p75': 4.0, 'p90': 5.0,
+    },
+    'league_team_count': 28,
+}
+
+
+def test_league_clean_options_baseline_builds_distribution_from_team_counts():
+    records_by_team = {
+        1: [record(1, name='A1'), record(2, name='A2')],  # 2 clean
+        2: [record(11, name='B1')],  # 1 clean
+        3: [record(21, status=STATUS_MONITOR, name='C1', reasons=['recent workload'])],  # 0 clean
+    }
+
+    baseline = build_league_clean_options_baseline(records_by_team, reference_date=REF)
+
+    assert baseline['league_team_count'] == 3
+    distribution = baseline['clean_workload_options_distribution']
+    assert distribution['sample_count'] == 3
+    assert distribution['median'] == 1.0
+    assert round(distribution['mean'], 2) == 1.0
+
+
+def test_league_clean_options_baseline_skips_teams_without_records():
+    records_by_team = {
+        1: [record(1, name='A1'), record(2, name='A2')],  # 2 clean
+        2: [],  # no records -> context unavailable -> not counted
+    }
+
+    baseline = build_league_clean_options_baseline(records_by_team, reference_date=REF)
+
+    assert baseline['league_team_count'] == 1
+    assert baseline['clean_workload_options_distribution']['sample_count'] == 1
+
+
+def test_baseline_read_marks_thin_clean_options_below_league_norm():
+    result = build_bullpen_optionality_context(
+        [
+            record(1, name='Clean One'),
+            record(2, status=STATUS_MONITOR, name='Monitor', reasons=['recent workload']),
+        ],
+        reference_date=REF,
+        league_baseline=_LEAGUE_CLEAN_OPTIONS,
+    )
+
+    read = result['baseline_read']
+    assert read['available'] is True
+    assert read['metric'] == 'clean_trusted_options'
+    assert read['comparison'] == 'below_average'
+    assert read['value'] == 1.0
+
+
+def test_baseline_read_marks_deep_clean_options_against_league_norm():
+    records = [record(player_id, name=f'Clean {player_id}') for player_id in range(1, 6)]
+
+    result = build_bullpen_optionality_context(
+        records,
+        reference_date=REF,
+        league_baseline=_LEAGUE_CLEAN_OPTIONS,
+    )
+
+    read = result['baseline_read']
+    assert read['available'] is True
+    assert read['comparison'] == 'among_highest'
+    assert read['value'] == 5.0
+
+
+def test_baseline_read_guards_on_thin_league_sample():
+    thin = {
+        'clean_workload_options_distribution': {
+            'sample_count': 3, 'mean': 2.0, 'median': 2.0,
+            'p10': 1.0, 'p25': 1.0, 'p75': 3.0, 'p90': 3.0,
+        },
+        'league_team_count': 3,
+    }
+
+    result = build_bullpen_optionality_context(
+        [record(1, name='Clean One')],
+        reference_date=REF,
+        league_baseline=thin,
+    )
+
+    assert result['baseline_read']['available'] is False
+    assert result['baseline_read']['comparison'] == 'insufficient_sample'
+
+
+def test_baseline_read_without_distribution_degrades_gracefully():
+    # A legacy-shaped league baseline (no distribution) must not crash the context.
+    result = build_bullpen_optionality_context(
+        [record(1, name='Clean One')],
+        reference_date=REF,
+        league_baseline={'league_team_count': 5},
+    )
+
+    assert result['baseline_read']['available'] is False
+
+
+def test_empty_context_carries_unavailable_baseline_read():
+    result = context([])
+
+    assert result['baseline_read']['available'] is False
+    assert result['baseline_read']['comparison'] == 'unavailable'

--- a/backend/tests/test_story_writer_v1.py
+++ b/backend/tests/test_story_writer_v1.py
@@ -358,6 +358,70 @@ def test_baseline_story_language_has_no_ranking_or_recommendation_terms():
             assert term not in lowered, (sentence, term)
 
 
+def test_writer_voices_clean_options_below_norm_baseline():
+    optionality = _trust_lane_optionality(clean=1, secondary=5, available=6)
+    optionality['baseline_read'] = {
+        'available': True, 'metric': 'clean_trusted_options', 'comparison': 'below_average',
+    }
+    frame = frame_for(team_context(optionality=optionality), TYPE_TRUST_LANE_PRESSURE)
+
+    text = written_text(write_story_frame(frame))
+
+    assert 'thinner than the league norm' in text
+    # The distribution-aware read replaces the board-vs-lane comparison line.
+    assert 'The comparison point is the' not in text
+
+
+def test_writer_voices_deeper_clean_options_baseline():
+    optionality = _trust_lane_optionality(clean=1, secondary=5, available=6)
+    optionality['baseline_read'] = {
+        'available': True, 'metric': 'clean_trusted_options', 'comparison': 'above_average',
+    }
+    frame = frame_for(team_context(optionality=optionality), TYPE_TRUST_LANE_PRESSURE)
+
+    text = written_text(write_story_frame(frame))
+
+    assert 'deeper than the league norm' in text
+
+
+def test_writer_falls_back_to_board_comparison_when_clean_options_baseline_guarded():
+    optionality = _trust_lane_optionality(clean=1, secondary=5, available=6)
+    optionality['baseline_read'] = {'available': False, 'comparison': 'insufficient_sample'}
+    frame = frame_for(team_context(optionality=optionality), TYPE_TRUST_LANE_PRESSURE)
+
+    text = written_text(write_story_frame(frame))
+
+    # Guarded read -> existing behavior preserved, no distribution-aware sentence.
+    assert 'The comparison point is the 6-arm available board' in text
+    assert 'league norm' not in text
+
+
+def test_writer_trust_lane_without_baseline_read_keeps_board_comparison():
+    # No baseline_read at all (legacy frame) still produces the board comparison.
+    frame = frame_for(
+        team_context(optionality=_trust_lane_optionality(clean=1, secondary=5, available=6)),
+        TYPE_TRUST_LANE_PRESSURE,
+    )
+
+    text = written_text(write_story_frame(frame))
+
+    assert 'The comparison point is the 6-arm available board' in text
+    assert 'league norm' not in text
+
+
+def test_clean_options_baseline_language_has_no_ranking_or_recommendation_terms():
+    from services.story_writer_v1 import _CLEAN_OPTIONS_BASELINE_SENTENCE
+
+    forbidden = (
+        'highest', 'deepest', '#1', 'top-ranked', 'league-leading', 'most',
+        'worst', 'best', 'rank', 'recommend', 'should', 'predict', 'will ',
+    )
+    for sentence in _CLEAN_OPTIONS_BASELINE_SENTENCE.values():
+        lowered = sentence.lower()
+        for term in forbidden:
+            assert term not in lowered, (sentence, term)
+
+
 def test_writer_outputs_optionality_strength_observation():
     frame = frame_for(team_context(optionality={
         'optionality_band': 'deep',


### PR DESCRIPTION
Integrate a distribution-aware "compared to what?" read of the current clean_workload_options count into the canonical trust-lane pressure story.

- bullpen_optionality_context: build a per-snapshot baseline_read for the clean-options count against a current league distribution, and add build_league_clean_options_baseline to summarize that league snapshot. The read is transient context only and is never serialized onto the feed.
- bullpen_context: build the league clean-options snapshot once and thread it into the optionality context, mirroring the workload-concentration baseline wiring.
- story_construction_engine: carry baseline_read into the trust-lane frame baseline_facts.
- story_writer_v1: voice a governed league sentence in the trust-lane baseline beat (thinner/deeper than league norm), falling back to the existing board comparison when the read is guarded or unavailable.

Clean options is better-is-higher, so the engine's value-neutral position bands are mapped to lane-depth language without rank, recommendation, or prediction. No UI or feed-shape changes; ranking_applied and selection_made stay false.