### PR TITLE
Add clean-options league baseline context to the optionality-strength…

### DIFF
--- a/backend/services/story_construction_engine.py
+++ b/backend/services/story_construction_engine.py
@@ -272,6 +272,7 @@ def _optionality_strength_frame(team_context, observation):
         'available_arms_count': optionality.get('available_arms_count'),
         'monitor_arms_count': optionality.get('monitor_arms_count'),
         'restricted_arms_count': optionality.get('restricted_arms_count'),
+        'baseline_read': optionality.get('baseline_read'),
     }
     frame['cause_facts'] = {
         'clean_workload_options': clean,

--- a/backend/services/story_writer_v1.py
+++ b/backend/services/story_writer_v1.py
@@ -423,6 +423,25 @@ def _concentration_pressure(frame):
     )
 
 
+# Distribution-aware league phrasing for the positive optionality/depth story's
+# baseline beat. Same clean-options metric and bands as the trust-lane story, but
+# voiced for a healthy-depth narrative (better-is-higher). Descriptive context
+# only — no rank, recommendation, prediction, or superlative-singular language
+# (governance C1I). Reuses the shared C1H band reader; does not recompute the read.
+_OPTIONALITY_DEPTH_BASELINE_SENTENCE = {
+    'below_average': 'That is still thinner than the league norm',
+    'about_typical': 'That is about as deep as a typical bullpen',
+    'above_average': 'That is deeper than the league norm',
+    'well_above_average': 'That clean lane sits well above the league norm',
+    'among_highest': 'That puts them among the deeper clean-options groups in baseball',
+}
+
+
+def _optionality_depth_baseline_sentence(baseline):
+    band = _clean_options_band(baseline)
+    return _OPTIONALITY_DEPTH_BASELINE_SENTENCE.get(band) if band else None
+
+
 def _optionality_strength(frame):
     team = _team(frame)
     headline = _facts(frame, 'headline_facts')
@@ -469,6 +488,10 @@ def _optionality_strength(frame):
                 f"There are {_fmt(clean_count)} low-workload late-inning {_count_word(clean_count, 'choice', 'choices')}"
                 if _present(clean_count) and clean_count > 0 else None
             ),
+            # Distribution-aware league depth read of the clean-options count,
+            # enriching the internal counts above with "compared to what?" context.
+            # Absent or guarded reads return None and leave the copy unchanged.
+            _optionality_depth_baseline_sentence(baseline),
         ),
         cause_paragraph=_paragraph(
             (

--- a/backend/tests/test_story_construction_engine.py
+++ b/backend/tests/test_story_construction_engine.py
@@ -230,6 +230,23 @@ def test_construction_frame_for_optionality_strength():
     assert story_frame['interpretation_facts']['concentration_band'] == 'normal'
 
 
+def test_construction_threads_baseline_read_into_optionality_strength_frame():
+    read = {'available': True, 'metric': 'clean_trusted_options', 'comparison': 'above_average'}
+    context = team_context(optionality={
+        'optionality_band': 'deep',
+        'practical_close_game_paths_count': 6,
+        'available_arms_count': 7,
+        'clean_workload_options': [{'name': 'Clean One'}, {'name': 'Clean Two'}],
+        'secondary_options': [{'name': 'Secondary One'}],
+        'baseline_read': read,
+    })
+
+    frame = single_frame(context, TYPE_OPTIONALITY_STRENGTH)
+
+    # Transient league read is carried into the frame for the writer, not onto the feed.
+    assert frame['story_frame']['baseline_facts']['baseline_read'] == read
+
+
 def test_construction_frame_for_stable_core():
     context = team_context(stability={
         'stability_band': 'stable',

--- a/backend/tests/test_story_writer_v1.py
+++ b/backend/tests/test_story_writer_v1.py
@@ -444,6 +444,86 @@ def test_writer_outputs_optionality_strength_observation():
     assert_quality_sections(output)
 
 
+def _optionality_strength_optionality(*, comparison=None, available=True):
+    optionality = {
+        'optionality_band': 'deep',
+        'practical_close_game_paths_count': 6,
+        'available_arms_count': 7,
+        'clean_workload_options': [{'name': 'Clean One'}, {'name': 'Clean Two'}],
+        'secondary_options': [{'name': 'Secondary One'}],
+    }
+    if comparison is not None or available is False:
+        read = {'available': available, 'comparison': comparison}
+        if available:
+            read['metric'] = 'clean_trusted_options'
+        optionality['baseline_read'] = read
+    return optionality
+
+
+def test_writer_voices_optionality_depth_above_norm_baseline():
+    frame = frame_for(
+        team_context(optionality=_optionality_strength_optionality(comparison='above_average')),
+        TYPE_OPTIONALITY_STRENGTH,
+    )
+
+    text = written_text(write_story_frame(frame))
+
+    # The internal clean-count line is enriched with a league depth read.
+    assert '2 low-workload late-inning choices' in text
+    assert 'deeper than the league norm' in text
+
+
+def test_writer_voices_optionality_depth_among_highest_baseline():
+    frame = frame_for(
+        team_context(optionality=_optionality_strength_optionality(comparison='among_highest')),
+        TYPE_OPTIONALITY_STRENGTH,
+    )
+
+    text = written_text(write_story_frame(frame))
+
+    assert 'among the deeper clean-options groups in baseball' in text
+
+
+def test_writer_optionality_strength_without_baseline_read_keeps_existing_copy():
+    frame = frame_for(
+        team_context(optionality=_optionality_strength_optionality()),
+        TYPE_OPTIONALITY_STRENGTH,
+    )
+
+    text = written_text(write_story_frame(frame))
+
+    assert '2 low-workload late-inning choices' in text
+    assert 'league norm' not in text
+    assert 'among the deeper' not in text
+
+
+def test_writer_optionality_strength_guarded_baseline_keeps_existing_copy():
+    frame = frame_for(
+        team_context(optionality=_optionality_strength_optionality(comparison='insufficient_sample', available=False)),
+        TYPE_OPTIONALITY_STRENGTH,
+    )
+
+    text = written_text(write_story_frame(frame))
+
+    # Guarded read -> existing positive copy preserved, no forced league comparison.
+    assert '2 low-workload late-inning choices' in text
+    assert 'league norm' not in text
+    assert 'among the deeper' not in text
+
+
+def test_optionality_depth_baseline_language_has_no_ranking_or_recommendation_terms():
+    from services.story_writer_v1 import _OPTIONALITY_DEPTH_BASELINE_SENTENCE
+
+    forbidden = (
+        'highest', 'lowest', 'deepest', '#1', 'top-ranked', 'league-leading', 'most',
+        'worst', 'best', 'rank', 'recommend', 'should', 'likely to', 'projected', 'predict', 'will ',
+    )
+    for sentence in _OPTIONALITY_DEPTH_BASELINE_SENTENCE.values():
+        lowered = sentence.lower()
+        for term in forbidden:
+            assert term not in lowered, (sentence, term)
+
+
 def test_writer_outputs_stable_core_observation():
     frame = frame_for(team_context(stability={
         'stability_band': 'stable',


### PR DESCRIPTION
… story

Extend the C1H clean-options "compared to what?" read from the trust-lane pressure story to its positive counterpart, the optionality-strength depth story, so a healthy clean-options count can also be framed against the league.

- story_construction_engine: carry the existing transient baseline_read into the optionality-strength frame baseline_facts (no new read computed).
- story_writer_v1: voice a governed positive-depth league sentence in the optionality-strength baseline beat (deeper/typical/thinner than the league norm), reusing the shared clean-options band reader. Absent or guarded reads leave the existing depth copy untouched.

Reuses the C1H baseline_read, baseline_distribution, and baseline_engine; no new baseline system, story engine, or feed. baseline_read stays transient and is not serialized onto canonical feed items. No UI or feed-shape changes; ranking_applied and selection_made stay false.