### PR TITLE
Add bullpen coverage league baseline context to the bridge story

### DIFF
--- a/backend/services/bullpen_context.py
+++ b/backend/services/bullpen_context.py
@@ -38,6 +38,7 @@ from services.injury_context import build_injury_context, empty_injury_context
 from services.rotation_context import (
     build_league_rotation_baseline,
     build_rotation_context,
+    bullpen_coverage_baseline_read,
     rotation_length_baseline_read,
 )
 from services.role_stability_context import (
@@ -292,6 +293,7 @@ def _rotation_context(last_logs, prev_logs, windows):
         'rotation_games_excluded_14d': layer1['games_excluded_14d'],
         'rotation_early_bullpen_entry_games_14d': layer1['early_bullpen_entry_games_14d'],
         'baseline_read': rotation_length_baseline_read(layer1['rotation_avg_ip_7d'], league_baseline),
+        'coverage_baseline_read': bullpen_coverage_baseline_read(layer1['bullpen_coverage_ip_7d'], league_baseline),
         'rotation_context_layer': layer1,
         **signal,
     }
@@ -319,6 +321,7 @@ def _empty_rotation_context(windows=None):
         'rotation_games_excluded_14d': 0,
         'rotation_early_bullpen_entry_games_14d': 0,
         'baseline_read': rotation_length_baseline_read(None, None),
+        'coverage_baseline_read': bullpen_coverage_baseline_read(None, None),
         'rotation_context_layer': None,
         'start_classification_state': 'complete',
         'unknown_start_rows': 0,

--- a/backend/services/rotation_context.py
+++ b/backend/services/rotation_context.py
@@ -256,6 +256,7 @@ def build_rotation_context(logs, *, reference_date=None):
 
 
 ROTATION_LENGTH_BASELINE_METRIC = 'rotation_avg_ip_7d'
+BULLPEN_COVERAGE_BASELINE_METRIC = 'bullpen_coverage_ip_7d'
 
 
 def _team_id(log: Any):
@@ -281,15 +282,19 @@ def build_league_rotation_baseline(logs, *, reference_date=None):
         by_team[team_id].append(log)
 
     values = []
+    coverage_values = []
     for team_logs in by_team.values():
         context = build_rotation_context(team_logs, reference_date=reference_date)
         avg_7d = context.get('rotation_avg_ip_7d')
-        if avg_7d is None:
-            continue
-        values.append(avg_7d)
+        if avg_7d is not None:
+            values.append(avg_7d)
+        coverage = context.get('bullpen_coverage_ip_7d')
+        if coverage is not None:
+            coverage_values.append(coverage)
 
     return {
         'rotation_avg_ip_7d_distribution': build_distribution(values),
+        'bullpen_coverage_ip_7d_distribution': build_distribution(coverage_values),
         'league_team_count': len(values),
     }
 
@@ -311,6 +316,23 @@ def rotation_length_baseline_read(avg_7d, league_baseline):
     )
 
 
+def _league_coverage_distribution(league_baseline):
+    if isinstance(league_baseline, dict):
+        return league_baseline.get('bullpen_coverage_ip_7d_distribution')
+    return None
+
+
+def bullpen_coverage_baseline_read(coverage_ip, league_baseline):
+    # Distribution-aware league read of the team's recent bullpen-coverage burden.
+    # Separate from the rotation-length read; same dedicated 7-day league window.
+    # Higher coverage is more bullpen burden; the language layer assigns direction.
+    return interpret_value(
+        BULLPEN_COVERAGE_BASELINE_METRIC,
+        coverage_ip,
+        _league_coverage_distribution(league_baseline),
+    )
+
+
 __all__ = [
     'CAPABILITY',
     'CURRENT_ASSIGNMENT_LIMITATION',
@@ -320,9 +342,11 @@ __all__ = [
     'OPENER_BULK_LIMITATION',
     'ROTATION_CONTEXT_7D',
     'ROTATION_CONTEXT_14D',
+    'BULLPEN_COVERAGE_BASELINE_METRIC',
     'ROTATION_LENGTH_BASELINE_METRIC',
     'VERSION',
     'build_league_rotation_baseline',
     'build_rotation_context',
+    'bullpen_coverage_baseline_read',
     'rotation_length_baseline_read',
 ]

--- a/backend/services/story_construction_engine.py
+++ b/backend/services/story_construction_engine.py
@@ -542,6 +542,8 @@ def _bridge_instability_frame(team_context, observation):
         'current_operational_core': core,
         'core_stability_pct': stability.get('core_stability_pct'),
         'available_arms_count': optionality.get('available_arms_count'),
+        'bullpen_coverage_ip_7d': rotation.get('bullpen_coverage_ip_7d'),
+        'coverage_baseline_read': rotation.get('coverage_baseline_read'),
     }
     frame['cause_facts'] = {
         'early_bullpen_entry_rate': rotation.get('early_bullpen_entry_rate'),

--- a/backend/services/story_writer_v1.py
+++ b/backend/services/story_writer_v1.py
@@ -920,6 +920,34 @@ def _trust_lane_pressure(frame):
     )
 
 
+# Distribution-aware league phrasing for the bridge story's bullpen-coverage
+# baseline line. bullpen_coverage_ip_7d is higher-is-more-pressure (more relief
+# innings absorbed). Descriptive context only — no rank, recommendation,
+# prediction, or superlative-singular ("highest"/"most overworked") language
+# (governance C1N).
+_COVERAGE_BASELINE_SENTENCE = {
+    'below_average': 'That is below the league norm for recent bullpen coverage',
+    'about_typical': 'That is around the league norm for recent bullpen coverage',
+    'above_average': 'That is above the league norm for recent bullpen coverage',
+    'well_above_average': 'That is well above the league norm for recent bullpen coverage',
+    'among_highest': 'That is among the heavier recent bullpen-coverage workloads',
+}
+
+
+def _coverage_band(baseline):
+    """The supported coverage comparison band, only when its read is available."""
+    read = baseline.get('coverage_baseline_read') if isinstance(baseline, dict) else None
+    if not isinstance(read, dict) or read.get('available') is not True:
+        return None
+    comparison = read.get('comparison')
+    return comparison if comparison in _COVERAGE_BASELINE_SENTENCE else None
+
+
+def _coverage_baseline_sentence(baseline):
+    band = _coverage_band(baseline)
+    return _COVERAGE_BASELINE_SENTENCE.get(band) if band else None
+
+
 def _bridge_instability(frame):
     team = _team(frame)
     headline = _facts(frame, 'headline_facts')
@@ -970,6 +998,11 @@ def _bridge_instability(frame):
                 f"The bullpen is covering {_fmt(coverage_ip)} innings a game on the way there"
                 if _present(coverage_ip) else None
             ),
+            # Distribution-aware league read of recent bullpen-coverage burden,
+            # appended to the coverage line above; voiced only when the coverage
+            # baseline read is available. Absent or guarded reads leave the
+            # existing bridge copy unchanged.
+            _coverage_baseline_sentence(baseline),
         ),
         cause_paragraph=_paragraph(
             (

--- a/backend/tests/test_bullpen_context.py
+++ b/backend/tests/test_bullpen_context.py
@@ -42,6 +42,7 @@ ROTATION_CONTEXT_KEYS = {
     'rotation_games_excluded_14d',
     'rotation_early_bullpen_entry_games_14d',
     'baseline_read',
+    'coverage_baseline_read',
     'rotation_context_layer',
     'start_classification_state',
     'unknown_start_rows',

--- a/backend/tests/test_rotation_context.py
+++ b/backend/tests/test_rotation_context.py
@@ -6,6 +6,7 @@ from services.rotation_context import (
     OPENER_BULK_LIMITATION,
     build_league_rotation_baseline,
     build_rotation_context,
+    bullpen_coverage_baseline_read,
     rotation_length_baseline_read,
 )
 from utils.innings import outs_to_decimal_innings
@@ -221,3 +222,65 @@ def test_rotation_length_baseline_read_guards_on_thin_league_sample():
 def test_rotation_length_baseline_read_without_distribution_degrades_gracefully():
     assert rotation_length_baseline_read(4.0, {'league_team_count': 5})['available'] is False
     assert rotation_length_baseline_read(None, None)['available'] is False
+
+
+# Current 7-day-window league distribution of bullpen_coverage_ip_7d: a typical
+# club hands the bullpen ~3.5 innings a game, so 2.5 is light and 4.8 is heavy.
+_LEAGUE_COVERAGE = {
+    'bullpen_coverage_ip_7d_distribution': {
+        'sample_count': 28, 'mean': 3.5, 'median': 3.4,
+        'p10': 2.6, 'p25': 3.0, 'p75': 4.0, 'p90': 4.6,
+    },
+}
+
+
+def test_league_rotation_baseline_includes_bullpen_coverage_distribution():
+    logs = [
+        *team_game(1, 101, 1, 18, 9),   # bullpen 9 outs -> 3.0 IP
+        *team_game(2, 201, 1, 12, 15),  # bullpen 15 outs -> 5.0 IP
+        *team_game(3, 301, 1, 15, 12),  # bullpen 12 outs -> 4.0 IP
+    ]
+
+    baseline = build_league_rotation_baseline(logs, reference_date=REF)
+
+    distribution = baseline['bullpen_coverage_ip_7d_distribution']
+    assert distribution['sample_count'] == 3
+    assert round(distribution['mean'], 1) == 4.0
+    assert distribution['median'] == 4.0
+    # The C1K rotation-length distribution is unchanged.
+    assert baseline['rotation_avg_ip_7d_distribution']['sample_count'] == 3
+
+
+def test_bullpen_coverage_baseline_read_marks_heavy_coverage_above_norm():
+    read = bullpen_coverage_baseline_read(4.8, _LEAGUE_COVERAGE)
+
+    assert read['available'] is True
+    assert read['metric'] == 'bullpen_coverage_ip_7d'
+    assert read['comparison'] == 'among_highest'
+    assert read['value'] == 4.8
+
+
+def test_bullpen_coverage_baseline_read_marks_light_coverage_below_norm():
+    read = bullpen_coverage_baseline_read(2.5, _LEAGUE_COVERAGE)
+
+    assert read['available'] is True
+    assert read['comparison'] == 'below_average'
+
+
+def test_bullpen_coverage_baseline_read_guards_on_thin_league_sample():
+    thin = {
+        'bullpen_coverage_ip_7d_distribution': {
+            'sample_count': 3, 'mean': 3.5, 'median': 3.5,
+            'p10': 3.0, 'p25': 3.2, 'p75': 3.8, 'p90': 4.0,
+        },
+    }
+
+    read = bullpen_coverage_baseline_read(4.8, thin)
+
+    assert read['available'] is False
+    assert read['comparison'] == 'insufficient_sample'
+
+
+def test_bullpen_coverage_baseline_read_without_distribution_degrades_gracefully():
+    assert bullpen_coverage_baseline_read(4.0, {'league_team_count': 5})['available'] is False
+    assert bullpen_coverage_baseline_read(None, None)['available'] is False

--- a/backend/tests/test_story_writer_v1.py
+++ b/backend/tests/test_story_writer_v1.py
@@ -212,6 +212,77 @@ def test_writer_outputs_bridge_instability_observation():
     assert output['written_observation']['constraint_paragraph'].startswith('If ')
 
 
+def _bridge_inputs_with_coverage(coverage_read):
+    inputs = _bridge_inputs()
+    if coverage_read is not None:
+        inputs['rotation'] = {**inputs['rotation'], 'coverage_baseline_read': coverage_read}
+    return inputs
+
+
+def test_writer_voices_bullpen_coverage_above_norm_baseline():
+    frame = frame_for(
+        team_context(**_bridge_inputs_with_coverage(
+            {'available': True, 'metric': 'bullpen_coverage_ip_7d', 'comparison': 'above_average'},
+        )),
+        TYPE_BRIDGE_INSTABILITY,
+    )
+
+    text = written_text(write_story_frame(frame))
+
+    assert 'innings a game on the way there' in text
+    assert 'above the league norm for recent bullpen coverage' in text
+
+
+def test_writer_voices_bullpen_coverage_heavy_baseline():
+    frame = frame_for(
+        team_context(**_bridge_inputs_with_coverage(
+            {'available': True, 'metric': 'bullpen_coverage_ip_7d', 'comparison': 'among_highest'},
+        )),
+        TYPE_BRIDGE_INSTABILITY,
+    )
+
+    text = written_text(write_story_frame(frame))
+
+    assert 'among the heavier recent bullpen-coverage workloads' in text
+
+
+def test_writer_bridge_without_coverage_read_keeps_existing_copy():
+    frame = frame_for(team_context(**_bridge_inputs()), TYPE_BRIDGE_INSTABILITY)
+
+    text = written_text(write_story_frame(frame))
+
+    assert 'innings a game on the way there' in text
+    assert 'league norm for recent bullpen coverage' not in text
+
+
+def test_writer_bridge_guarded_coverage_read_keeps_existing_copy():
+    frame = frame_for(
+        team_context(**_bridge_inputs_with_coverage(
+            {'available': False, 'comparison': 'insufficient_sample'},
+        )),
+        TYPE_BRIDGE_INSTABILITY,
+    )
+
+    text = written_text(write_story_frame(frame))
+
+    # Guarded coverage read -> existing bridge copy preserved, no league sentence.
+    assert 'innings a game on the way there' in text
+    assert 'league norm for recent bullpen coverage' not in text
+
+
+def test_bullpen_coverage_baseline_language_has_no_ranking_or_recommendation_terms():
+    from services.story_writer_v1 import _COVERAGE_BASELINE_SENTENCE
+
+    forbidden = (
+        'highest', 'lowest', '#1', 'top-ranked', 'league-leading', 'most overworked', 'least overworked',
+        'best', 'worst', 'rank', 'recommend', 'should', 'likely to', 'projected', 'predict', 'will ',
+    )
+    for sentence in _COVERAGE_BASELINE_SENTENCE.values():
+        lowered = sentence.lower()
+        for term in forbidden:
+            assert term not in lowered, (sentence, term)
+
+
 def test_writer_outputs_trust_lane_pressure_observation():
     frame = frame_for(
         team_context(optionality=_trust_lane_optionality(clean=1, secondary=5, available=6)),


### PR DESCRIPTION
Give the bridge-instability story a governed "compared to what?" read of recent bullpen-coverage burden by comparing bullpen_coverage_ip_7d against a current league distribution.

- rotation_context: add a bullpen_coverage_ip_7d_distribution to the existing league rotation baseline (same 7-day window and _coverage_ip definition, one value per team) and a separate bullpen_coverage_baseline_read, reusing baseline_distribution and baseline_engine. The C1K rotation-length distribution and read are unchanged.
- bullpen_context: attach a separate transient coverage_baseline_read to the rotation context (alongside the rotation-length baseline_read).
- story_construction_engine: carry the coverage read into the bridge frame baseline_facts.
- story_writer_v1: voice a governed league sentence on the bridge story's existing bullpen-coverage line (below/around/above/well above the league norm, or among the heavier recent workloads); an absent or guarded read leaves the existing bridge copy unchanged.

bullpen_coverage_ip_7d is higher-is-more-pressure and is described without rank, recommendation, prediction, or superlative-singular language. Both rotation-context reads stay internal/transient and are not serialized onto canonical feed items. No UI or feed-shape changes; ranking_applied and selection_made stay false.