### PR TITLE
Add lead-arm workload league baseline context to the concentration story

### DIFF
--- a/backend/services/bullpen_concentration_context.py
+++ b/backend/services/bullpen_concentration_context.py
@@ -151,6 +151,8 @@ def _empty_context(ref, window_start, league_baseline=None):
         ),
         'top_three_share_delta_vs_league': None,
         'baseline_read': _baseline_read(None, league_baseline),
+        'top_one_workload_share_10d': None,
+        'lead_arm_baseline_read': _lead_arm_baseline_read(None, league_baseline),
         'bullpen_workload_total_10d': 0,
         'concentration_band': CONCENTRATION_INSUFFICIENT_DATA,
         'top_three_relievers_10d': [],
@@ -213,6 +215,23 @@ def _baseline_read(top_three_share, league_baseline):
         'top_share',
         top_three_share,
         _league_baseline_distribution(league_baseline),
+    )
+
+
+def _league_top_one_distribution(league_baseline):
+    if isinstance(league_baseline, dict):
+        return league_baseline.get('top_one_workload_share_distribution_10d')
+    return None
+
+
+def _lead_arm_baseline_read(top_one_share, league_baseline):
+    # Distribution-aware league read for the lead-arm (single most-used reliever)
+    # workload share. Separate from the top-three read; same 10-day percentage
+    # units and the same 10-day league window.
+    return interpret_value(
+        'top_one_share',
+        top_one_share,
+        _league_top_one_distribution(league_baseline),
     )
 
 
@@ -299,6 +318,7 @@ def build_bullpen_concentration_context(
     top_three = relievers[:TOP_RELIEVER_COUNT]
     top_three_total = sum(row['pitches'] for row in top_three)
     top_three_share = _share(top_three_total, total_workload)
+    top_one_share = _share(relievers[0]['pitches'], total_workload)
     league_value = _league_baseline_value(league_baseline)
     league_team_count = (
         (league_baseline or {}).get('league_team_count_10d', 0)
@@ -321,6 +341,8 @@ def build_bullpen_concentration_context(
         'league_top_three_workload_share_10d': league_value,
         'top_three_share_delta_vs_league': _delta(top_three_share, league_value),
         'baseline_read': _baseline_read(top_three_share, league_baseline),
+        'top_one_workload_share_10d': top_one_share,
+        'lead_arm_baseline_read': _lead_arm_baseline_read(top_one_share, league_baseline),
         'bullpen_workload_total_10d': total_workload,
         'concentration_band': concentration_band(top_three_share),
         'top_three_relievers_10d': [
@@ -359,17 +381,24 @@ def build_league_bullpen_concentration_baseline(logs, *, reference_date=None):
         by_team[team_id].append(log)
 
     shares = []
+    top_one_shares = []
     for team_logs in by_team.values():
         context = build_bullpen_concentration_context(team_logs, reference_date=ref)
+        if context.get('bullpen_workload_total_10d', 0) <= 0:
+            continue
         share = context.get('top_three_workload_share_10d')
-        if share is not None and context.get('bullpen_workload_total_10d', 0) > 0:
+        if share is not None:
             shares.append(share)
+        top_one = context.get('top_one_workload_share_10d')
+        if top_one is not None:
+            top_one_shares.append(top_one)
 
     league_share = round(sum(shares) / len(shares), 1) if shares else None
     return {
         'league_top_three_workload_share_10d': league_share,
         'league_team_count_10d': len(shares),
         'top_three_workload_share_distribution_10d': build_distribution(shares),
+        'top_one_workload_share_distribution_10d': build_distribution(top_one_shares),
     }
 
 

--- a/backend/services/story_construction_engine.py
+++ b/backend/services/story_construction_engine.py
@@ -216,6 +216,8 @@ def _concentration_pressure_frame(team_context, observation):
         'top_three_share_delta_vs_league': concentration.get('top_three_share_delta_vs_league'),
         'league_team_count_10d': concentration.get('league_team_count_10d'),
         'baseline_read': concentration.get('baseline_read'),
+        'top_one_workload_share_10d': concentration.get('top_one_workload_share_10d'),
+        'lead_arm_baseline_read': concentration.get('lead_arm_baseline_read'),
     }
     frame['cause_facts'] = {
         'rotation_avg_ip_7d': rotation.get('rotation_avg_ip_7d'),

--- a/backend/services/story_writer_v1.py
+++ b/backend/services/story_writer_v1.py
@@ -369,6 +369,34 @@ def _concentration_baseline_sentence(baseline):
     return _CONCENTRATION_BASELINE_SENTENCE.get(band) if band else None
 
 
+# Secondary distribution-aware phrasing for lead-arm (single most-used reliever)
+# workload reliance, layered under the primary top-three concentration read.
+# top_one_share is higher-is-more-concentrated (not "better"). Descriptive context
+# only — no rank, recommendation, prediction, or superlative-singular
+# ("highest"/"most used") language (governance C1L).
+_LEAD_ARM_BASELINE_SENTENCE = {
+    'below_average': 'The lead arm is carrying less of the workload than a typical bullpen',
+    'about_typical': 'The lead arm is carrying about a typical share of the workload',
+    'above_average': 'The lead arm is carrying more of the workload than a typical bullpen',
+    'well_above_average': 'The lead arm is carrying well above a typical share of the workload',
+    'among_highest': 'The lead arm is near the upper end of recent single-arm workload',
+}
+
+
+def _lead_arm_band(baseline):
+    """The supported lead-arm comparison band, only when its read is available."""
+    read = baseline.get('lead_arm_baseline_read') if isinstance(baseline, dict) else None
+    if not isinstance(read, dict) or read.get('available') is not True:
+        return None
+    comparison = read.get('comparison')
+    return comparison if comparison in _LEAD_ARM_BASELINE_SENTENCE else None
+
+
+def _lead_arm_baseline_sentence(baseline):
+    band = _lead_arm_band(baseline)
+    return _LEAD_ARM_BASELINE_SENTENCE.get(band) if band else None
+
+
 def _concentration_pressure(frame):
     team = _team(frame)
     headline = _facts(frame, 'headline_facts')
@@ -429,6 +457,11 @@ def _concentration_pressure(frame):
                 f"That puts this bullpen {_fmt(delta)} percentage points above that baseline"
                 if _present(delta) and not _baseline_band(baseline) else None
             ),
+            # Secondary, optional lead-arm read: single-arm reliance vs the league,
+            # voiced only when the separate lead-arm baseline read is available. The
+            # top-three comparison above stays primary; absent/guarded reads add
+            # nothing and preserve the existing C1E copy.
+            _lead_arm_baseline_sentence(baseline),
         ),
         cause_paragraph=_paragraph(
             (

--- a/backend/tests/test_bullpen_concentration_context.py
+++ b/backend/tests/test_bullpen_concentration_context.py
@@ -233,3 +233,87 @@ def test_doubleheader_workload_aggregation_counts_distinct_appearances():
     assert result['top_three_relievers_10d'][0]['pitches'] == 25
     assert result['top_three_relievers_10d'][0]['appearances'] == 2
     assert result['top_three_workload_share_10d'] == 88.9
+
+
+_LEAGUE_TOP_ONE = {
+    'top_one_workload_share_distribution_10d': {
+        'sample_count': 28, 'mean': 25.0, 'median': 24.0,
+        'p10': 16.0, 'p25': 20.0, 'p75': 30.0, 'p90': 36.0,
+    },
+}
+
+
+def test_league_baseline_includes_top_one_workload_distribution():
+    team_one = [
+        log(1, 1, 40, team_id=1),
+        log(2, 1, 30, team_id=1),
+        log(3, 2, 30, team_id=1),
+    ]  # lead arm 40 / 100 -> 40.0
+    team_two = [
+        log(11, 1, 80, team_id=2),
+        log(12, 1, 20, team_id=2),
+    ]  # lead arm 80 / 100 -> 80.0
+    baseline = build_league_bullpen_concentration_baseline(
+        [*team_one, *team_two],
+        reference_date=REF,
+    )
+
+    distribution = baseline['top_one_workload_share_distribution_10d']
+    assert distribution['sample_count'] == 2
+    assert round(distribution['mean'], 1) == 60.0
+
+
+def test_context_exposes_lead_arm_share_and_separate_baseline_read():
+    result = context([log(1, 1, 80), log(2, 1, 10), log(3, 1, 10)])
+
+    assert result['top_one_workload_share_10d'] == 80.0
+    # Separate read, distinct from the top-three baseline_read.
+    assert result['lead_arm_baseline_read']['metric'] == 'top_one_share'
+    assert result['baseline_read']['metric'] == 'top_share'
+
+
+def test_lead_arm_baseline_read_marks_heavy_single_arm_reliance():
+    result = context(
+        [log(1, 1, 80), log(2, 1, 10), log(3, 1, 10)],
+        league_baseline=_LEAGUE_TOP_ONE,
+    )
+
+    read = result['lead_arm_baseline_read']
+    assert read['available'] is True
+    assert read['metric'] == 'top_one_share'
+    assert read['comparison'] == 'among_highest'
+    assert read['value'] == 80.0
+
+
+def test_lead_arm_baseline_read_marks_balanced_lead_arm_below_norm():
+    # Six arms split the workload evenly -> the lead arm is below the league norm.
+    result = context(
+        [log(player_id, 1, 20) for player_id in range(1, 7)],
+        league_baseline=_LEAGUE_TOP_ONE,
+    )
+
+    read = result['lead_arm_baseline_read']
+    assert read['available'] is True
+    assert read['comparison'] == 'below_average'
+
+
+def test_lead_arm_baseline_read_guards_on_thin_league_sample():
+    thin = {
+        'top_one_workload_share_distribution_10d': {
+            'sample_count': 2, 'mean': 50.0, 'median': 50.0,
+            'p10': 40.0, 'p25': 45.0, 'p75': 55.0, 'p90': 60.0,
+        },
+    }
+    result = context([log(1, 1, 80), log(2, 1, 10), log(3, 1, 10)], league_baseline=thin)
+
+    assert result['lead_arm_baseline_read']['available'] is False
+    assert result['lead_arm_baseline_read']['comparison'] == 'insufficient_sample'
+
+
+def test_lead_arm_baseline_read_without_distribution_degrades_gracefully():
+    result = context(
+        [log(1, 1, 80), log(2, 1, 10), log(3, 1, 10)],
+        league_baseline={'league_team_count_10d': 5},
+    )
+
+    assert result['lead_arm_baseline_read']['available'] is False

--- a/backend/tests/test_bullpen_context.py
+++ b/backend/tests/test_bullpen_context.py
@@ -80,6 +80,8 @@ BULLPEN_CONCENTRATION_CONTEXT_KEYS = {
     'league_top_three_workload_share_10d',
     'top_three_share_delta_vs_league',
     'baseline_read',
+    'top_one_workload_share_10d',
+    'lead_arm_baseline_read',
     'bullpen_workload_total_10d',
     'concentration_band',
     'top_three_relievers_10d',

--- a/backend/tests/test_story_construction_engine.py
+++ b/backend/tests/test_story_construction_engine.py
@@ -228,6 +228,33 @@ def test_construction_frame_for_concentration_pressure():
     ]
 
 
+def test_construction_threads_lead_arm_read_into_concentration_frame():
+    read = {'available': True, 'metric': 'top_one_share', 'comparison': 'above_average'}
+    context = team_context(
+        concentration={
+            'concentration_band': 'narrow',
+            'top_three_workload_share_10d': 94.0,
+            'top_three_share_delta_vs_league': 36.0,
+            'bullpen_workload_total_10d': 240,
+            'top_one_workload_share_10d': 48.0,
+            'lead_arm_baseline_read': read,
+        },
+        rotation={
+            'rotation_avg_ip_7d': 4.6,
+            'rotation_avg_ip_14d': 5.9,
+            'rotation_ip_trend': -1.3,
+            'early_bullpen_entry_rate': 42.0,
+        },
+    )
+
+    frame = single_frame(context, TYPE_CONCENTRATION_PRESSURE)
+
+    # Separate lead-arm read carried alongside the top-three read; not on the feed.
+    baseline_facts = frame['story_frame']['baseline_facts']
+    assert baseline_facts['lead_arm_baseline_read'] == read
+    assert baseline_facts['top_one_workload_share_10d'] == 48.0
+
+
 def test_construction_frame_for_optionality_strength():
     context = team_context(optionality={
         'optionality_band': 'deep',

--- a/backend/tests/test_story_writer_v1.py
+++ b/backend/tests/test_story_writer_v1.py
@@ -436,6 +436,76 @@ def test_baseline_story_language_has_no_ranking_or_recommendation_terms():
             assert term not in lowered, (sentence, term)
 
 
+def _concentration_with_lead_arm(lead_arm_read):
+    concentration = {
+        'concentration_band': 'narrow',
+        'top_three_workload_share_10d': 94.0,
+        'league_top_three_workload_share_10d': 58.0,
+        'top_three_share_delta_vs_league': 36.0,
+        'bullpen_workload_total_10d': 240,
+        'baseline_read': {'available': True, 'metric': 'top_share', 'comparison': 'among_highest'},
+    }
+    if lead_arm_read is not None:
+        concentration['top_one_workload_share_10d'] = 48.0
+        concentration['lead_arm_baseline_read'] = lead_arm_read
+    return concentration
+
+
+def test_writer_voices_lead_arm_baseline_as_secondary_read():
+    frame = frame_for(
+        team_context(concentration=_concentration_with_lead_arm(
+            {'available': True, 'metric': 'top_one_share', 'comparison': 'above_average'},
+        )),
+        TYPE_CONCENTRATION_PRESSURE,
+    )
+
+    text = written_text(write_story_frame(frame))
+
+    # Primary top-three read stays; lead-arm read is layered as a secondary line.
+    assert 'among the more concentrated workloads in baseball recently' in text
+    assert 'The lead arm is carrying more of the workload than a typical bullpen' in text
+
+
+def test_writer_omits_lead_arm_sentence_when_read_absent():
+    frame = frame_for(
+        team_context(concentration=_concentration_with_lead_arm(None)),
+        TYPE_CONCENTRATION_PRESSURE,
+    )
+
+    text = written_text(write_story_frame(frame))
+
+    assert 'among the more concentrated workloads in baseball recently' in text
+    assert 'lead arm' not in text.lower()
+
+
+def test_writer_omits_lead_arm_sentence_when_read_guarded():
+    frame = frame_for(
+        team_context(concentration=_concentration_with_lead_arm(
+            {'available': False, 'comparison': 'insufficient_sample'},
+        )),
+        TYPE_CONCENTRATION_PRESSURE,
+    )
+
+    text = written_text(write_story_frame(frame))
+
+    # Guarded lead-arm read -> existing C1E copy preserved, no lead-arm sentence.
+    assert 'among the more concentrated workloads in baseball recently' in text
+    assert 'lead arm' not in text.lower()
+
+
+def test_lead_arm_baseline_language_has_no_ranking_or_recommendation_terms():
+    from services.story_writer_v1 import _LEAD_ARM_BASELINE_SENTENCE
+
+    forbidden = (
+        'highest', 'lowest', '#1', 'top-ranked', 'league-leading', 'most used', 'least used',
+        'best', 'worst', 'rank', 'recommend', 'should', 'likely to', 'projected', 'predict', 'will ',
+    )
+    for sentence in _LEAD_ARM_BASELINE_SENTENCE.values():
+        lowered = sentence.lower()
+        for term in forbidden:
+            assert term not in lowered, (sentence, term)
+
+
 def test_writer_voices_clean_options_below_norm_baseline():
     optionality = _trust_lane_optionality(clean=1, secondary=5, available=6)
     optionality['baseline_read'] = {


### PR DESCRIPTION
Extend the existing concentration_pressure story with a governed "compared to what?" read of single-arm workload reliance (top_one_share), layered under the primary top-three concentration baseline from C1E.

- bullpen_concentration_context: expose the lead arm's 10-day workload share (top_one_workload_share_10d) and a separate lead_arm_baseline_read, and add a top_one_workload_share_distribution_10d to the league baseline (same 10-day window and relief-workload definition; the top-three baseline_read is left unchanged). Reuses baseline_distribution and baseline_engine.
- story_construction_engine: carry the lead-arm read into the concentration frame baseline_facts alongside the top-three read.
- story_writer_v1: voice an optional secondary lead-arm sentence in the concentration baseline beat (single-arm reliance above/around/below the league norm); the top-three comparison stays primary, and an absent or guarded lead-arm read preserves the existing C1E copy unchanged.

top_one_share is higher-is-more-concentrated and is described without rank, recommendation, prediction, or superlative-singular language. Both reads stay internal/transient and are not serialized onto canonical feed items. No UI or feed-shape changes; ranking_applied and selection_made stay false.