### PR TITLE
Add rotation length league baseline context to the rotation-pressure …

### DIFF
--- a/backend/services/bullpen_context.py
+++ b/backend/services/bullpen_context.py
@@ -35,7 +35,11 @@ from services.bullpen_optionality_context import (
 )
 from services.bullpen_population import usage_logs_by_pitcher
 from services.injury_context import build_injury_context, empty_injury_context
-from services.rotation_context import build_rotation_context
+from services.rotation_context import (
+    build_league_rotation_baseline,
+    build_rotation_context,
+    rotation_length_baseline_read,
+)
 from services.role_stability_context import (
     build_role_stability_context,
     empty_role_stability_context,
@@ -243,12 +247,21 @@ def _demand_trend(last_appearances, prev_appearances, last_pitches, prev_pitches
     return 'mixed_demand'
 
 
+def _league_rotation_baseline(windows):
+    last = windows['last_7']
+    return build_league_rotation_baseline(
+        _league_logs(last['start_date'], last['end_date']),
+        reference_date=last['end_date'],
+    )
+
+
 def _rotation_context(last_logs, prev_logs, windows):
     all_logs = [*(last_logs or []), *(prev_logs or [])]
     layer1 = build_rotation_context(
         all_logs,
         reference_date=windows['last_7']['end_date'] if windows else None,
     )
+    league_baseline = _league_rotation_baseline(windows) if windows else None
     signal = _start_signal_fields(all_logs)
     last_starts = _starter_logs(last_logs)
     prev_starts = _starter_logs(prev_logs)
@@ -278,6 +291,7 @@ def _rotation_context(last_logs, prev_logs, windows):
         'rotation_games_analyzed_14d': layer1['games_analyzed_14d'],
         'rotation_games_excluded_14d': layer1['games_excluded_14d'],
         'rotation_early_bullpen_entry_games_14d': layer1['early_bullpen_entry_games_14d'],
+        'baseline_read': rotation_length_baseline_read(layer1['rotation_avg_ip_7d'], league_baseline),
         'rotation_context_layer': layer1,
         **signal,
     }
@@ -304,6 +318,7 @@ def _empty_rotation_context(windows=None):
         'rotation_games_analyzed_14d': 0,
         'rotation_games_excluded_14d': 0,
         'rotation_early_bullpen_entry_games_14d': 0,
+        'baseline_read': rotation_length_baseline_read(None, None),
         'rotation_context_layer': None,
         'start_classification_state': 'complete',
         'unknown_start_rows': 0,

--- a/backend/services/rotation_context.py
+++ b/backend/services/rotation_context.py
@@ -12,6 +12,8 @@ from datetime import date, datetime, timedelta
 from typing import Any
 
 from services.availability_reference_date import product_current_date
+from services.baseline_distribution import build_distribution
+from services.baseline_engine import interpret_value
 from utils.games_started import RELIEF, START, games_started_state
 from utils.innings import log_innings_outs, outs_to_decimal_innings
 
@@ -253,6 +255,62 @@ def build_rotation_context(logs, *, reference_date=None):
     }
 
 
+ROTATION_LENGTH_BASELINE_METRIC = 'rotation_avg_ip_7d'
+
+
+def _team_id(log: Any):
+    pitcher = _value(log, 'pitcher')
+    return _value(pitcher, 'team_id') or _value(log, 'team_id')
+
+
+def build_league_rotation_baseline(logs, *, reference_date=None):
+    """Current 7-day-window league distribution of rotation_avg_ip_7d.
+
+    Groups raw league game logs by team and reuses ``build_rotation_context`` so
+    each team's rotation_avg_ip_7d is derived with the exact same starter-IP and
+    start-classification logic as the per-team story value (one value per team).
+    Teams without a usable 7-day rotation_avg_ip_7d are skipped, not counted low.
+    This is a dedicated rotation distribution: independent of dashboard.baselines,
+    the workload-concentration distribution, and the clean-options distribution.
+    """
+    by_team = defaultdict(list)
+    for log in logs or []:
+        team_id = _team_id(log)
+        if team_id is None:
+            continue
+        by_team[team_id].append(log)
+
+    values = []
+    for team_logs in by_team.values():
+        context = build_rotation_context(team_logs, reference_date=reference_date)
+        avg_7d = context.get('rotation_avg_ip_7d')
+        if avg_7d is None:
+            continue
+        values.append(avg_7d)
+
+    return {
+        'rotation_avg_ip_7d_distribution': build_distribution(values),
+        'league_team_count': len(values),
+    }
+
+
+def _league_rotation_distribution(league_baseline):
+    if isinstance(league_baseline, dict):
+        return league_baseline.get('rotation_avg_ip_7d_distribution')
+    return None
+
+
+def rotation_length_baseline_read(avg_7d, league_baseline):
+    # Distribution-aware league read of the team's recent starter length. The
+    # shared baseline engine owns the interpretation; this only feeds it the team
+    # value and the current 7-day league distribution (longer starts are deeper).
+    return interpret_value(
+        ROTATION_LENGTH_BASELINE_METRIC,
+        avg_7d,
+        _league_rotation_distribution(league_baseline),
+    )
+
+
 __all__ = [
     'CAPABILITY',
     'CURRENT_ASSIGNMENT_LIMITATION',
@@ -262,6 +320,9 @@ __all__ = [
     'OPENER_BULK_LIMITATION',
     'ROTATION_CONTEXT_7D',
     'ROTATION_CONTEXT_14D',
+    'ROTATION_LENGTH_BASELINE_METRIC',
     'VERSION',
+    'build_league_rotation_baseline',
     'build_rotation_context',
+    'rotation_length_baseline_read',
 ]

--- a/backend/services/story_construction_engine.py
+++ b/backend/services/story_construction_engine.py
@@ -160,6 +160,7 @@ def _rotation_pressure_frame(team_context, observation):
     frame['baseline_facts'] = {
         'rotation_avg_ip_14d': rotation.get('rotation_avg_ip_14d'),
         'rotation_games_analyzed_14d': rotation.get('rotation_games_analyzed_14d'),
+        'baseline_read': rotation.get('baseline_read'),
     }
     frame['cause_facts'] = {
         'bullpen_coverage_ip_7d': rotation.get('bullpen_coverage_ip_7d'),

--- a/backend/services/story_writer_v1.py
+++ b/backend/services/story_writer_v1.py
@@ -244,6 +244,35 @@ def validate_written_observation(output):
     }
 
 
+# Distribution-aware league phrasing for the rotation-pressure story's baseline
+# beat. rotation_avg_ip_7d is better-is-higher (longer starts ease bullpen load),
+# so the engine's value-neutral position bands read as starter length: a
+# below-average 7-day average is shorter than the league norm. Descriptive
+# context only — no rank, recommendation, prediction, or superlative-singular
+# ("longest"/"most") language (governance C1K).
+_ROTATION_LENGTH_BASELINE_SENTENCE = {
+    'below_average': 'That is shorter than the league norm for starter length',
+    'about_typical': 'That is around the league norm for starter length',
+    'above_average': 'That is longer than the league norm for starter length',
+    'well_above_average': 'That is well above the league norm for starter length',
+    'among_highest': 'That recent starter length is among the longer rotations in baseball',
+}
+
+
+def _rotation_length_band(baseline):
+    """The supported comparison band, only when the baseline read is available."""
+    read = baseline.get('baseline_read') if isinstance(baseline, dict) else None
+    if not isinstance(read, dict) or read.get('available') is not True:
+        return None
+    comparison = read.get('comparison')
+    return comparison if comparison in _ROTATION_LENGTH_BASELINE_SENTENCE else None
+
+
+def _rotation_length_baseline_sentence(baseline):
+    band = _rotation_length_band(baseline)
+    return _ROTATION_LENGTH_BASELINE_SENTENCE.get(band) if band else None
+
+
 def _rotation_pressure(frame):
     team = _team(frame)
     headline = _facts(frame, 'headline_facts')
@@ -277,13 +306,18 @@ def _rotation_pressure(frame):
             ),
         ),
         baseline_paragraph=_paragraph(
+            # Distribution-aware league read of recent starter length when
+            # available; adds "compared to what?" context alongside the team's own
+            # 14-day mark. The seven-day restate is dropped when the league read is
+            # present (it already anchors the seven-day value) to avoid stacking.
+            _rotation_length_baseline_sentence(baseline),
             (
                 f"The comparison point is {_fmt(avg_14)} starter innings over the full 14-day window"
                 if _present(avg_14) else None
             ),
             (
                 f"The current seven-day handoff is {_fmt(avg_7)} innings"
-                if _present(avg_7) else None
+                if _present(avg_7) and not _rotation_length_band(baseline) else None
             ),
         ),
         cause_paragraph=_paragraph(

--- a/backend/tests/test_bullpen_context.py
+++ b/backend/tests/test_bullpen_context.py
@@ -41,6 +41,7 @@ ROTATION_CONTEXT_KEYS = {
     'rotation_games_analyzed_14d',
     'rotation_games_excluded_14d',
     'rotation_early_bullpen_entry_games_14d',
+    'baseline_read',
     'rotation_context_layer',
     'start_classification_state',
     'unknown_start_rows',

--- a/backend/tests/test_rotation_context.py
+++ b/backend/tests/test_rotation_context.py
@@ -4,7 +4,9 @@ from services.rotation_context import (
     CAPABILITY,
     INCOMPLETE_GAME_DATA_LIMITATION,
     OPENER_BULK_LIMITATION,
+    build_league_rotation_baseline,
     build_rotation_context,
+    rotation_length_baseline_read,
 )
 from utils.innings import outs_to_decimal_innings
 
@@ -131,3 +133,91 @@ def test_games_without_clear_starter_are_excluded_from_context():
     assert result['early_bullpen_entry_rate'] == 0.0
     assert result['bullpen_coverage_ip_7d'] == 3.0
     assert INCOMPLETE_GAME_DATA_LIMITATION in result['limitations']
+
+
+def team_log(team_id, game_pk, days_ago, outs, games_started):
+    row = log(game_pk, days_ago, outs, games_started)
+    row['team_id'] = team_id
+    return row
+
+
+def team_game(team_id, game_pk, days_ago, starter_outs, relief_outs=None):
+    rows = [team_log(team_id, game_pk, days_ago, starter_outs, 1)]
+    if relief_outs is not None:
+        rows.append(team_log(team_id, game_pk, days_ago, relief_outs, 0))
+    return rows
+
+
+# Current 7-day-window league distribution of rotation_avg_ip_7d: a typical
+# rotation runs ~5.2 innings, so 4.0 is short and 6.2 is among the longer.
+_LEAGUE_ROTATION = {
+    'rotation_avg_ip_7d_distribution': {
+        'sample_count': 28, 'mean': 5.2, 'median': 5.3,
+        'p10': 4.2, 'p25': 4.8, 'p75': 5.7, 'p90': 6.1,
+    },
+    'league_team_count': 28,
+}
+
+
+def test_league_rotation_baseline_builds_distribution_from_team_values():
+    logs = [
+        *team_game(1, 101, 1, 18), *team_game(1, 102, 2, 18),  # 6.0 IP
+        *team_game(2, 201, 1, 12), *team_game(2, 202, 2, 12),  # 4.0 IP
+        *team_game(3, 301, 1, 15), *team_game(3, 302, 2, 15),  # 5.0 IP
+    ]
+
+    baseline = build_league_rotation_baseline(logs, reference_date=REF)
+
+    assert baseline['league_team_count'] == 3
+    distribution = baseline['rotation_avg_ip_7d_distribution']
+    assert distribution['sample_count'] == 3
+    assert round(distribution['mean'], 1) == 5.0
+    assert distribution['median'] == 5.0
+
+
+def test_league_rotation_baseline_skips_teams_without_a_seven_day_value():
+    logs = [
+        *team_game(1, 101, 1, 18), *team_game(1, 102, 2, 18),  # 6.0 IP (in 7d)
+        *team_game(2, 201, 10, 18),  # only a game 10 days ago -> no 7d value
+    ]
+
+    baseline = build_league_rotation_baseline(logs, reference_date=REF)
+
+    assert baseline['league_team_count'] == 1
+    assert baseline['rotation_avg_ip_7d_distribution']['sample_count'] == 1
+
+
+def test_rotation_length_baseline_read_marks_short_rotation_below_norm():
+    read = rotation_length_baseline_read(4.0, _LEAGUE_ROTATION)
+
+    assert read['available'] is True
+    assert read['metric'] == 'rotation_avg_ip_7d'
+    assert read['comparison'] == 'below_average'
+    assert read['value'] == 4.0
+
+
+def test_rotation_length_baseline_read_marks_long_rotation_above_norm():
+    read = rotation_length_baseline_read(5.5, _LEAGUE_ROTATION)
+
+    assert read['available'] is True
+    assert read['comparison'] == 'above_average'
+
+
+def test_rotation_length_baseline_read_guards_on_thin_league_sample():
+    thin = {
+        'rotation_avg_ip_7d_distribution': {
+            'sample_count': 3, 'mean': 5.0, 'median': 5.0,
+            'p10': 4.5, 'p25': 4.8, 'p75': 5.2, 'p90': 5.5,
+        },
+        'league_team_count': 3,
+    }
+
+    read = rotation_length_baseline_read(4.0, thin)
+
+    assert read['available'] is False
+    assert read['comparison'] == 'insufficient_sample'
+
+
+def test_rotation_length_baseline_read_without_distribution_degrades_gracefully():
+    assert rotation_length_baseline_read(4.0, {'league_team_count': 5})['available'] is False
+    assert rotation_length_baseline_read(None, None)['available'] is False

--- a/backend/tests/test_story_construction_engine.py
+++ b/backend/tests/test_story_construction_engine.py
@@ -176,6 +176,23 @@ def test_construction_frame_for_rotation_pressure():
     assert story_frame['constraint_facts']['rotation_games_analyzed_14d'] == 12
 
 
+def test_construction_threads_baseline_read_into_rotation_pressure_frame():
+    read = {'available': True, 'metric': 'rotation_avg_ip_7d', 'comparison': 'below_average'}
+    context = team_context(rotation={
+        'rotation_avg_ip_7d': 4.1,
+        'rotation_avg_ip_14d': 5.4,
+        'rotation_ip_trend': -1.3,
+        'early_bullpen_entry_rate': 50.0,
+        'bullpen_coverage_ip_7d': 4.9,
+        'baseline_read': read,
+    })
+
+    frame = single_frame(context, TYPE_ROTATION_PRESSURE)
+
+    # Transient league read is carried into the frame for the writer, not onto the feed.
+    assert frame['story_frame']['baseline_facts']['baseline_read'] == read
+
+
 def test_construction_frame_for_concentration_pressure():
     context = team_context(
         concentration={

--- a/backend/tests/test_story_writer_v1.py
+++ b/backend/tests/test_story_writer_v1.py
@@ -263,6 +263,84 @@ def test_writer_outputs_rotation_pressure_observation():
     assert_quality_sections(output)
 
 
+def _rotation_pressure_rotation(*, comparison=None, available=True):
+    rotation = {
+        'rotation_avg_ip_7d': 4.1,
+        'rotation_avg_ip_14d': 5.4,
+        'rotation_ip_trend': -1.3,
+        'early_bullpen_entry_rate': 50.0,
+        'bullpen_coverage_ip_7d': 4.9,
+    }
+    if comparison is not None or available is False:
+        read = {'available': available, 'comparison': comparison}
+        if available:
+            read['metric'] = 'rotation_avg_ip_7d'
+        rotation['baseline_read'] = read
+    return rotation
+
+
+def test_writer_voices_rotation_length_below_norm_baseline():
+    frame = frame_for(
+        team_context(rotation=_rotation_pressure_rotation(comparison='below_average')),
+        TYPE_ROTATION_PRESSURE,
+    )
+
+    text = written_text(write_story_frame(frame))
+
+    assert 'shorter than the league norm for starter length' in text
+    # The league read anchors the seven-day value, so the restate line is dropped.
+    assert 'seven-day handoff' not in text
+
+
+def test_writer_voices_rotation_length_above_norm_baseline():
+    frame = frame_for(
+        team_context(rotation=_rotation_pressure_rotation(comparison='above_average')),
+        TYPE_ROTATION_PRESSURE,
+    )
+
+    text = written_text(write_story_frame(frame))
+
+    assert 'longer than the league norm for starter length' in text
+
+
+def test_writer_rotation_without_baseline_read_keeps_existing_copy():
+    frame = frame_for(
+        team_context(rotation=_rotation_pressure_rotation()),
+        TYPE_ROTATION_PRESSURE,
+    )
+
+    text = written_text(write_story_frame(frame))
+
+    assert 'The current seven-day handoff is 4.1 innings' in text
+    assert 'league norm' not in text
+
+
+def test_writer_rotation_guarded_baseline_keeps_existing_copy():
+    frame = frame_for(
+        team_context(rotation=_rotation_pressure_rotation(comparison='insufficient_sample', available=False)),
+        TYPE_ROTATION_PRESSURE,
+    )
+
+    text = written_text(write_story_frame(frame))
+
+    # Guarded read -> existing rotation copy preserved, no forced league comparison.
+    assert 'The current seven-day handoff is 4.1 innings' in text
+    assert 'league norm' not in text
+
+
+def test_rotation_length_baseline_language_has_no_ranking_or_recommendation_terms():
+    from services.story_writer_v1 import _ROTATION_LENGTH_BASELINE_SENTENCE
+
+    forbidden = (
+        'highest', 'lowest', 'longest', 'shortest', '#1', 'top-ranked', 'league-leading',
+        'most', 'best', 'worst', 'rank', 'recommend', 'should', 'likely to', 'projected', 'predict', 'will ',
+    )
+    for sentence in _ROTATION_LENGTH_BASELINE_SENTENCE.values():
+        lowered = sentence.lower()
+        for term in forbidden:
+            assert term not in lowered, (sentence, term)
+
+
 def test_writer_outputs_concentration_pressure_observation():
     frame = frame_for(team_context(
         concentration={


### PR DESCRIPTION
…story

Give the rotation-pressure story a governed "compared to what?" read of recent starter length by comparing rotation_avg_ip_7d against a current league distribution.

- rotation_context: add build_league_rotation_baseline (a dedicated current 7-day-window distribution of rotation_avg_ip_7d, one value per team via the same starter-IP and start-classification logic) and rotation_length_baseline_read, reusing baseline_distribution and baseline_engine.
- bullpen_context: build the league rotation baseline once and attach a transient baseline_read to the rotation context, mirroring the concentration wiring.
- story_construction_engine: carry baseline_read into the rotation-pressure frame baseline_facts.
- story_writer_v1: voice a governed league sentence in the rotation-pressure baseline beat (shorter/longer than the league norm), dropping the redundant seven-day restate when the read is present and preserving the existing copy when the read is absent or guarded.

rotation_avg_ip_7d is better-is-higher, so the engine's value-neutral position bands are mapped to starter-length language without rank, recommendation, or prediction. The read is internal/transient and is not serialized onto canonical feed items. No UI or feed-shape changes; ranking_applied and selection_made stay false.